### PR TITLE
Fix export for single frame animations (from .vmdl export)

### DIFF
--- a/ValveResourceFormat/IO/ModelExtract.cs
+++ b/ValveResourceFormat/IO/ModelExtract.cs
@@ -780,23 +780,24 @@ public class ModelExtract
             }
 
             //If both layers are 0s only, modeldoc will ignore the animations on this bone.
-            //We'll replace the position layer's values with one that has a very small value outside of the range of the animation.
-            if (positionLogLayer.IsLayerZero() && orientationLogLayer.IsLayerZero())
+            //In that case, replace the position layer's values with one that has a very small value outside of the range of the animation.
+            //Do the same if there's only a single frame, since modeldoc also ignores animations that don't have any movement at all (Fixes #663)
+            if (anim.FrameCount == 1 || (positionLogLayer.IsLayerZero() && orientationLogLayer.IsLayerZero()))
             {
                 positionLogLayer.Times.Clear();
                 positionLogLayer.Times.AddRange(new TimeSpan[] {
-                        TimeSpan.FromSeconds(-0.2f),
-                        TimeSpan.FromSeconds(-0.1f),
-                        TimeSpan.FromSeconds(0f)
-                    });
+                    TimeSpan.FromSeconds(-0.2f),
+                    TimeSpan.FromSeconds(-0.1f),
+                    TimeSpan.FromSeconds(0f)
+                });
 
+                var layerValue = positionLogLayer.LayerValues[0];
                 positionLogLayer.LayerValues = new Vector3[] {
-                        Vector3.Zero,
-                        new Vector3(0, 0, 0.00001f),
-                        Vector3.Zero,
-                    };
+                    layerValue,
+                    layerValue + new Vector3(0, 0, 0.00001f),
+                    layerValue,
+                };
             }
-
             clip.Channels.Add(positionChannel);
             clip.Channels.Add(orientationChannel);
         }

--- a/ValveResourceFormat/IO/ModelExtract.cs
+++ b/ValveResourceFormat/IO/ModelExtract.cs
@@ -777,24 +777,24 @@ public class ModelExtract
                 TimeSpan time = TimeSpan.FromSeconds((double)i / anim.Fps);
 
                 ProcessBoneFrameForDmeChannel(bone, frame, time, positionLogLayer, orientationLogLayer);
+            }
 
-                //If both layers are 0s only, modeldoc will ignore the animations on this bone.
-                //We'll replace the position layer's values, that has a very small value outside of the range of the animation.
-                if (positionLogLayer.IsLayerZero() && orientationLogLayer.IsLayerZero())
-                {
-                    positionLogLayer.Times.Clear();
-                    positionLogLayer.Times.AddRange(new TimeSpan[] {
+            //If both layers are 0s only, modeldoc will ignore the animations on this bone.
+            //We'll replace the position layer's values with one that has a very small value outside of the range of the animation.
+            if (positionLogLayer.IsLayerZero() && orientationLogLayer.IsLayerZero())
+            {
+                positionLogLayer.Times.Clear();
+                positionLogLayer.Times.AddRange(new TimeSpan[] {
                         TimeSpan.FromSeconds(-0.2f),
                         TimeSpan.FromSeconds(-0.1f),
                         TimeSpan.FromSeconds(0f)
                     });
 
-                    positionLogLayer.LayerValues = new Vector3[] {
+                positionLogLayer.LayerValues = new Vector3[] {
                         Vector3.Zero,
                         new Vector3(0, 0, 0.00001f),
                         Vector3.Zero,
                     };
-                }
             }
 
             clip.Channels.Add(positionChannel);


### PR DESCRIPTION
Fixes #663
This is a workaround for an issue with modeldoc, the same problem occurs when exporting animations without any motion from SFM.