### PR TITLE
Add `--gltf_export_animations` decompiler option

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -116,13 +116,11 @@ public partial class GltfModelExporter
                 if (attribute.SemanticName == "NORMAL")
                 {
                     var (normals, tangents) = VBIB.GetNormalTangentArray(vertexBuffer, attribute);
-
-                    normals = FixZeroLengthVectors(normals);
+                    FixZeroLengthVectors(normals);
 
                     if (tangents.Length > 0)
                     {
-                        tangents = FixZeroLengthVectors(tangents);
-
+                        FixZeroLengthVectors(tangents);
                         accessors["NORMAL"] = CreateAccessor(exportedModel, normals);
                         accessors["TANGENT"] = CreateAccessor(exportedModel, tangents);
                     }
@@ -181,7 +179,7 @@ public partial class GltfModelExporter
 
                                 if (accessorName == "TANGENT")
                                 {
-                                    vectors = FixZeroLengthVectors(vectors);
+                                    FixZeroLengthVectors(vectors);
                                 }
 
                                 accessors[accessorName] = CreateAccessor(exportedModel, vectors);
@@ -518,7 +516,7 @@ public partial class GltfModelExporter
         return accessor;
     }
 
-    private static Vector4[] FixZeroLengthVectors(Vector4[] vectorArray)
+    private static void FixZeroLengthVectors(Span<Vector4> vectorArray)
     {
         for (var i = 0; i < vectorArray.Length; i++)
         {
@@ -530,11 +528,9 @@ public partial class GltfModelExporter
                 vectorArray[i].W = vec.W;
             }
         }
-
-        return vectorArray;
     }
 
-    private static Vector3[] FixZeroLengthVectors(Vector3[] vectorArray)
+    private static void FixZeroLengthVectors(Span<Vector3> vectorArray)
     {
         for (var i = 0; i < vectorArray.Length; i++)
         {
@@ -543,7 +539,5 @@ public partial class GltfModelExporter
                 vectorArray[i] = -Vector3.UnitZ;
             }
         }
-
-        return vectorArray;
     }
 }

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -30,10 +30,12 @@ namespace ValveResourceFormat.IO
         public IFileLoader FileLoader { get; }
         private readonly ShaderDataProvider shaderDataProvider;
         private readonly BasicShaderDataProvider shaderDataProviderFallback = new();
+        public bool ExportAnimations { get; set; } = true;
         public bool ExportMaterials { get; set; } = true;
         public bool AdaptTextures { get; set; } = true;
         public bool SatelliteImages { get; set; } = true;
         public bool ExportExtras { get; set; }
+        public HashSet<string> AnimationFilter { get; } = [];
 
         private string DstDir;
         private CancellationToken CancellationToken;
@@ -354,7 +356,10 @@ namespace ValveResourceFormat.IO
 #endif
 
             CancellationToken.ThrowIfCancellationRequested();
-            var (skeletonNode, joints) = CreateGltfSkeleton(scene, model.Skeleton, name);
+
+            var (skeletonNode, joints) = ExportAnimations
+                ? CreateGltfSkeleton(scene, model.Skeleton, name)
+                : (null, null);
 
             if (skeletonNode != null)
             {
@@ -380,6 +385,11 @@ namespace ValveResourceFormat.IO
 
                 foreach (var animation in animations)
                 {
+                    if (AnimationFilter.Count > 0 && !AnimationFilter.Contains(animation.Name))
+                    {
+                        continue;
+                    }
+
                     // Cleanup state
                     frame.Clear(model.Skeleton);
                     for (var i = 0; i < boneCount; i++)


### PR DESCRIPTION
Not providing this option will strip all animations and skeleton for glTF model exports.

This affects decompiler.exe only.