### PR TITLE
add Texture.ReadTextureMipLevel()

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -763,6 +763,22 @@ namespace ValveResourceFormat.ResourceTypes
             }
         }
 
+        public void ReadTextureMipLevel(Span<byte> output, uint mipLevel)
+        {
+            var bufferSize = CalculateBufferSizeForMipLevel(mipLevel);
+
+            if (output.Length != bufferSize)
+            {
+                throw new ArgumentException($"Buffer size ({output.Length}) should be equal to {bufferSize}, mip level {mipLevel}");
+            }
+
+            Reader.BaseStream.Position = Offset + Size;
+
+            SkipMipmaps(mipLevel);
+
+            ReadTexture(mipLevel, output);
+        }
+
         private int CalculateJpegSize()
         {
             return (int)(Reader.BaseStream.Length - DataOffset);

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -618,7 +618,7 @@ namespace ValveResourceFormat.ResourceTypes
             return bytes;
         }
 
-        private int CalculateBufferSizeForMipLevel(uint mipLevel)
+        public int CalculateBufferSizeForMipLevel(uint mipLevel)
         {
             var bytesPerPixel = BlockSize;
             var width = MipLevelSize(Width, mipLevel);
@@ -763,13 +763,16 @@ namespace ValveResourceFormat.ResourceTypes
             }
         }
 
+        /// <summary>
+        /// Read single mip level of texture. Buffer size must be at least <see cref="CalculateBufferSizeForMipLevel"/>.
+        /// </summary>
         public void ReadTextureMipLevel(Span<byte> output, uint mipLevel)
         {
             var bufferSize = CalculateBufferSizeForMipLevel(mipLevel);
 
-            if (output.Length != bufferSize)
+            if (bufferSize > output.Length)
             {
-                throw new ArgumentException($"Buffer size ({output.Length}) should be equal to {bufferSize}, mip level {mipLevel}");
+                throw new ArgumentException($"Buffer size ({output.Length}) must be at least {bufferSize}, mip level {mipLevel}");
             }
 
             Reader.BaseStream.Position = Offset + Size;

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -618,6 +618,11 @@ namespace ValveResourceFormat.ResourceTypes
             return bytes;
         }
 
+        /// <summary>
+        /// Calculate buffer size that is required to hold data of specified mip level.
+        /// </summary>
+        /// <param name="mipLevel">Mip level for which to calculate buffer size.</param>
+        /// <returns>Buffer size.</returns>
         public int CalculateBufferSizeForMipLevel(uint mipLevel)
         {
             var bytesPerPixel = BlockSize;
@@ -766,6 +771,8 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>
         /// Read single mip level of texture. Buffer size must be at least <see cref="CalculateBufferSizeForMipLevel"/>.
         /// </summary>
+        /// <param name="output">Buffer that will receive texture data.</param>
+        /// <param name="mipLevel">Mip level for which to read texture data.</param>
         public void ReadTextureMipLevel(Span<byte> output, uint mipLevel)
         {
             var bufferSize = CalculateBufferSizeForMipLevel(mipLevel);


### PR DESCRIPTION
I need to read only 1 mip level from texture, to reduce the memory required to load the map.