### PR TITLE
Remove [PR#] prefix for Entity values

### DIFF
--- a/ValveResourceFormat/IO/MapExtract.cs
+++ b/ValveResourceFormat/IO/MapExtract.cs
@@ -851,7 +851,7 @@ public sealed class MapExtract
             }
 
             var key = property.Name;
-            var value = PropertyToEditString(property);
+            var value = RemovePrefix(PropertyToEditString(property));
             mapEntity.EntityProperties.Add(key, value);
         }
 
@@ -863,7 +863,7 @@ public sealed class MapExtract
                 {
                     OutputName = connection.GetProperty<string>("m_outputName"),
                     TargetType = connection.GetInt32Property("m_targetType"),
-                    TargetName = connection.GetProperty<string>("m_targetName"),
+                    TargetName = RemovePrefix(connection.GetProperty<string>("m_targetName")),
                     InputName = connection.GetProperty<string>("m_inputName"),
                     OverrideParam = connection.GetProperty<string>("m_overrideParam"),
                     Delay = connection.GetFloatProperty("m_flDelay"),
@@ -943,6 +943,8 @@ public sealed class MapExtract
 
     static string StringBool(bool value)
         => value ? "1" : "0";
+
+    private static string RemovePrefix(string value) => value.Replace("[PR#]", "");
 
     private static string PropertyToEditString(EntityLump.EntityProperty property)
     {

--- a/ValveResourceFormat/IO/MapExtract.cs
+++ b/ValveResourceFormat/IO/MapExtract.cs
@@ -958,6 +958,7 @@ public sealed class MapExtract
             string str => str,
             bool boolean => StringBool(boolean),
             Vector3 vector => $"{vector.X} {vector.Y} {vector.Z}",
+            Vector2 vector => $"{vector.X} {vector.Y}",
             byte[] color => $"{color[0]} {color[1]} {color[2]} {color[3]}",
             null => string.Empty,
             _ => data.ToString()

--- a/ValveResourceFormat/IO/ModelExtract.Mesh.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Mesh.cs
@@ -325,7 +325,7 @@ partial class ModelExtract
 
                 var material = drawCall.GetProperty<string>("m_material") ?? drawCall.GetProperty<string>("m_pMaterial");
 
-                if (material != null && materialInputSignature.Elements.Length == 0 && materialInputSignatures != null)
+                if (material != null && materialInputSignatures != null && (materialInputSignature.Elements == null || materialInputSignature.Elements.Length == 0))
                 {
                     materialInputSignature = materialInputSignatures.GetValueOrDefault(material);
                 }


### PR DESCRIPTION
Makes entity names and inputs/outputs visually cleaner and fixes some problems associated with this [PR#] prefix in the map editor
![1](https://github.com/ValveResourceFormat/ValveResourceFormat/assets/55619735/80cae2df-be29-45b7-8f4a-35227deddd5d)
