### PR TITLE
Add mesh properties onto glTF extras when decompiling

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -86,6 +86,9 @@ namespace Decompiler
         [Option("--gltf_textures_adapt", "Whether to perform any glTF spec adaptations on textures (e.g. split metallic map).", CommandOptionType.NoValue)]
         public bool GltfExportAdaptTextures { get; }
 
+        [Option("--gltf_export_extras", "Export additional Mesh properties into glTF extras", CommandOptionType.NoValue)]
+        public bool GltfExportExtras { get; }
+
         [Option("--tools_asset_info_short", "Whether to print only file paths for tools_asset_info files.", CommandOptionType.NoValue)]
         public bool ToolsAssetInfoShort { get; }
 
@@ -915,6 +918,7 @@ namespace Decompiler
             {
                 ExportMaterials = GltfExportMaterials,
                 AdaptTextures = GltfExportAdaptTextures,
+                ExportExtras = GltfExportExtras,
                 ProgressReporter = new Progress<string>(progress => Console.WriteLine($"--- {progress}")),
             };
 
@@ -1222,6 +1226,7 @@ namespace Decompiler
                 var gltfModelExporter = new GltfModelExporter(new NullFileLoader())
                 {
                     ExportMaterials = false,
+                    ExportExtras = GltfExportExtras,
                     ProgressReporter = new Progress<string>(progress => { }),
                 };
                 gltfModelExporter.Export(resource, null); // Filename passed as null which tells exporter to write gltf to a null stream

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -43,7 +43,7 @@ namespace ValveResourceFormat.IO
         public bool ExportMaterials { get; set; } = true;
         public bool AdaptTextures { get; set; } = true;
         public bool SatelliteImages { get; set; } = true;
-        public bool ExportExtras { get; set; } = false;
+        public bool ExportExtras { get; set; }
 
         private string DstDir;
         private CancellationToken CancellationToken;


### PR DESCRIPTION
Add mesh properties onto glTF extras when decompiling

Things like `targetname` and `classname` can now be seen from anything which uses the glTF models. 

This is helpful to determine dynamic entities and things that change between game modes (i.e. the extra barriers for wingman maps)

![image](https://github.com/ValveResourceFormat/ValveResourceFormat/assets/1388264/baae6c4a-6d35-404a-b8bd-4a21532da382)
