### PR TITLE
Gradient/Cubemap Fog support

### DIFF
--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -23,7 +23,7 @@ namespace GUI.Controls
 
         public GLControl GLControl { get; }
 
-        private int currentControlsHeight = 35;
+        private int currentControlsHeight;
 
         public class RenderEventArgs
         {
@@ -49,6 +49,8 @@ namespace GUI.Controls
         {
             InitializeComponent();
             Dock = DockStyle.Fill;
+
+            currentControlsHeight = fpsLabel.Location.Y + fpsLabel.Height + 10;
 
             Camera = new Camera();
 

--- a/GUI/Controls/GLViewerMultiSelectionControl.Designer.cs
+++ b/GUI/Controls/GLViewerMultiSelectionControl.Designer.cs
@@ -28,42 +28,42 @@ namespace GUI.Controls
         /// </summary>
         private void InitializeComponent()
         {
-            this.selectionNameLabel = new System.Windows.Forms.Label();
-            this.checkedListBox = new System.Windows.Forms.CheckedListBox();
-            this.SuspendLayout();
+            selectionNameLabel = new System.Windows.Forms.Label();
+            checkedListBox = new System.Windows.Forms.CheckedListBox();
+            SuspendLayout();
             // 
             // selectionNameLabel
             // 
-            this.selectionNameLabel.AutoSize = true;
-            this.selectionNameLabel.Location = new System.Drawing.Point(3, 2);
-            this.selectionNameLabel.Name = "selectionNameLabel";
-            this.selectionNameLabel.Size = new System.Drawing.Size(41, 15);
-            this.selectionNameLabel.TabIndex = 0;
-            this.selectionNameLabel.Text = "Select:";
+            selectionNameLabel.AutoSize = true;
+            selectionNameLabel.Location = new System.Drawing.Point(2, 1);
+            selectionNameLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            selectionNameLabel.Name = "selectionNameLabel";
+            selectionNameLabel.Size = new System.Drawing.Size(41, 15);
+            selectionNameLabel.TabIndex = 0;
+            selectionNameLabel.Text = "Select:";
             // 
             // checkedListBox
             // 
-            this.checkedListBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.checkedListBox.CheckOnClick = true;
-            this.checkedListBox.FormattingEnabled = true;
-            this.checkedListBox.Location = new System.Drawing.Point(3, 18);
-            this.checkedListBox.Margin = new System.Windows.Forms.Padding(0);
-            this.checkedListBox.Name = "checkedListBox";
-            this.checkedListBox.Size = new System.Drawing.Size(215, 76);
-            this.checkedListBox.TabIndex = 1;
+            checkedListBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            checkedListBox.CheckOnClick = true;
+            checkedListBox.FormattingEnabled = true;
+            checkedListBox.Location = new System.Drawing.Point(3, 20);
+            checkedListBox.Margin = new System.Windows.Forms.Padding(0);
+            checkedListBox.Name = "checkedListBox";
+            checkedListBox.Size = new System.Drawing.Size(214, 130);
+            checkedListBox.TabIndex = 1;
             // 
             // GLViewerMultiSelectionControl
             // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            this.Controls.Add(this.checkedListBox);
-            this.Controls.Add(this.selectionNameLabel);
-            this.Name = "GLViewerMultiSelectionControl";
-            this.Size = new System.Drawing.Size(220, 100);
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(checkedListBox);
+            Controls.Add(selectionNameLabel);
+            Margin = new System.Windows.Forms.Padding(2);
+            Name = "GLViewerMultiSelectionControl";
+            Size = new System.Drawing.Size(220, 154);
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -83,14 +83,14 @@ namespace GUI.Types.Renderer
             return new Vector3(MathF.Cos(Yaw - OpenTK.MathHelper.PiOver2), MathF.Sin(Yaw - OpenTK.MathHelper.PiOver2), 0);
         }
 
-        public UniformBuffers.ViewConstants SetViewConstants(UniformBuffers.ViewConstants viewConstants)
+        public UniformBuffers.ViewConstants SetViewConstants(UniformBuffers.ViewConstants viewConstants, float mapScale)
         {
             return viewConstants with
             {
                 WorldToProjection = ProjectionMatrix,
                 WorldToView = CameraViewMatrix,
                 ViewToProjection = ViewProjectionMatrix,
-                CameraPosition = Location,
+                CameraPosition = Location / mapScale,
             };
         }
 

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -83,14 +83,14 @@ namespace GUI.Types.Renderer
             return new Vector3(MathF.Cos(Yaw - OpenTK.MathHelper.PiOver2), MathF.Sin(Yaw - OpenTK.MathHelper.PiOver2), 0);
         }
 
-        public UniformBuffers.ViewConstants SetViewConstants(UniformBuffers.ViewConstants viewConstants, float mapScale)
+        public UniformBuffers.ViewConstants SetViewConstants(UniformBuffers.ViewConstants viewConstants)
         {
             return viewConstants with
             {
                 WorldToProjection = ProjectionMatrix,
                 WorldToView = CameraViewMatrix,
                 ViewToProjection = ViewProjectionMatrix,
-                CameraPosition = Location / mapScale,
+                CameraPosition = Location / Scale,
             };
         }
 

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -212,7 +212,7 @@ namespace GUI.Types.Renderer
             GL.Enable(EnableCap.CullFace);
 
             // For SceneSky
-            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f) with
+            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data) with
             {
                 Time = Uptime,
             };
@@ -232,7 +232,7 @@ namespace GUI.Types.Renderer
                 skyboxCamera.SetLocation(e.Camera.Location - SkyboxOrigin);
 
                 lightingBuffer.Data = SkyboxScene.LightingInfo.LightingData;
-                viewBuffer.Data = skyboxCamera.SetViewConstants(viewBuffer.Data, SkyboxScale);
+                viewBuffer.Data = skyboxCamera.SetViewConstants(viewBuffer.Data);
                 viewBuffer.Data = SkyboxScene.FogInfo.SetFogUniforms(viewBuffer.Data, SkyboxOrigin, SkyboxScale);
 
                 SkyboxScene.MainCamera = skyboxCamera;
@@ -243,7 +243,7 @@ namespace GUI.Types.Renderer
             }
 
             lightingBuffer.Data = Scene.LightingInfo.LightingData;
-            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f);
+            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data);
             viewBuffer.Data = Scene.FogInfo.SetFogUniforms(viewBuffer.Data, Vector3.Zero, 1.0f);
 
             Scene.RenderWithCamera(e.Camera, bufferSet, lockedCullFrustum);

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -212,7 +212,7 @@ namespace GUI.Types.Renderer
             GL.Enable(EnableCap.CullFace);
 
             // For SceneSky
-            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data) with
+            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f) with
             {
                 Time = Uptime,
             };
@@ -231,7 +231,7 @@ namespace GUI.Types.Renderer
                 skyboxCamera.SetScaledProjectionMatrix();
                 skyboxCamera.SetLocation(e.Camera.Location - SkyboxOrigin);
 
-                viewBuffer.Data = skyboxCamera.SetViewConstants(viewBuffer.Data);
+                viewBuffer.Data = skyboxCamera.SetViewConstants(viewBuffer.Data, SkyboxScale);
                 lightingBuffer.Data = SkyboxScene.LightingInfo.LightingData;
 
                 SkyboxScene.MainCamera = skyboxCamera;
@@ -241,8 +241,8 @@ namespace GUI.Types.Renderer
                 GL.Clear(ClearBufferMask.DepthBufferBit);
             }
 
+            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f);
             lightingBuffer.Data = Scene.LightingInfo.LightingData;
-            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data);
 
             Scene.RenderWithCamera(e.Camera, bufferSet, lockedCullFrustum);
 

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -78,6 +78,15 @@ namespace GUI.Types.Renderer
                     SkyboxScene.ShowToolsMaterials = v;
                 }
             });
+            AddCheckBox("Show Fog", Scene.FogEnabled, (v) =>
+            {
+                Scene.FogEnabled = v;
+
+                if (SkyboxScene != null)
+                {
+                    SkyboxScene.FogEnabled = v;
+                }
+            });
             AddCheckBox("Lock Cull Frustum", false, (v) =>
             {
                 if (v)

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -231,8 +231,9 @@ namespace GUI.Types.Renderer
                 skyboxCamera.SetScaledProjectionMatrix();
                 skyboxCamera.SetLocation(e.Camera.Location - SkyboxOrigin);
 
-                viewBuffer.Data = skyboxCamera.SetViewConstants(viewBuffer.Data, SkyboxScale);
                 lightingBuffer.Data = SkyboxScene.LightingInfo.LightingData;
+                viewBuffer.Data = skyboxCamera.SetViewConstants(viewBuffer.Data, SkyboxScale);
+                viewBuffer.Data = SkyboxScene.FogInfo.SetFogUniforms(viewBuffer.Data, SkyboxOrigin, SkyboxScale);
 
                 SkyboxScene.MainCamera = skyboxCamera;
                 SkyboxScene.Update(e.FrameTime);
@@ -241,8 +242,8 @@ namespace GUI.Types.Renderer
                 GL.Clear(ClearBufferMask.DepthBufferBit);
             }
 
-            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f);
             lightingBuffer.Data = Scene.LightingInfo.LightingData;
+            viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f);
 
             Scene.RenderWithCamera(e.Camera, bufferSet, lockedCullFrustum);
 

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -244,6 +244,7 @@ namespace GUI.Types.Renderer
 
             lightingBuffer.Data = Scene.LightingInfo.LightingData;
             viewBuffer.Data = e.Camera.SetViewConstants(viewBuffer.Data, 1.0f);
+            viewBuffer.Data = Scene.FogInfo.SetFogUniforms(viewBuffer.Data, Vector3.Zero, 1.0f);
 
             Scene.RenderWithCamera(e.Camera, bufferSet, lockedCullFrustum);
 

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -156,11 +156,33 @@ namespace GUI.Types.Renderer
                 if (result.Skybox != null)
                 {
                     SkyboxScene = new Scene(GuiContext);
+
+                    if (Scene.RenderAttributes.ContainsKey("USE_GRADIENT_FOG"))
+                    {
+                        SkyboxScene.RenderAttributes["USE_GRADIENT_FOG"] = 1;
+                    }
+                    if (Scene.RenderAttributes.ContainsKey("USE_CUBEMAP_FOG"))
+                    {
+                        SkyboxScene.RenderAttributes["USE_CUBEMAP_FOG"] = 1;
+                    }
+
                     var skyboxLoader = new WorldLoader(GuiContext, result.Skybox);
                     var skyboxResult = skyboxLoader.Load(SkyboxScene);
 
                     SkyboxScale = skyboxResult.SkyboxScale;
-                    SkyboxOrigin = skyboxResult.SkyboxOrigin;
+                    SkyboxOrigin = skyboxResult.SkyboxOrigin + result.SkyboxReferenceOffset;
+
+                    SkyboxScene.WorldOffset = SkyboxOrigin;
+                    SkyboxScene.WorldScale = SkyboxScale;
+
+                    SkyboxScene.FogInfo = new WorldFogInfo
+                    {
+                        CubeFogActive = Scene.FogInfo.CubeFogActive,
+                        GradientFogActive = Scene.FogInfo.GradientFogActive,
+                        CubemapFog = Scene.FogInfo.CubemapFog,
+                        GradientFog = Scene.FogInfo.GradientFog,
+                    };
+
 
                     AddCheckBox("Show Skybox", ShowSkybox, (v) => ShowSkybox = v);
                 }

--- a/GUI/Types/Renderer/GPUMeshBufferCache.cs
+++ b/GUI/Types/Renderer/GPUMeshBufferCache.cs
@@ -68,10 +68,7 @@ namespace GUI.Types.Renderer
                 foreach (var attribute in curVertexBuffer.InputLayoutFields)
                 {
                     var attributeLocation = -1;
-
-#if DEBUG
                     var insgElemName = string.Empty;
-#endif
 
                     if (material.VsInputSignature is not null)
                     {

--- a/GUI/Types/Renderer/MaterialLoader.cs
+++ b/GUI/Types/Renderer/MaterialLoader.cs
@@ -67,9 +67,10 @@ namespace GUI.Types.Renderer
                 return GetErrorMaterial();
             }
 
+            var vrfMaterial = (VrfMaterial)resource.DataBlock;
             var mat = new RenderMaterial(
-                (VrfMaterial)resource.DataBlock,
-                GetInputSignature(resource),
+                vrfMaterial,
+                vrfMaterial.GetInputSignature(),
                 VrfGuiContext.ShaderLoader
             );
 
@@ -498,37 +499,6 @@ namespace GUI.Types.Renderer
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)TextureWrapMode.Repeat);
 
             return texture;
-        }
-
-        private static IKeyValueCollection GetInputSignature(Resource resource)
-        {
-            if (resource.ContainsBlockType(BlockType.INSG))
-            {
-                return ((BinaryKV3)resource.GetBlockByType(BlockType.INSG)).Data;
-            }
-
-            // Material might not have REDI, or it might have RED2 without INSG
-            if (resource.EditInfo != null && resource.EditInfo.Type != BlockType.REDI)
-            {
-                return null;
-            }
-
-            var extraStringData = (ValveResourceFormat.Blocks.ResourceEditInfoStructs.ExtraStringData)resource.EditInfo.Structs[ValveResourceFormat.Blocks.ResourceEditInfo.REDIStruct.ExtraStringData];
-            var inputSignatureString = extraStringData.List.Where(x => x.Name == "VSInputSignature").FirstOrDefault()?.Value;
-
-            if (inputSignatureString == null)
-            {
-                return null;
-            }
-
-            if (!inputSignatureString.StartsWith("<!-- kv3", StringComparison.InvariantCulture))
-            {
-                return null;
-            }
-
-            var ms = new MemoryStream(Encoding.UTF8.GetBytes(inputSignatureString));
-
-            return KeyValues3.ParseKVFile(ms).Root;
         }
     }
 }

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -94,6 +94,9 @@ namespace GUI.Types.Renderer
                     buffer.SetBlockBinding(shader);
                 }
 
+                context.FogInfo.SetFogUniforms(shader, context);
+                shader.SetUniform1("VRF_ENABLE_FOG", context.EnableFog ? 1 : 0);
+
                 foreach (var materialGroup in shaderGroup.GroupBy(a => a.Call.Material))
                 {
                     var material = materialGroup.Key;
@@ -102,6 +105,7 @@ namespace GUI.Types.Renderer
                     {
                         continue;
                     }
+
 
                     material.Render(shader, context.LightingInfo);
 
@@ -161,9 +165,9 @@ namespace GUI.Types.Renderer
             {
                 if (uniforms.AnimationTexture != -1)
                 {
-                    GL.ActiveTexture(TextureUnit.Texture0);
+                    GL.ActiveTexture(TextureUnit.Texture0 + (int)ReservedTextureSlots.AnimationTexture);
                     GL.BindTexture(TextureTarget.Texture2D, request.Mesh.AnimationTexture.Value);
-                    GL.Uniform1(uniforms.AnimationTexture, 0);
+                    GL.Uniform1(uniforms.AnimationTexture, (int)ReservedTextureSlots.AnimationTexture);
                 }
 
                 if (uniforms.NumBones != -1)

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -94,7 +94,7 @@ namespace GUI.Types.Renderer
                     buffer.SetBlockBinding(shader);
                 }
 
-                context.FogInfo.SetFogUniforms(shader, context);
+                context.FogInfo.SetCubemapFogTexture(shader);
                 shader.SetUniform1("VRF_ENABLE_FOG", context.EnableFog ? 1 : 0);
 
                 foreach (var materialGroup in shaderGroup.GroupBy(a => a.Call.Material))

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -58,7 +58,6 @@ namespace GUI.Types.Renderer
                 isAdditiveBlend = blendMode == 4;
             }
         }
-        
         public void Render(Shader shader = default, WorldLightingInfo lightingInfo = default)
         {
             textureUnit = TextureUnitStart;

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -6,9 +6,15 @@ using ValveResourceFormat.Serialization;
 
 namespace GUI.Types.Renderer
 {
+    enum ReservedTextureSlots
+    {
+        AnimationTexture = 0,
+        CubemapFog = 1,
+    }
+
     class RenderMaterial
     {
-        private const int TextureUnitStart = 1; // Start at 1, texture unit 0 is reserved for the animation texture
+        private const int TextureUnitStart = 2; // Reserve texture slots. Must always be the size of ReservedTextureSlots.
 
         public Shader Shader => shader;
         public Material Material { get; }
@@ -52,7 +58,7 @@ namespace GUI.Types.Renderer
                 isAdditiveBlend = blendMode == 4;
             }
         }
-
+        
         public void Render(Shader shader = default, WorldLightingInfo lightingInfo = default)
         {
             textureUnit = TextureUnitStart;

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -23,9 +23,13 @@ namespace GUI.Types.Renderer
             public Camera Camera { get; init; }
             public IEnumerable<UniformBuffers.IBlockBindableBuffer> Buffers { get; set; }
             public WorldLightingInfo LightingInfo { get; set; }
+            public WorldFogInfo FogInfo { get; set; }
             public RenderPass RenderPass { get; set; }
             public Shader ReplacementShader { get; set; }
             public bool RenderToolsMaterials { get; init; }
+            public bool EnableFog { get; init; }
+            public Vector3 WorldOffset { get; set; } // skybox, for fog
+            public float WorldScale { get; set; } // skybox
         }
 
         public Camera MainCamera { get; set; }
@@ -33,12 +37,17 @@ namespace GUI.Types.Renderer
         public Matrix4x4 GlobalLightTransform { get; set; }
         public Vector4 GlobalLightColor { get; set; }
         public WorldLightingInfo LightingInfo { get; } = new();
+        public WorldFogInfo FogInfo { get; set; } = new();
         public Dictionary<string, byte> RenderAttributes { get; } = new();
         public VrfGuiContext GuiContext { get; }
         public Octree<SceneNode> StaticOctree { get; }
         public Octree<SceneNode> DynamicOctree { get; }
+        public Vector3 WorldOffset { get; set; } = Vector3.Zero;
+        public float WorldScale { get; set; } = 1.0f;
 
+        public bool IsSkybox { get; set; }
         public bool ShowToolsMaterials { get; set; }
+        public bool FogEnabled { get; set; } = true;
 
         public IEnumerable<SceneNode> AllNodes => staticNodes.Concat(dynamicNodes);
 
@@ -190,8 +199,12 @@ namespace GUI.Types.Renderer
                 Camera = camera,
                 Buffers = buffers,
                 LightingInfo = LightingInfo,
+                FogInfo = FogInfo,
                 RenderPass = RenderPass.Opaque,
                 RenderToolsMaterials = ShowToolsMaterials,
+                EnableFog = FogEnabled,
+                WorldOffset = WorldOffset,
+                WorldScale = WorldScale,
             };
 
             if (camera.Picker is not null)
@@ -301,7 +314,7 @@ namespace GUI.Types.Renderer
                 LightingInfo.LightingData.EnvMapColorRotated[envMap.ArrayIndex] = new Vector4(envMap.Tint, 0);
 
                 // TODO
-                LightingInfo.LightingData.EnvMapNormalizationSH[envMap.ArrayIndex] = new Vector4(1, 1, 1, 1);
+                LightingInfo.LightingData.EnvMapNormalizationSH[envMap.ArrayIndex] = new Vector4(0, 0, 0, 1);
             }
 
             foreach (var node in AllNodes)

--- a/GUI/Types/Renderer/SceneCubemapFog.cs
+++ b/GUI/Types/Renderer/SceneCubemapFog.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Numerics;
+
+namespace GUI.Types.Renderer;
+class SceneCubemapFog : SceneNode
+{
+    public float StartDist { get; set; }
+    public float EndDist { get; set; }
+    public float FalloffExponent { get; set; }
+    public float HeightStart { get; set; }
+    public float HeightWidth { get; set; }
+    public float HeightExponent { get; set; }
+    public float LodBias { get; set; }
+    public RenderTexture CubemapFogTexture { get; set; }
+
+    public Vector4 OffsetScaleBiasExponent(Vector3 mapOffset, float mapScale)
+    {
+        var scale = mapScale / (EndDist - StartDist);
+        var offset = -(StartDist * scale) / mapScale;
+
+        //Console.WriteLine($"depth fog bias scale {new Vector2(offset, scale)}");
+        return new Vector4(offset, scale, LodBias, FalloffExponent);
+    }
+    public Vector4 Height_OffsetScaleExponentLog2Mip(Vector3 mapOffset, float mapScale)
+    {
+        float offset;
+        float scale;
+        if (HeightWidth > 0)
+        {
+            Console.WriteLine($"{mapOffset}");
+            var start = (HeightStart - mapOffset.Z) / mapScale;
+
+            scale = mapScale / HeightWidth; // indeed applies to scale and start
+            offset = -(start * scale);
+
+            //Console.WriteLine($"height cubefog {new Vector4(offset, scale, HeightExponent, CubemapFogTexture.NumMipLevels)}");
+        }
+        else
+        {
+            offset = 0f;
+            scale = 0f;
+        }
+
+        return new Vector4(offset, scale, HeightExponent, Math.Min(7f, CubemapFogTexture.NumMipLevels));
+    }
+    public Vector2 CullingParams(Vector3 mapOffset, float mapScale)
+    {
+        var distCull = StartDist / mapScale;
+        distCull *= distCull;
+        var heightCull = (HeightWidth > 0) ? ((HeightStart - mapOffset.Z) / mapScale) : float.PositiveInfinity;
+        return new Vector2(distCull, heightCull);
+    }
+
+    public SceneCubemapFog(Scene scene) : base(scene)
+    {
+    }
+    public override void Render(Scene.RenderContext context)
+    {
+    }
+
+    public override void Update(Scene.UpdateContext context)
+    {
+    }
+}

--- a/GUI/Types/Renderer/SceneCubemapFog.cs
+++ b/GUI/Types/Renderer/SceneCubemapFog.cs
@@ -12,9 +12,9 @@ class SceneCubemapFog : SceneNode
     public float HeightExponent { get; set; }
     public float LodBias { get; set; }
     public float Opacity { get; set; }
-    public bool UseHeightFog { get; set; } = true;
+    public bool UseHeightFog { get; set; }
     public RenderTexture CubemapFogTexture { get; set; }
-    public float ExposureBias { get; set; } // need to implement so it matches on some CS2 maps
+    public float ExposureBias { get; set; }
 
     public Vector4 OffsetScaleBiasExponent(Vector3 mapOffset, float mapScale)
     {
@@ -35,7 +35,7 @@ class SceneCubemapFog : SceneNode
 
             scale = mapScale / (HeightEnd - HeightStart);
             offset = -(bias * scale);
-            Console.WriteLine($"height cubefog {new Vector4(offset, scale, HeightExponent, CubemapFogTexture.NumMipLevels)}");
+            //Console.WriteLine($"height cubefog {new Vector4(offset, scale, HeightExponent, CubemapFogTexture.NumMipLevels)}");
         }
         else
         {
@@ -50,7 +50,8 @@ class SceneCubemapFog : SceneNode
         var distCull = StartDist / mapScale;
         distCull *= distCull;
         var heightCull = (UseHeightFog || ((HeightEnd - HeightStart) > 0)) ? ((HeightStart - mapOffset.Z) / mapScale) : float.PositiveInfinity;
-        return new Vector4(distCull, heightCull, 0f, Opacity);
+
+        return new Vector4(distCull, heightCull, MathF.Pow(2f, ExposureBias), Opacity);
     }
 
     public SceneCubemapFog(Scene scene) : base(scene)

--- a/GUI/Types/Renderer/SceneGradientFog.cs
+++ b/GUI/Types/Renderer/SceneGradientFog.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Numerics;
+
+namespace GUI.Types.Renderer;
+class SceneGradientFog : SceneNode
+{
+    public float StartDist { get; set; }
+    public float EndDist { get; set; }
+    public float FalloffExponent { get; set; }
+    public float HeightStart { get; set; }
+    public float HeightEnd { get; set; }
+    public float VerticalExponent { get; set; }
+    public Vector3 Color { get; set; }
+    public float Strength { get; set; }
+    public float MaxOpacity { get; set; }
+
+    // TODO: don't do this every frame lol
+    public Vector4 GetBiasAndScale(Vector3 mapOffset, float mapScale)
+    {
+        var startDist = StartDist;
+        var endDist = EndDist;
+
+        var distScale = mapScale / (endDist - startDist);
+        var distBias = -(startDist * distScale) / mapScale;
+
+        float heightScale;
+        float heightBias;
+        if ((HeightStart - HeightEnd) > 0f)
+        {
+            // confusing
+            var startHeight = HeightStart + mapOffset.Z;
+            var endHeight = HeightEnd + mapOffset.Z;
+
+            heightScale = mapScale / (startHeight - endHeight);
+            heightBias = -(endHeight * heightScale) / mapScale;
+        }
+        else
+        {
+            // Despite this, the cullingparams value is unaffected
+            heightScale = float.PositiveInfinity;
+            heightBias = float.NegativeInfinity;
+        }
+
+        return new Vector4(distBias, heightBias, distScale, heightScale);
+    }
+    public Vector2 Exponents => new(FalloffExponent, VerticalExponent);
+    public Vector4 Color_Opacity => new(Color * Strength, MaxOpacity);
+    public Vector2 CullingParams(Vector3 mapOffset, float mapScale)
+    {
+        return new Vector2((StartDist * StartDist) / (mapScale * mapScale), (HeightStart + mapOffset.Z) / mapScale);
+    }
+
+    public SceneGradientFog(Scene scene) : base(scene)
+    {
+    }
+    public override void Render(Scene.RenderContext context)
+    {
+    }
+
+    public override void Update(Scene.UpdateContext context)
+    {
+    }
+}

--- a/GUI/Types/Renderer/SceneGradientFog.cs
+++ b/GUI/Types/Renderer/SceneGradientFog.cs
@@ -14,7 +14,6 @@ class SceneGradientFog : SceneNode
     public float Strength { get; set; }
     public float MaxOpacity { get; set; }
 
-    // TODO: don't do this every frame lol
     public Vector4 GetBiasAndScale(Vector3 mapOffset, float mapScale)
     {
         var startDist = StartDist;
@@ -23,23 +22,12 @@ class SceneGradientFog : SceneNode
         var distScale = mapScale / (endDist - startDist);
         var distBias = -(startDist * distScale) / mapScale;
 
-        float heightScale;
-        float heightBias;
-        if ((HeightStart - HeightEnd) > 0f)
-        {
-            // confusing
-            var startHeight = HeightStart + mapOffset.Z;
-            var endHeight = HeightEnd + mapOffset.Z;
+        // this might be same as cubemap fog height calculations
+        var startHeight = HeightStart - mapOffset.Z;
+        var endHeight = HeightEnd - mapOffset.Z;
 
-            heightScale = mapScale / (startHeight - endHeight);
-            heightBias = -(endHeight * heightScale) / mapScale;
-        }
-        else
-        {
-            // Despite this, the cullingparams value is unaffected
-            heightScale = float.PositiveInfinity;
-            heightBias = float.NegativeInfinity;
-        }
+        var heightScale = mapScale / (startHeight - endHeight);
+        var heightBias = -(endHeight * heightScale) / mapScale;
 
         return new Vector4(distBias, heightBias, distScale, heightScale);
     }

--- a/GUI/Types/Renderer/SceneSky.cs
+++ b/GUI/Types/Renderer/SceneSky.cs
@@ -52,6 +52,7 @@ namespace GUI.Types.Renderer
             -1.0f, -1.0f,  1.0f,
             1.0f, -1.0f,  1.0f
         };
+        public string TargetName { get; set; }
 
         public SceneSky(Scene scene) : base(scene)
         {

--- a/GUI/Types/Renderer/Shaders/common/ViewConstants.glsl
+++ b/GUI/Types/Renderer/Shaders/common/ViewConstants.glsl
@@ -4,4 +4,13 @@ layout(std140) uniform ViewConstants {
     mat4 g_matWorldToView;
     vec3 g_vCameraPositionWs;
     float g_flTime;
+    vec4 g_vGradientFogBiasAndScale;
+    vec4 g_vGradientFogColor_Opacity;
+    vec2 m_vGradientFogExponents;
+    vec2 g_vGradientFogCullingParams;
+    vec4 g_vCubeFog_Offset_Scale_Bias_Exponent;
+    vec4 g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip;
+    mat4 g_matvCubeFogSkyWsToOs;
+    vec4 g_vCubeFogCullingParams_ExposureBias_MaxOpacity;
 };
+

--- a/GUI/Types/Renderer/Shaders/common/environment.glsl
+++ b/GUI/Types/Renderer/Shaders/common/environment.glsl
@@ -54,7 +54,8 @@ float GetEnvMapNormalization(float rough, vec3 N, vec3 irradiance)
 {
     #if (bUseCubemapNormalization == 1 && renderMode_Cubemaps == 0)
         // Cancel out lighting
-        // edit: no cancellation. I don't know how to get the greyscale SH that they use here, because the radiance coefficients in the cubemap texture are rgb.
+        // SH is currently fully 1.0, for temporary reasons.
+        // We don't know how to get the greyscale SH that they use here, because the radiance coefficients in the cubemap texture are rgb.
         float NormalizationTerm = GetLuma(irradiance);// / dot(vec4(N, 1.0), g_vEnvironmentMapNormalizationSH[EnvMapIndex]);
 
         // Reduce cancellation on glossier surfaces

--- a/GUI/Types/Renderer/Shaders/common/fog.glsl
+++ b/GUI/Types/Renderer/Shaders/common/fog.glsl
@@ -1,0 +1,144 @@
+// Fog pixel shaders.
+
+// Per-material
+uniform bool g_bFogEnabled = true;
+
+// This is linked to the GUI option, to allow visibility on maps with fog that inhibits visibility.
+uniform bool VRF_ENABLE_FOG;
+
+#define USE_GRADIENT_FOG 0
+#define USE_CUBEMAP_FOG 0
+#define USE_VOLUMETRIC_FOG 0
+#define USE_SPHERICAL_VIGNETTE_TERRIBLEIDEA 0
+
+#if defined(USE_GRADIENT_FOG)
+
+uniform vec4 g_vGradientFogBiasAndScale;
+uniform vec4 g_vGradientFogColor_Opacity;
+uniform vec2 m_vGradientFogExponents;
+uniform vec2 g_vGradientFogCullingParams;
+
+void ApplyGradientFog(inout vec3 pixelColor, vec3 positionWS, float pixelDepth)
+{
+    vec2 gradientFogComponents; // x for View Space depth, y for height in World Space
+    gradientFogComponents.x = sqrt(pixelDepth);
+    gradientFogComponents.y = positionWS.z;
+
+    gradientFogComponents = pow( saturate(gradientFogComponents * g_vGradientFogBiasAndScale.zw + g_vGradientFogBiasAndScale.xy), m_vGradientFogExponents );
+
+    float gradientFogBlend = gradientFogComponents.x * gradientFogComponents.y * g_vGradientFogColor_Opacity.a;
+
+    pixelColor = mix(pixelColor, g_vGradientFogColor_Opacity.rgb, gradientFogBlend);
+}
+
+#endif
+
+#if defined(USE_CUBEMAP_FOG)
+uniform vec4 g_vCubeFog_Offset_Scale_Bias_Exponent;
+uniform vec4 g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip;
+uniform mat4 g_matvCubeFogSkyWsToOs; // hopefully the mat3 -> mat4 transition doesnt cause problems
+uniform vec2 g_vCubeFogCullingParams;
+
+uniform samplerCube g_tFogCubeTexture;
+
+void ApplyCubemapFog(inout vec3 pixelColor, vec3 positionWS, vec3 posRelativeToCamera, float pixelDepth)
+{
+    vec2 cubeFogComponents;
+    cubeFogComponents.x = pow(ClampToPositive(pixelDepth * g_vCubeFog_Offset_Scale_Bias_Exponent.y + g_vCubeFog_Offset_Scale_Bias_Exponent.x), g_vCubeFog_Offset_Scale_Bias_Exponent.w);
+    cubeFogComponents.y = pow(ClampToPositive(positionWS.z * g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.y + g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.x), g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.z);
+
+    float cubemapFogBlend = min(1.0, max(cubeFogComponents.x, cubeFogComponents.y) );
+
+    vec3 fogCoords = normalize((vec4(normalize(posRelativeToCamera), 0.0) * g_matvCubeFogSkyWsToOs).xyz);
+    float cubemapFogLod = saturate( 1.0 - cubemapFogBlend * g_vCubeFog_Offset_Scale_Bias_Exponent.z ) * g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.w;
+
+    vec3 cubemapFogColor = textureLod(g_tFogCubeTexture, fogCoords.xyz, cubemapFogLod).rgb;
+    pixelColor = mix(pixelColor, cubemapFogColor, cubemapFogBlend);
+}
+
+#endif
+
+#if (USE_VOLUMETRIC_FOG == 1)
+// I have all the shader code for volumetric fog, but it would be HARD to implement. Disabled for now.
+uniform vec4 g_vVolFog_VolumeScale_Shift_Near_Range;
+uniform vec4 g_vVolFogDitherScaleBias;
+uniform vec4 g_vVolFogPostWorldToFrustumScale;
+uniform vec4 g_vVolFogPostWorldToFrustumBias;
+uniform mat4 g_mVolFogFromWorld; // original code is an array of length 2, and the code uses address [1]
+uniform sampler3D g_tFogVolume;
+
+#if !defined(g_tBlueNoise)
+uniform sampler2D g_tBlueNoise;
+#endif
+
+void ApplyVolumetricFog( inout vec3 PixelColor, vec3 positionWS )
+{
+    vec3 blueNoise = texture(g_tBlueNoise, gl_FragCoord.xy * g_vScreenSpaceDitherParams.zz + g_vScreenSpaceDitherParams.xy ) );
+	vec3 volFogWorldPosJittered = positionWS + (blueNoise * g_vVolFogDitherScaleBias.xxx + g_vVolFogDitherScaleBias.yyy);
+	
+	vec4 projectedWorldPos = vec4(volFogWorldPosJittered, 1.0 ) * g_mVolFogFromWorld[0];
+
+	vec3 frustumProjection = vec3(projectedWorldPos.xy / projectedWorldPos.ww, projectedWorldPos.w );
+    frustumProjection = frustumProjection * g_vVolFogPostWorldToFrustumScale.xyz + g_vVolFogPostWorldToFrustumBias.xyz;
+	vec4 volFogCoords = vec4( frustumProjection.xy, sqrt(ClampToPositive(frustumProjection.z)), ProjectedWorldPos.w ); //coords for the volfog sample are xyw in asm and xyz in vulkan
+	
+	vec4 volumetricFogColor = texture( g_tFogVolume, volFogCoords);
+	PixelColor = ( PixelColor * volumetricFogColor.a ) + volumetricFogColor.rgb;
+}
+#endif
+
+#if (USE_SPHERICAL_VIGNETTE_TERRIBLEIDEA == 42069)
+// Spherical vignette is a bad idea, plain and simple. Would destroy visibility on maps that use it, since it's usually controlled by code.
+vec4 g_vSphericalVignetteBiasAndScale;
+vec4 g_vSphericalVignetteOrigin_Exponent;
+vec4 g_vSphericalVignetteColor_Opacity;
+
+void ApplySphericalVignette( inout vec3 pixelColor, vec3 worldPositionLightingOffset)
+{
+	float sphericalVignetteLinear = saturate(g_vSphericalVignetteBiasAndScale.y * distance(worldPositionLightingOffset, g_vSphericalVignetteOrigin_Exponent.xyz) + g_vSphericalVignetteBiasAndScale.x);
+	float sphericalVignetteBlend = pow(sphericalVignetteLinear, g_vSphericalVignetteOrigin_Exponent.w);
+	PixelColor = mix(pixelColor, g_vSphericalVignetteColor_Opacity.rgb, g_vSphericalVignetteColor_Opacity.a * sphericalVignetteBlend);
+}
+#endif
+
+void ApplyFog(inout vec3 pixelColor, vec3 positionWS)
+{
+    if (g_bFogEnabled && VRF_ENABLE_FOG && ((USE_CUBEMAP_FOG == 1) || (USE_GRADIENT_FOG == 1)))
+    {
+        vec3 cameraCenteredPixelPos = positionWS - vEyePosition;
+
+#if (USE_GRADIENT_FOG == 1)
+        float horizontalDistanceQuadratic = dot(cameraCenteredPixelPos.xy, cameraCenteredPixelPos.xy);
+
+        bool bPixelHasGradientFog = (horizontalDistanceQuadratic > g_vGradientFogCullingParams.x) || (positionWS.z > g_vGradientFogCullingParams.y);
+        if (bPixelHasGradientFog)
+        {
+            ApplyGradientFog(pixelColor, positionWS, length(cameraCenteredPixelPos));
+        }
+#endif
+
+#if (USE_CUBEMAP_FOG == 1)
+        float distanceQuadratic = dot(cameraCenteredPixelPos, cameraCenteredPixelPos);
+
+        bool bPixelHasCubemapFog = (distanceQuadratic > g_vCubeFogCullingParams.x) || (positionWS.z > g_vCubeFogCullingParams.y);
+        if (bPixelHasCubemapFog)
+        {
+            ApplyCubemapFog(pixelColor, positionWS, cameraCenteredPixelPos, sqrt(distanceQuadratic));
+        }
+#endif
+
+#if (USE_VOLUMETRIC_FOG == 1)
+		//if (g_bFogTypeEnabled.x)
+		//{
+	    ApplyVolumetricFog(pixelColor, LightingPos);
+		//}
+#endif
+#if (USE_SPHERICAL_VIGNETTE_TERRIBLEIDEA == 42069)
+		// Spherical Vignette (Exclusive to Half-Life: Alyx. Used in a1_intro_world and startup, maybe others)
+		if (g_bFogTypeEnabled.w)
+		{
+		ApplySphericalVignette(pixelColor, LightingPos);
+#endif
+
+    }
+}

--- a/GUI/Types/Renderer/Shaders/csgo_effects.frag
+++ b/GUI/Types/Renderer/Shaders/csgo_effects.frag
@@ -49,6 +49,8 @@ uniform vec3 m_vTintColorDrawCall;
 
 #include "common/ViewConstants.glsl"
 
+#include "common/fog.glsl"
+
 //Main entry point
 void main()
 {
@@ -93,6 +95,8 @@ void main()
         color.rgb * tintColor * g_flColorBoost * (vColorOut.rgb / 255.0),
         opacity
     );
+
+    ApplyFog(outputColor.rgb, vFragPosition);
 
 #if renderMode_Color == 1
     outputColor = color * mask1;

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -212,6 +212,7 @@ uniform float g_flBumpStrength = 1.0;
     uniform sampler2D g_tAnisoGloss;
 #endif
 
+
 // These two must be first
 #include "common/lighting_common.glsl"
 #include "common/texturing.glsl"
@@ -221,6 +222,7 @@ uniform float g_flBumpStrength = 1.0;
 #if (S_SPECULAR == 1 || renderMode_Cubemaps == 1)
 #include "common/environment.glsl"
 #endif
+#include "common/fog.glsl"
 
 // Must be last
 #include "common/lighting.glsl"
@@ -552,6 +554,9 @@ void main()
 
     outputColor.rgb = combinedLighting;
 #endif
+
+    //outputColor.rgb = vec3(0.0);
+    ApplyFog(outputColor.rgb, mat.PositionWS);
 
 #if (F_DISABLE_TONE_MAPPING == 0)
     outputColor.rgb = pow(outputColor.rgb, invGamma);

--- a/GUI/Types/Renderer/Shaders/sky.frag
+++ b/GUI/Types/Renderer/Shaders/sky.frag
@@ -26,6 +26,7 @@ uniform vec3 m_vTint = vec3(1.0, 1.0, 1.0);
 
 const float g_flToneMapScalarLinear = 1.0;
 
+
 vec3 DecodeYCoCg(vec4 YCoCg)
 {
     float scale = (YCoCg.z * (255.0 / 8.0)) + 1.0;
@@ -56,6 +57,7 @@ void main()
 #else
     vColor.rgb = skyTexel.rgb;
 #endif
+    vColor.rgb = pow(vColor.rgb, invGamma);
 
     //vColor.rgb *= (1.0 + g_flBrightnessExposureBias);
     //vColor.rgb *= (1.0 + g_flRenderOnlyExposureBias);

--- a/GUI/Types/Renderer/Shaders/vr_black_unlit.frag
+++ b/GUI/Types/Renderer/Shaders/vr_black_unlit.frag
@@ -1,7 +1,16 @@
 #version 460
 
+#include "common/utils.glsl"
+
+in vec3 vFragPosition;
 out vec4 outputColor;
+
+uniform vec3 vEyePosition;
+
+#include "common/fog.glsl"
 
 void main(void) {
     outputColor = vec4(0.0, 0.0, 0.0, 1.0);
+
+    ApplyFog(outputColor.rgb, vFragPosition);
 }

--- a/GUI/Types/Renderer/Shaders/vr_black_unlit.frag
+++ b/GUI/Types/Renderer/Shaders/vr_black_unlit.frag
@@ -5,7 +5,7 @@
 in vec3 vFragPosition;
 out vec4 outputColor;
 
-uniform vec3 vEyePosition;
+#include "common/ViewConstants.glsl"
 
 #include "common/fog.glsl"
 

--- a/GUI/Types/Renderer/Shaders/vr_black_unlit.vert
+++ b/GUI/Types/Renderer/Shaders/vr_black_unlit.vert
@@ -6,8 +6,6 @@ layout (location = 0) in vec3 vPOSITION;
 
 out vec3 vFragPosition;
 
-uniform vec3 vEyePosition;
-
 #include "common/ViewConstants.glsl"
 uniform mat4 transform;
 

--- a/GUI/Types/Renderer/Shaders/vr_black_unlit.vert
+++ b/GUI/Types/Renderer/Shaders/vr_black_unlit.vert
@@ -6,7 +6,7 @@ layout (location = 0) in vec3 vPOSITION;
 
 out vec3 vFragPosition;
 
-out vec2 vTexCoordOut;
+uniform vec3 vEyePosition;
 
 #include "common/ViewConstants.glsl"
 uniform mat4 transform;

--- a/GUI/Types/Renderer/Shaders/vr_unlit.frag
+++ b/GUI/Types/Renderer/Shaders/vr_unlit.frag
@@ -1,5 +1,7 @@
 #version 460
 
+#include "common/utils.glsl"
+
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define F_ALPHA_TEST 0
 //End of parameter defines
@@ -11,10 +13,13 @@ in vec4 vTintColorFadeOut;
 
 out vec4 outputColor;
 
+uniform vec3 vEyePosition;
+
 uniform float g_flAlphaTestReference;
 uniform sampler2D g_tColor;
 uniform sampler2D g_tTintMask;
 
+#include "common/fog.glsl"
 
 //Main entry point
 void main()
@@ -36,4 +41,6 @@ void main()
     //Simply multiply the color from the color texture with the illumination
     //outputColor = vec4(color.rgb * tintFactor, color.a * vTintColorFadeOut.a);
     outputColor = vec4(color.rgb, 1.0);
+
+    ApplyFog(outputColor.rgb, vFragPosition);
 }

--- a/GUI/Types/Renderer/Shaders/vr_unlit.frag
+++ b/GUI/Types/Renderer/Shaders/vr_unlit.frag
@@ -13,7 +13,7 @@ in vec4 vTintColorFadeOut;
 
 out vec4 outputColor;
 
-uniform vec3 vEyePosition;
+#include "common/ViewConstants.glsl"
 
 uniform float g_flAlphaTestReference;
 uniform sampler2D g_tColor;

--- a/GUI/Types/Renderer/UniformBuffers/ViewConstants.cs
+++ b/GUI/Types/Renderer/UniformBuffers/ViewConstants.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
@@ -11,5 +12,13 @@ namespace GUI.Types.Renderer.UniformBuffers
         public Matrix4x4 WorldToView;
         public Vector3 CameraPosition;
         public float Time;
+        public Vector4 GradientFogBiasAndScale;
+        public Vector4 GradientFogColor_Opacity;
+        public Vector2 GradientFogExponents;
+        public Vector2 GradientFogCullingParams;
+        public Vector4 CubeFog_Offset_Scale_Bias_Exponent;
+        public Vector4 CubeFog_Height_Offset_Scale_Exponent_Log2Mip;
+        public Matrix4x4 CubeFogSkyWsToOs;
+        public Vector4 CubeFogCullingParams_ExposureBias_MaxOpacity;
     }
 }

--- a/GUI/Types/Renderer/WorldFogInfo.cs
+++ b/GUI/Types/Renderer/WorldFogInfo.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Numerics;
+using System.Collections.Generic;
+using GUI.Utils;
+using OpenTK.Graphics.OpenGL;
+
+namespace GUI.Types.Renderer
+{
+    /// <summary>
+    /// Represents the fog data for the current scene.
+    /// </summary>
+    class WorldFogInfo
+    {
+        //private const int VOLFOG_BBOX_LIMIT = 128;
+
+        // If we were to do this correctly, we would bin all of these entities and pick the best one at runtime.
+        // We don't use triggers though, so there's isn't much of a need. So we're only storing one.
+        public bool GradientFogActive { get; set; }
+        public bool CubeFogActive { get; set; }
+        //public bool VolumetricFogActive { get; set; }
+
+        // For now we're only using one gradient fog
+        public SceneGradientFog GradientFog { get; set; }
+        public SceneCubemapFog CubemapFog { get; set; }
+
+        /*
+        // VOLUMETRIC FOG
+        // Volumetric fog is a vital part of the look of Half-Life: Alyx, and it's very much possible to implement... but it's hard.
+        public void LoadVolumetricFogController(EntityLump.Entity entity)
+        {
+            VolumetricFogActive = true;
+            var fogIrradianceVolume = entity.GetProperty<string>("fogirradiancevolume");
+            //var anisotropy = entity.GetProperty<float>("anisotropy"); // according to the decompiled code, i think this is unused
+            var drawDistance = entity.GetProperty<float>("drawdistance");
+            var fogStrength = entity.GetProperty<float>("fogstrength");
+            var boxMins = entity.GetProperty<string>("box_mins");
+            var boxMaxs = entity.GetProperty<string>("box_maxs");
+            var indirectVoxelDim = float.Parse(entity.GetProperty<string>("indirectvoxeldim"));
+            var indirectStrength = entity.GetProperty<float>("indirectstrength");
+            var indirectEnabled = entity.GetProperty<bool>("indirectenabled");
+
+            //var indirDimX = float.Parse(entity.GetProperty<string>("indirectvoxeldimx"));
+            //var indirDimY = float.Parse(entity.GetProperty<string>("indirectvoxeldimy"));
+            //var indirDimZ = float.Parse(entity.GetProperty<string>("indirectvoxeldimz"));
+        }
+
+
+        public class FogVolume
+        {
+            public int Shape { get; set; }
+            public float Strength { get; set; }
+            public float Exponent { get; set; }
+            public Matrix4x4 Transform { get; set; }
+        }
+
+        private readonly List<FogVolume> fogVolumes = new();
+        public void LoadFogVolume(EntityLump.Entity entity)
+        {
+            if (fogVolumes.Count < VOLFOG_BBOX_LIMIT)
+            {
+                var fogVol = new FogVolume
+                {
+                    Shape = int.Parse(entity.GetProperty<string>("shape")),
+                    Strength = entity.GetProperty<float>("fogstrength"),
+                    Exponent = entity.GetProperty<float>("falloffexponent"),
+                    //Transform = SceneLightingInfo.BoxToTransform(entity)
+                };
+
+                fogVolumes.Add(fogVol);
+            }
+            else
+            {
+                Console.WriteLine($"Tried to go over limit of {VOLFOG_BBOX_LIMIT} fog volumes that could be loaded in the current map.");
+            }
+        }*/
+
+
+
+
+        // Pass data to shader
+
+        public void SetFogUniforms(Shader shader, Scene.RenderContext context)
+        {
+            if (GradientFogActive)
+            {
+                shader.SetUniform4("g_vGradientFogBiasAndScale", GradientFog.GetBiasAndScale(context.WorldOffset, context.WorldScale));
+                shader.SetUniform4("g_vGradientFogColor_Opacity", GradientFog.Color_Opacity);
+                shader.SetUniform2("m_vGradientFogExponents", GradientFog.Exponents);
+                shader.SetUniform2("g_vGradientFogCullingParams", GradientFog.CullingParams(context.WorldOffset, context.WorldScale));
+            }
+
+            if (CubeFogActive)
+            {
+                shader.SetUniform4("g_vCubeFog_Offset_Scale_Bias_Exponent", CubemapFog.OffsetScaleBiasExponent(context.WorldOffset, context.WorldScale));
+                shader.SetUniform4("g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip", CubemapFog.Height_OffsetScaleExponentLog2Mip(context.WorldOffset, context.WorldScale));
+                shader.SetUniform2("g_vCubeFogCullingParams", CubemapFog.CullingParams(context.WorldOffset, context.WorldScale));
+                shader.SetUniform4x4("g_matvCubeFogSkyWsToOs", CubemapFog.Transform); // transposed before?
+
+                shader.SetTexture((int)ReservedTextureSlots.CubemapFog, "g_tFogCubeTexture", CubemapFog.CubemapFogTexture);
+            }
+        }
+    }
+}

--- a/GUI/Types/Renderer/WorldFogInfo.cs
+++ b/GUI/Types/Renderer/WorldFogInfo.cs
@@ -93,7 +93,7 @@ namespace GUI.Types.Renderer
             {
                 shader.SetUniform4("g_vCubeFog_Offset_Scale_Bias_Exponent", CubemapFog.OffsetScaleBiasExponent(context.WorldOffset, context.WorldScale));
                 shader.SetUniform4("g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip", CubemapFog.Height_OffsetScaleExponentLog2Mip(context.WorldOffset, context.WorldScale));
-                shader.SetUniform2("g_vCubeFogCullingParams", CubemapFog.CullingParams(context.WorldOffset, context.WorldScale));
+                shader.SetUniform4("g_vCubeFogCullingParams_Opacity", CubemapFog.CullingParams_Opacity(context.WorldOffset, context.WorldScale));
                 shader.SetUniform4x4("g_matvCubeFogSkyWsToOs", CubemapFog.Transform); // transposed before?
 
                 shader.SetTexture((int)ReservedTextureSlots.CubemapFog, "g_tFogCubeTexture", CubemapFog.CubemapFogTexture);

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -415,6 +415,7 @@ namespace GUI.Types.Renderer
                         {
                             useHeightFog &= entity.GetProperty<bool>("cubemapheightfog");
                         }
+
                         var heightExponent = 1.0f;
                         var heightStart = float.PositiveInfinity; // is this right?
                         var heightEnd = float.PositiveInfinity;
@@ -434,14 +435,12 @@ namespace GUI.Types.Renderer
                             }
                         }
 
-                        // New in CS2
                         var opacity = 1f;
                         if (entity.GetProperty("cubemapfogmaxopacity") != default)
                         {
                             opacity = entity.GetPropertyUnchecked<float>("cubemapfogmaxopacity");
                         }
 
-                        // New in DeskJob
                         var fogSource = "0";
                         if (entity.GetProperty("cubemapfogsource") != default)
                         {
@@ -449,6 +448,8 @@ namespace GUI.Types.Renderer
                         }
 
                         RenderTexture fogTexture;
+                        var exposureBias = 0.0f;
+                        // Disabled in CS2
                         if (fogSource == "0")
                         {
                             fogTexture = guiContext.MaterialLoader.LoadTexture(
@@ -494,7 +495,16 @@ namespace GUI.Types.Renderer
 
                             using var matFile = guiContext.LoadFileByAnyMeansNecessary(material + "_c");
                             var mat = guiContext.MaterialLoader.LoadMaterial(matFile);
+
                             fogTexture = mat.Textures["g_tSkyTexture"];
+
+                            float brightnessExposureBias;
+                            if (mat.Material.FloatParams.TryGetValue("g_flBrightnessExposureBias", out brightnessExposureBias))
+                                brightnessExposureBias = 0f;
+                            float renderOnlyExposureBias;
+                            if (mat.Material.FloatParams.TryGetValue("g_flRenderOnlyExposureBias", out renderOnlyExposureBias))
+                                renderOnlyExposureBias = 0f;
+                            exposureBias = brightnessExposureBias + renderOnlyExposureBias; // These are both logarithms
                         }
 
 
@@ -510,6 +520,7 @@ namespace GUI.Types.Renderer
                             Transform = transform,
                             CubemapFogTexture = fogTexture,
                             Opacity = opacity,
+                            ExposureBias = exposureBias,
                             UseHeightFog = useHeightFog,
                         };
                     }

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -28,6 +28,8 @@ namespace GUI.Types.Renderer
             public World Skybox { get; set; }
             public float SkyboxScale { get; set; } = 1.0f;
             public Vector3 SkyboxOrigin { get; set; } = Vector3.Zero;
+            public Vector3 SkyboxReferenceOffset { get; set; } = Vector3.Zero;
+            // TODO: also store skybox reference rotation
         }
 
         public WorldLoader(VrfGuiContext vrfGuiContext, World world)
@@ -286,6 +288,8 @@ namespace GUI.Types.Renderer
                             result.Skybox = (World)skyboxPackage.DataBlock;
                         }
                     }
+
+                    result.SkyboxReferenceOffset = EntityTransformHelper.ParseVector(entity.GetProperty<string>("origin"));
                 }
                 else if (classname == "env_sky" || classname == "ent_dota_lightinfo")
                 {
@@ -317,6 +321,118 @@ namespace GUI.Types.Renderer
                         Material = guiContext.MaterialLoader.LoadMaterial(skyMaterial),
                     };
                 }
+                else if (classname == "env_gradient_fog")
+                {
+                    // If it has "start_disabled", only take it if we haven't found any others yet.
+                    if (!entity.GetProperty<bool>("start_disabled") || scene.FogInfo.GradientFogActive)
+                    {
+                        scene.FogInfo.GradientFogActive = true;
+                        scene.RenderAttributes["USE_GRADIENT_FOG"] = 1;
+
+                        var distExponent = entity.GetProperty<float>("fogfalloffexponent");
+                        var startDist = entity.GetProperty<float>("fogstart");
+                        var endDist = entity.GetProperty<float>("fogend");
+
+                        // Some maps don't have these properties.
+                        // TODO: find the correct behavior under this condition
+                        var startHeight = float.NegativeInfinity;
+                        var endHeight = float.NegativeInfinity;
+                        var heightExponent = 1.0f;
+                        if (entity.GetProperty("fogverticalexponent") != default)
+                        {
+                            heightExponent = entity.GetProperty<float>("fogverticalexponent");
+                            startHeight = entity.GetProperty<float>("fogstartheight");
+                            endHeight = entity.GetProperty<float>("fogendheight");
+                        }
+
+                        var strength = entity.GetProperty<float>("fogstrength");
+                        var colorData = entity.GetProperty("fogcolor");
+
+                        Vector3 color;
+                        switch (colorData.Type)
+                        {
+                            case EntityFieldType.Vector:
+                                color = (Vector3)colorData.Data;
+                                break;
+                            case EntityFieldType.Color32:
+                                // todo make this a function
+                                var colorBytes = (byte[])colorData.Data;
+                                color.X = colorBytes[0] / 255.0f;
+                                color.Y = colorBytes[1] / 255.0f;
+                                color.Z = colorBytes[2] / 255.0f;
+                                break;
+                            default:
+                                throw new Exception("unknown entity type");
+                        }
+
+                        var maxOpacity = entity.GetProperty<float>("fogmaxopacity");
+
+                        scene.FogInfo.GradientFog = new SceneGradientFog(scene)
+                        {
+                            StartDist = startDist,
+                            EndDist = endDist,
+                            FalloffExponent = distExponent,
+                            HeightStart = startHeight,
+                            HeightEnd = endHeight,
+                            VerticalExponent = heightExponent,
+                            Color = color,
+                            Strength = strength,
+                            MaxOpacity = maxOpacity,
+                        };
+                    }
+                }
+                else if (classname == "env_cubemap_fog")
+                {
+                    // If it has "start_disabled", only take it if it's the first one in the map.
+                    if (!entity.GetProperty<bool>("start_disabled") || scene.FogInfo.CubeFogActive)
+                    {
+                        scene.FogInfo.CubeFogActive = true;
+                        scene.RenderAttributes["USE_CUBEMAP_FOG"] = 1;
+
+                        // these aren't always present
+                        var heightExponent = float.PositiveInfinity;
+                        var heightStart = float.NegativeInfinity;
+                        var heightWidth = 0.0f;
+                        if (entity.GetProperty("cubemapfogheightexponent") != default)
+                        {
+                            heightExponent = entity.GetProperty<float>("cubemapfogheightexponent");
+                            heightStart = entity.GetProperty<float>("cubemapfogheightstart");
+                            heightWidth = entity.GetProperty<float>("cubemapfogheightwidth");
+                        }
+
+                        var lodBias = entity.GetProperty<float>("cubemapfoglodbiase");
+
+                        var falloffExponent = entity.GetProperty<float>("cubemapfogfalloffexponent");
+                        var startDist = entity.GetProperty<float>("cubemapfogstartdistance");
+                        var endDist = entity.GetProperty<float>("cubemapfogenddistance");
+
+                        var transform = EntityTransformHelper.CalculateTransformationMatrix(entity);
+
+                        var fogTexture = guiContext.MaterialLoader.LoadTexture(
+                            entity.GetProperty<string>("cubemapfogtexture"));
+
+                        scene.FogInfo.CubemapFog = new SceneCubemapFog(scene)
+                        {
+                            StartDist = startDist,
+                            EndDist = endDist,
+                            FalloffExponent = falloffExponent,
+                            HeightStart = heightStart,
+                            HeightWidth = heightWidth,
+                            HeightExponent = heightExponent,
+                            LodBias = lodBias,
+                            Transform = transform,
+                            CubemapFogTexture = fogTexture,
+                        };
+                    }
+                }
+                /*else if (classname == "env_volumetric_fog_controller" && entity.GetProperty<bool>("ismaster"))
+                {
+                    scene.FogInfo.LoadVolumetricFogController(entity);
+                }
+                else if (classname == "env_volumetric_fog_volume" && !entity.GetProperty<bool>("start_disabled"))
+                {
+                    scene.FogInfo.LoadFogVolume(entity);
+                }*/
                 else if (IsCubemapOrProbe(classname))
                 {
                     var handShakeString = entity.GetProperty<string>("handshake");

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -430,7 +430,7 @@ namespace GUI.Types.Renderer
                             }
                             else
                             {
-                                var heightWidth = entity.GetProperty<float>("cubemapfogheightwidth");
+                                var heightWidth = entity.GetPropertyUnchecked<float>("cubemapfogheightwidth");
                                 heightEnd = heightStart + heightWidth;
                             }
                         }
@@ -498,13 +498,12 @@ namespace GUI.Types.Renderer
 
                             fogTexture = mat.Textures["g_tSkyTexture"];
 
-                            float brightnessExposureBias;
-                            if (mat.Material.FloatParams.TryGetValue("g_flBrightnessExposureBias", out brightnessExposureBias))
+                            if (!mat.Material.FloatParams.TryGetValue("g_flBrightnessExposureBias", out var brightnessExposureBias))
                                 brightnessExposureBias = 0f;
-                            float renderOnlyExposureBias;
-                            if (mat.Material.FloatParams.TryGetValue("g_flRenderOnlyExposureBias", out renderOnlyExposureBias))
+                            if (!mat.Material.FloatParams.TryGetValue("g_flRenderOnlyExposureBias", out var renderOnlyExposureBias))
                                 renderOnlyExposureBias = 0f;
-                            exposureBias = brightnessExposureBias + renderOnlyExposureBias; // These are both logarithms
+                            // These are both logarithms, so this is equivalent to a multiply of the raw value
+                            exposureBias = brightnessExposureBias + renderOnlyExposureBias;
                         }
 
 

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -459,16 +459,28 @@ namespace GUI.Types.Renderer
                             var material = "";
                             if (fogSource == "1")
                             {
+                                var skyEntTargetName = entity.GetProperty<string>("cubemapfogskyentity");
                                 // env_sky target
-                                if (scene.Sky.TargetName == entity.GetProperty<string>("cubemapfogskyentity"))
+                                if (scene.Sky != default && (scene.Sky.TargetName == skyEntTargetName))
                                 {
                                     material = scene.Sky.Material.Material.Name;
                                 }
                                 else
                                 {
-                                    Console.WriteLine("error");
-                                    Console.WriteLine(scene.Sky.TargetName);
-                                    Console.WriteLine(entity.GetProperty<string>("cubemapfogskyentity"));
+                                    // SO APPARENTLY ENTITY TARGET REFERENCES CAN GO ACROSS SKYBOX MAPS. THIS HAPPENS IN OVERPASS
+                                    // For now, skip these cases. We'll come back to them later.
+                                    if (scene.Sky == default)
+                                    {
+                                        Console.WriteLine("WARNING (Cubemap Fog): No sky entity exists in this base map! It may exist in the skybox map, but this is currently unsupported.");
+                                    }
+                                    else
+                                    {
+                                        Console.WriteLine($"WARNING: Current sky entity (named {scene.Sky.TargetName}) does not match cubemap fog sky source target {skyEntTargetName}!");
+                                    }
+                                    Console.WriteLine("Disabling cubemap fog.");
+                                    scene.FogInfo.CubeFogActive = false;
+                                    scene.RenderAttributes["USE_CUBEMAP_FOG"] = 0;
+                                    continue;
                                 }
                             }
                             else if (fogSource == "2")

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -132,7 +132,7 @@ namespace ValveResourceFormat.IO
                     break;
 
                 case ResourceType.Model:
-                    contentFile = new ModelExtract((Model)resource.DataBlock, fileLoader).ToContentFile();
+                    contentFile = new ModelExtract(resource, fileLoader).ToContentFile();
                     break;
 
                 case ResourceType.Panorama:

--- a/ValveResourceFormat/IO/MapExtract.cs
+++ b/ValveResourceFormat/IO/MapExtract.cs
@@ -276,7 +276,7 @@ public sealed class MapExtract
                 ModelEntityAssociations.TryGetValue(modelName, out var associatedEntityClass);
                 var toolTexture = GetToolTextureForEntity(associatedEntityClass);
 
-                var modelExtract = new ModelExtract(data, FileLoader)
+                var modelExtract = new ModelExtract(model, FileLoader)
                 {
                     Type = isJustPhysics
                         ? ModelExtract.ModelExtractType.Map_PhysicsToRenderMesh


### PR DESCRIPTION
This adds support for gradient fog and cubemap fog, which are used in Half-Life Alyx and later.

The remaining fog types include spherical vignettes (which won't be implemented as they are meant for restricting visibility during cinematics and would destroy visibility) and volumetric fog. Volumetric fog would be difficult to implement but would give a massive payoff. It isn't used in CS2, though- it is only used in the VR renderer.

This improves two other things as a result of the fixes required to implement this:
- Reflections in Skybox maps are now fixed, which is especially noticeable in de_vertigo, as all buildings previously had broken reflections. This is because the shaders did not take into account the skybox scale when calculating g_vCameraPosition.
- Skybox textures are now gamma-corrected

Known issues:
- Slight technical discrepencies between the game and VRF values for the cubemap fog log2mip value. This is because I'm not quite sure how to actually calculate it. Won't be very noticeable.