### PR TITLE
Fixed rendering clipping brushes on some levels

### DIFF
--- a/GUI/Types/Renderer/PhysSceneNode.cs
+++ b/GUI/Types/Renderer/PhysSceneNode.cs
@@ -308,6 +308,7 @@ namespace GUI.Types.Renderer
 
                 inds.Add(baseVertex + i * 2);
                 inds.Add(baseVertex + i * 2 + 1);
+                inds.Add(baseVertex + i * 2);
             }
         }
 


### PR DESCRIPTION
Rendering of clipping brushes seems to be broken when there's capsule shaped clipping brushes in the level. 

Current version:
![image](https://github.com/ValveResourceFormat/ValveResourceFormat/assets/23699979/aeb826c9-6329-4f82-8e13-2c80fce2f5c5)

Issue fixed:
![image](https://github.com/ValveResourceFormat/ValveResourceFormat/assets/23699979/15a461a6-6f62-49ee-b33c-b33f75faa476)

Seems to be caused by these:
![image](https://github.com/ValveResourceFormat/ValveResourceFormat/assets/23699979/dc9cc4ef-0b7b-485b-b74c-028de8d0c803)

As far as I can tell from spending far too long looking at the code to find the issue, the problem is adding an incorrect number of vertex indices to the index buffer. Since it's expecting 3 per triangle and capsules add 8. Fixed it by adding a duplicate of one of the indices, not sure if there's a better way. The rendering of capsules looks a bit off to me but I'm not sure if this was already the case before or if it's caused by this fix.

I think the same issue is also present in circles, although since `AddCircle` is only used in `AddSphere` which calls it 3 times it shouldn't cause any issues with rendering the rest of the map. 
