### PR TITLE
Add support for remap tables bigger than skeleton bone count

### DIFF
--- a/ValveResourceFormat/Resource/Blocks/VBIB.cs
+++ b/ValveResourceFormat/Resource/Blocks/VBIB.cs
@@ -375,7 +375,7 @@ namespace ValveResourceFormat.Blocks
             for (var i = 1; i < remapTables.Length; i++)
             {
                 var remapTable = remapTables[i];
-                newRemapTable = newRemapTable.Select(j => j != -1 ? remapTable[j] : -1);
+                newRemapTable = newRemapTable.Select(j => j >= 0 && j < remapTable.Length ? remapTable[j] : -1);
             }
             return newRemapTable.ToArray();
         }

--- a/ValveResourceFormat/Resource/Blocks/VBIB.cs
+++ b/ValveResourceFormat/Resource/Blocks/VBIB.cs
@@ -393,7 +393,6 @@ namespace ValveResourceFormat.Blocks
                     var formatSize = formatElementSize * formatElementCount;
                     buf.Data = buf.Data.ToArray();
                     var bufSpan = buf.Data.AsSpan();
-                    var maxRemapTableIdx = remapTable.Length - 1;
                     for (var i = (int)field.Offset; i < buf.Data.Length; i += (int)buf.ElementSizeInBytes)
                     {
                         for (var j = 0; j < formatSize; j += formatElementSize)
@@ -402,14 +401,14 @@ namespace ValveResourceFormat.Blocks
                             {
                                 case 4:
                                     BitConverter.TryWriteBytes(bufSpan.Slice(i + j),
-                                        remapTable[Math.Min(BitConverter.ToUInt32(buf.Data, i + j), maxRemapTableIdx)]);
+                                        remapTable[BitConverter.ToUInt32(buf.Data, i + j)]);
                                     break;
                                 case 2:
                                     BitConverter.TryWriteBytes(bufSpan.Slice(i + j),
-                                        (short)remapTable[Math.Min(BitConverter.ToUInt16(buf.Data, i + j), maxRemapTableIdx)]);
+                                        (short)remapTable[BitConverter.ToUInt16(buf.Data, i + j)]);
                                     break;
                                 case 1:
-                                    buf.Data[i + j] = (byte)remapTable[Math.Min(buf.Data[i + j], maxRemapTableIdx)];
+                                    buf.Data[i + j] = (byte)remapTable[buf.Data[i + j]];
                                     break;
                                 default:
                                     throw new NotImplementedException();

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -40,7 +40,6 @@ namespace ValveResourceFormat.ResourceTypes
             var start = (int)remapTableStarts[meshIndex];
             return remapTable
                 .Skip(start)
-                .Take(Skeleton.LocalRemapTable.Length)
                 .ToArray();
         }
 


### PR DESCRIPTION
This reverts #520 and attempts to properly fix remap tables bigger than skeleton bone count.

I wouldn't consider it finished as eyes on the model from Dota 2 `models/items/witchdoctor/wd_ti8_immortal_bonkers/wd_ti8_immortal_bonkers.vmdl` still don't move, while eyelids do.