### PR TITLE
Fix vents_c `timesToFire` is not `1` & `-1` error

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/EntityLump.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/EntityLump.cs
@@ -305,13 +305,17 @@ namespace ValveResourceFormat.ResourceTypes
 
                         var timesToFire = connection.GetInt32Property("m_nTimesToFire");
 
-                        if (timesToFire == 1)
+                        switch (timesToFire)
                         {
-                            builder.Append("OnlyOnce ");
-                        }
-                        else if (timesToFire != -1)
-                        {
-                            throw new UnexpectedMagicException("Unexpected times to fire", timesToFire, nameof(timesToFire));
+                            case 1:
+                                builder.Append("OnlyOnce ");
+                                break;
+                            case 2:
+                                builder.Append("OnlyTwice ");
+                                break;
+                            case >= 3:
+                                builder.Append($"Only{timesToFire}Times ");
+                                break;
                         }
 
                         builder.Append(connection.GetProperty<string>("m_inputName"));


### PR DESCRIPTION
There are extremely few map authors who use special methods to ensure that the entity output is not fired only once or infinitely.
Video:

https://github.com/ValveResourceFormat/ValveResourceFormat/assets/26628474/012e21f7-651b-4f83-89a5-e244dbe54271

Before and after:
![QQ截图20240627051011](https://github.com/ValveResourceFormat/ValveResourceFormat/assets/26628474/ceaef0a0-c9e2-413b-9080-358e0dd9d4b2)
