### PR TITLE
Add converted MurmurHash Value on the Readme to make it copy paste ready for the online tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Magic        | Description
 `0xC4CCACE8` | tools asset info
 `0xC4CCACE9` | tools asset info (newer version)
 `0x32736376` | vcs2 - compiled shader
-`0x31415926` | murmurhash2 seed used in various places (like entity keys)
+`0x31415926` | murmurhash2 seed used in various places (like entity keys), Decimal: 826366246
 `VFONT1`     | "encrypted" font file
 
 ## License


### PR DESCRIPTION
http://murmurhash.shorelabs.com/

This one, since it's useful for Source Filmmaker materialOverrides, even though you can type the string as well. But if you do not know the string and want to figure it out, then it's useful.