### PR TITLE
Do not change the model BLENDINDICES stream

### DIFF
--- a/GUI/Types/Renderer/LineSceneNode.cs
+++ b/GUI/Types/Renderer/LineSceneNode.cs
@@ -43,6 +43,8 @@ namespace GUI.Types.Renderer
             GL.UseProgram(renderShader.Program);
 
             renderShader.SetUniform4x4("transform", Transform);
+            renderShader.SetBoneAnimationData(false);
+            renderShader.SetUniform1("sceneObjectId", Id);
 
             GL.BindVertexArray(vaoHandle);
             GL.DrawArrays(PrimitiveType.Lines, 0, 2);

--- a/GUI/Types/Renderer/LineSceneNode.cs
+++ b/GUI/Types/Renderer/LineSceneNode.cs
@@ -43,8 +43,6 @@ namespace GUI.Types.Renderer
             GL.UseProgram(renderShader.Program);
 
             renderShader.SetUniform4x4("transform", Transform);
-            renderShader.SetUniform1("bAnimated", false);
-            renderShader.SetUniform1("sceneObjectId", Id);
 
             GL.BindVertexArray(vaoHandle);
             GL.DrawArrays(PrimitiveType.Lines, 0, 2);

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -140,7 +140,7 @@ namespace GUI.Types.Renderer
                         shader = requestShader;
                         uniforms = new Uniforms
                         {
-                            AnimationData = shader.GetUniformLocation("iAnimationData"),
+                            AnimationData = shader.GetUniformLocation("uAnimationData"),
                             AnimationTexture = shader.GetUniformLocation("animationTexture"),
                             Transform = shader.GetUniformLocation("transform"),
                             Tint = shader.GetUniformLocation("vTint"),
@@ -259,16 +259,16 @@ namespace GUI.Types.Renderer
                 var bAnimated = request.Mesh.AnimationTexture != null;
                 var numBones = 0u;
                 var numWeights = 0u;
-                var remapTableStart = 0u;
+                var boneStart = 0u;
 
                 if (bAnimated && uniforms.AnimationTexture != -1)
                 {
                     SetInstanceTexture(shader, ReservedTextureSlots.AnimationTexture, uniforms.AnimationTexture, request.Mesh.AnimationTexture);
-                    numBones = (uint)request.Mesh.SkeletonBoneCount;
-                    remapTableStart = (uint)request.Mesh.RemapTableStart;
+                    numBones = (uint)request.Mesh.MeshBoneCount;
+                    boneStart = (uint)request.Mesh.MeshBoneOffset;
                 }
 
-                GL.ProgramUniform4((uint)shader.Program, uniforms.AnimationData, bAnimated ? 1u : 0u, numBones, numWeights, remapTableStart);
+                GL.ProgramUniform4((uint)shader.Program, uniforms.AnimationData, bAnimated ? 1u : 0u, boneStart, numBones, numWeights);
             }
 
             if (uniforms.MorphVertexIdOffset != -1)

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -58,7 +58,7 @@ namespace GUI.Types.Renderer
 
         private ref struct Uniforms
         {
-            public int Animated = -1;
+            public int AnimationData = -1;
             public int AnimationTexture = -1;
             public int EnvmapTexture = -1;
             public int LightProbeVolumeData = -1;
@@ -140,7 +140,7 @@ namespace GUI.Types.Renderer
                         shader = requestShader;
                         uniforms = new Uniforms
                         {
-                            Animated = shader.GetUniformLocation("bAnimated"),
+                            AnimationData = shader.GetUniformLocation("iAnimationData"),
                             AnimationTexture = shader.GetUniformLocation("animationTexture"),
                             Transform = shader.GetUniformLocation("transform"),
                             Tint = shader.GetUniformLocation("vTint"),
@@ -254,15 +254,21 @@ namespace GUI.Types.Renderer
                 }
             }
 
-            if (uniforms.Animated != -1)
+            if (uniforms.AnimationData != -1)
             {
                 var bAnimated = request.Mesh.AnimationTexture != null;
-                GL.ProgramUniform1((uint)shader.Program, uniforms.Animated, bAnimated ? 1u : 0u);
+                var numBones = 0u;
+                var numWeights = 0u;
+                var remapTableStart = 0u;
 
                 if (bAnimated && uniforms.AnimationTexture != -1)
                 {
                     SetInstanceTexture(shader, ReservedTextureSlots.AnimationTexture, uniforms.AnimationTexture, request.Mesh.AnimationTexture);
+                    numBones = (uint)request.Mesh.SkeletonBoneCount;
+                    remapTableStart = (uint)request.Mesh.RemapTableStart;
                 }
+
+                GL.ProgramUniform4((uint)shader.Program, uniforms.AnimationData, bAnimated ? 1u : 0u, numBones, numWeights, remapTableStart);
             }
 
             if (uniforms.MorphVertexIdOffset != -1)

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -129,9 +129,9 @@ namespace GUI.Types.Renderer
         public void SetCharacterEyeRenderParams()
         {
             var eyeEnablingMaterials = meshRenderers
-                .SelectMany(m => m.DrawCallsOpaque)
-                .Where(d => d.Material.Material.IntParams.GetValueOrDefault("F_EYEBALLS") == 1)
-                .Select(d => d.Material.Material)
+                .SelectMany(Mesh => Mesh.DrawCallsOpaque.Select(Draw => (Mesh, Draw)))
+                .Where(meshDraw => meshDraw.Draw.Material.Material.IntParams.GetValueOrDefault("F_EYEBALLS") == 1)
+                .Select(meshDraw => (meshDraw.Mesh, meshDraw.Draw.Material.Material))
                 .ToList();
 
             if (eyeEnablingMaterials.Count == 0)
@@ -146,11 +146,11 @@ namespace GUI.Types.Renderer
                 return;
             }
 
-            foreach (var materialData in eyeEnablingMaterials)
+            foreach (var (mesh, materialData) in eyeEnablingMaterials)
             {
-                materialData.IntParams["g_nEyeLBindIdx"] = eyes.LeftEyeBoneIndex;
-                materialData.IntParams["g_nEyeRBindIdx"] = eyes.RightEyeBoneIndex;
-                materialData.IntParams["g_nEyeTargetBindIdx"] = eyes.TargetBoneIndex;
+                materialData.IntParams["g_nEyeLBindIdx"] = remapTable[mesh.RemapTableStart..].AsSpan().IndexOf(eyes.LeftEyeBoneIndex);
+                materialData.IntParams["g_nEyeRBindIdx"] = remapTable[mesh.RemapTableStart..].AsSpan().IndexOf(eyes.RightEyeBoneIndex);
+                materialData.IntParams["g_nEyeTargetBindIdx"] = remapTable[mesh.RemapTableStart..].AsSpan().IndexOf(eyes.TargetBoneIndex);
 
                 materialData.VectorParams["g_vEyeLBindPos"] = new Vector4(eyes.LeftEyePosition, 0);
                 materialData.VectorParams["g_vEyeLBindFwd"] = new Vector4(eyes.LeftEyeForwardVector, 0);

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -183,6 +183,7 @@ namespace GUI.Types.Renderer
 
                 try
                 {
+                    AnimationController.FrameCache.Skeleton.LocalRemapTable = meshRenderers[0].MeshSkeletonBoneTable;
                     Animation.GetAnimationMatrices(matrices, frame, AnimationController.FrameCache.Skeleton);
 
                     // Update animation texture

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -51,10 +51,6 @@ namespace GUI.Types.Renderer
             guiContext = scene.GuiContext;
 
             var vbib = mesh.VBIB;
-            if (model != null)
-            {
-                vbib = model.RemapBoneIndices(vbib, meshIndex);
-            }
 
             foreach (var a in vbib.VertexBuffers)
             {

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -25,8 +25,8 @@ namespace GUI.Types.Renderer
         private IEnumerable<DrawCall> DrawCalls => DrawCallsOpaque.Concat(DrawCallsOverlay).Concat(DrawCallsBlended);
 
         public RenderTexture AnimationTexture { get; private set; }
-        public int SkeletonBoneCount { get; private set; }
-        public int RemapTableStart { get; private set; }
+        public int MeshBoneOffset { get; private set; }
+        public int MeshBoneCount { get; private set; }
 
         public int MeshIndex { get; }
 
@@ -56,12 +56,16 @@ namespace GUI.Types.Renderer
 
             if (model != null)
             {
-                Span<int> meshToModel = model.GetRemapTable(meshIndex);
-                SkeletonBoneCount = model.Skeleton.Bones.Length;
                 var remapTableStarts = model.Data.GetIntegerArray("m_remappingTableStarts");
                 if (remapTableStarts.Length > meshIndex)
                 {
-                    RemapTableStart = (int)remapTableStarts[meshIndex];
+                    MeshBoneOffset = (int)remapTableStarts[meshIndex];
+                }
+
+                var modelSpaceBoneIndices = model.GetRemapTable(meshIndex);
+                if (modelSpaceBoneIndices != null)
+                {
+                    MeshBoneCount = modelSpaceBoneIndices.Length;
                 }
             }
 

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -24,8 +24,9 @@ namespace GUI.Types.Renderer
         public List<DrawCall> DrawCallsBlended { get; } = [];
         private IEnumerable<DrawCall> DrawCalls => DrawCallsOpaque.Concat(DrawCallsOverlay).Concat(DrawCallsBlended);
 
-        public int[] MeshSkeletonBoneTable { get; private set; }
         public RenderTexture AnimationTexture { get; private set; }
+        public int SkeletonBoneCount { get; private set; }
+        public int RemapTableStart { get; private set; }
 
         public int MeshIndex { get; }
 
@@ -56,13 +57,11 @@ namespace GUI.Types.Renderer
             if (model != null)
             {
                 Span<int> meshToModel = model.GetRemapTable(meshIndex);
-                MeshSkeletonBoneTable = new int[model.Skeleton.Bones.Length];
-
-                foreach (var bone in model.Skeleton.Bones)
+                SkeletonBoneCount = model.Skeleton.Bones.Length;
+                var remapTableStarts = model.Data.GetIntegerArray("m_remappingTableStarts");
+                if (remapTableStarts.Length > meshIndex)
                 {
-                    var meshBoneIndex = meshToModel.IndexOf(bone.Index);
-                    var modelBone = model.Skeleton.Bones[bone.Index];
-                    MeshSkeletonBoneTable[bone.Index] = meshBoneIndex;
+                    RemapTableStart = (int)remapTableStarts[meshIndex];
                 }
             }
 

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -24,6 +24,7 @@ namespace GUI.Types.Renderer
         public List<DrawCall> DrawCallsBlended { get; } = [];
         private IEnumerable<DrawCall> DrawCalls => DrawCallsOpaque.Concat(DrawCallsOverlay).Concat(DrawCallsBlended);
 
+        public int[] MeshSkeletonBoneTable { get; private set; }
         public RenderTexture AnimationTexture { get; private set; }
 
         public int MeshIndex { get; }
@@ -51,6 +52,19 @@ namespace GUI.Types.Renderer
             guiContext = scene.GuiContext;
 
             var vbib = mesh.VBIB;
+
+            if (model != null)
+            {
+                Span<int> meshToModel = model.GetRemapTable(meshIndex);
+                MeshSkeletonBoneTable = new int[model.Skeleton.Bones.Length];
+
+                foreach (var bone in model.Skeleton.Bones)
+                {
+                    var meshBoneIndex = meshToModel.IndexOf(bone.Index);
+                    var modelBone = model.Skeleton.Bones[bone.Index];
+                    MeshSkeletonBoneTable[bone.Index] = meshBoneIndex;
+                }
+            }
 
             foreach (var a in vbib.VertexBuffers)
             {

--- a/GUI/Types/Renderer/Shader.cs
+++ b/GUI/Types/Renderer/Shader.cs
@@ -130,16 +130,16 @@ namespace GUI.Types.Renderer
             }
         }
 
-        public void SetAnimationData(bool animated, int boneCount = 0, int weightCount = 0)
+        public void SetBoneAnimationData(bool animated, int boneOffset = 0, int boneCount = 0, int weightCount = 0)
         {
             var uniformLocation = GetUniformLocation("iAnimationData");
             if (uniformLocation > -1)
             {
-                GL.ProgramUniform4(Program, uniformLocation, animated ? 1u : 0u, (uint)boneCount, (uint)weightCount, 0);
+                GL.ProgramUniform4(Program, uniformLocation, animated ? 1u : 0u, (uint)boneOffset, (uint)boneCount, (uint)weightCount);
             }
         }
 
-        public void SetUniform4Array<T>(string name, int count, float[] value)
+        public void SetUniform4Array(string name, int count, float[] value)
         {
             var uniformLocation = GetUniformLocation(name);
             if (uniformLocation > -1)

--- a/GUI/Types/Renderer/Shader.cs
+++ b/GUI/Types/Renderer/Shader.cs
@@ -130,7 +130,16 @@ namespace GUI.Types.Renderer
             }
         }
 
-        public void SetUniform4Array(string name, int count, float[] value)
+        public void SetAnimationData(bool animated, int boneCount = 0, int weightCount = 0)
+        {
+            var uniformLocation = GetUniformLocation("iAnimationData");
+            if (uniformLocation > -1)
+            {
+                GL.ProgramUniform4(Program, uniformLocation, animated ? 1u : 0u, (uint)boneCount, (uint)weightCount, 0);
+            }
+        }
+
+        public void SetUniform4Array<T>(string name, int count, float[] value)
         {
             var uniformLocation = GetUniformLocation(name);
             if (uniformLocation > -1)

--- a/GUI/Types/Renderer/Shaders/common/animation.glsl
+++ b/GUI/Types/Renderer/Shaders/common/animation.glsl
@@ -3,24 +3,24 @@
 layout (location = 1) in uvec4 vBLENDINDICES;
 layout (location = 2) in vec4 vBLENDWEIGHT;
 
-uniform uvec4 iAnimationData;
+uniform uvec4 uAnimationData;
 uniform sampler2D animationTexture;
 
-#define bAnimated iAnimationData.x != 0u
-#define numBones iAnimationData.y
-#define numWeights iAnimationData.z
-#define animationTextureOffset iAnimationData.w
+#define bAnimated uAnimationData.x != 0u
+#define meshBoneOffset uAnimationData.y
+#define meshBoneCount uAnimationData.z
+#define numWeights uAnimationData.w
 
 mat4 getMatrix(uint boneIndex)
 {
-    boneIndex += animationTextureOffset;
-
     // Issue #705 out of bounds bone index (model needs ApplyVBIBDefaults)
     // Model:  hlvr/models/props/xen/xen_villi_medium.vmdl
     // In map: hlvr/maps/a3_distillery.vmap
-    // if (boneIndex >= numBones) {
-    //     return mat4(1.0);
-    // }
+    if (boneIndex >= meshBoneCount) {
+        return mat4(1.0);
+    }
+
+    boneIndex += meshBoneOffset;
 
     return mat4(
         texelFetch(animationTexture, ivec2(0, boneIndex), 0),

--- a/GUI/Types/Renderer/Shaders/common/animation.glsl
+++ b/GUI/Types/Renderer/Shaders/common/animation.glsl
@@ -1,19 +1,26 @@
 #version 460
 
-layout (location = 1) in ivec4 vBLENDINDICES;
+layout (location = 1) in uvec4 vBLENDINDICES;
 layout (location = 2) in vec4 vBLENDWEIGHT;
 
-uniform bool bAnimated;
+uniform uvec4 iAnimationData;
 uniform sampler2D animationTexture;
 
-mat4 getMatrix(int boneIndex) {
+#define bAnimated iAnimationData.x != 0u
+#define numBones iAnimationData.y
+#define numWeights iAnimationData.z
+#define animationTextureOffset iAnimationData.w
+
+mat4 getMatrix(uint boneIndex)
+{
+    boneIndex += animationTextureOffset;
 
     // Issue #705 out of bounds bone index (model needs ApplyVBIBDefaults)
     // Model:  hlvr/models/props/xen/xen_villi_medium.vmdl
     // In map: hlvr/maps/a3_distillery.vmap
-    if (boneIndex >= textureSize(animationTexture, 0).y) {
-        return mat4(1.0);
-    }
+    // if (boneIndex >= numBones) {
+    //     return mat4(1.0);
+    // }
 
     return mat4(
         texelFetch(animationTexture, ivec2(0, boneIndex), 0),
@@ -23,7 +30,8 @@ mat4 getMatrix(int boneIndex) {
     );
 }
 
-mat4 getSkinMatrix(){
+mat4 getSkinMatrix()
+{
     //[branch]
     if (bAnimated)
     {

--- a/GUI/Types/Renderer/ShapeSceneNode.cs
+++ b/GUI/Types/Renderer/ShapeSceneNode.cs
@@ -266,6 +266,8 @@ namespace GUI.Types.Renderer
             GL.UseProgram(renderShader.Program);
 
             renderShader.SetUniform4x4("transform", Transform);
+            renderShader.SetBoneAnimationData(false);
+            renderShader.SetUniform1("sceneObjectId", Id);
 
             renderShader.SetUniform1("g_bNormalShaded", Shaded);
             renderShader.SetUniform1("g_bTriplanarMapping", ToolTexture != null);

--- a/GUI/Types/Renderer/ShapeSceneNode.cs
+++ b/GUI/Types/Renderer/ShapeSceneNode.cs
@@ -266,8 +266,6 @@ namespace GUI.Types.Renderer
             GL.UseProgram(renderShader.Program);
 
             renderShader.SetUniform4x4("transform", Transform);
-            renderShader.SetUniform1("bAnimated", false);
-            renderShader.SetUniform1("sceneObjectId", Id);
 
             renderShader.SetUniform1("g_bNormalShaded", Shaded);
             renderShader.SetUniform1("g_bTriplanarMapping", ToolTexture != null);

--- a/GUI/Types/Renderer/SkeletonSceneNode.cs
+++ b/GUI/Types/Renderer/SkeletonSceneNode.cs
@@ -116,6 +116,8 @@ namespace GUI.Types.Renderer
             GL.UseProgram(renderShader.Program);
 
             renderShader.SetUniform4x4("transform", Transform);
+            renderShader.SetBoneAnimationData(false);
+            renderShader.SetUniform1("sceneObjectId", Id);
 
             GL.BindVertexArray(vaoHandle);
             GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);

--- a/GUI/Types/Renderer/SkeletonSceneNode.cs
+++ b/GUI/Types/Renderer/SkeletonSceneNode.cs
@@ -116,8 +116,6 @@ namespace GUI.Types.Renderer
             GL.UseProgram(renderShader.Program);
 
             renderShader.SetUniform4x4("transform", Transform);
-            renderShader.SetUniform1("bAnimated", false);
-            renderShader.SetUniform1("sceneObjectId", Id);
 
             GL.BindVertexArray(vaoHandle);
             GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);

--- a/GUI/Types/Renderer/SpriteSceneNode.cs
+++ b/GUI/Types/Renderer/SpriteSceneNode.cs
@@ -94,7 +94,7 @@ namespace GUI.Types.Renderer
             var transform = billboardMatrix * Transform;
             renderShader.SetUniform4x4("transform", transform);
 
-            renderShader.SetUniform1("bAnimated", false);
+            renderShader.SetAnimationData(false);
             renderShader.SetUniform1("sceneObjectId", Id);
             renderShader.SetUniform1("shaderId", (uint)material.Shader.NameHash);
             renderShader.SetUniform1("shaderProgramId", (uint)material.Shader.Program);

--- a/GUI/Types/Renderer/SpriteSceneNode.cs
+++ b/GUI/Types/Renderer/SpriteSceneNode.cs
@@ -94,7 +94,7 @@ namespace GUI.Types.Renderer
             var transform = billboardMatrix * Transform;
             renderShader.SetUniform4x4("transform", transform);
 
-            renderShader.SetAnimationData(false);
+            renderShader.SetBoneAnimationData(false);
             renderShader.SetUniform1("sceneObjectId", Id);
             renderShader.SetUniform1("shaderId", (uint)material.Shader.NameHash);
             renderShader.SetUniform1("shaderProgramId", (uint)material.Shader.Program);

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -716,7 +716,7 @@ namespace GUI.Types.Renderer
 
                             postProcess.ModelVolume = ppModelResource;
 
-                            var ppModelNode = new ModelSceneNode(scene, ppModelResource, skin, optimizeForMapLoad: true)
+                            var ppModelNode = new ModelSceneNode(scene, ppModelResource, skin)
                             {
                                 Transform = transformationMatrix,
                                 LayerName = layerName,
@@ -784,7 +784,7 @@ namespace GUI.Types.Renderer
 
                     if (errorModelResource != null)
                     {
-                        var errorModel = new ModelSceneNode(scene, (Model)errorModelResource.DataBlock, skin, optimizeForMapLoad: true)
+                        var errorModel = new ModelSceneNode(scene, (Model)errorModelResource.DataBlock, skin)
                         {
                             Name = "error",
                             Transform = transformationMatrix,
@@ -813,7 +813,7 @@ namespace GUI.Types.Renderer
 
                 var newModel = (Model)newEntity.DataBlock;
 
-                var modelNode = new ModelSceneNode(scene, newModel, skin, optimizeForMapLoad: true)
+                var modelNode = new ModelSceneNode(scene, newModel, skin)
                 {
                     Transform = transformationMatrix,
                     Tint = new Vector4(rendercolor, renderamt),
@@ -1030,7 +1030,7 @@ namespace GUI.Types.Renderer
             }
             else if (resource.ResourceType == ResourceType.Model)
             {
-                var modelNode = new ModelSceneNode(scene, (Model)resource.DataBlock, null, optimizeForMapLoad: true)
+                var modelNode = new ModelSceneNode(scene, (Model)resource.DataBlock, null)
                 {
                     Transform = transformationMatrix,
                     LayerName = "Entities",

--- a/GUI/Types/Renderer/WorldNodeLoader.cs
+++ b/GUI/Types/Renderer/WorldNodeLoader.cs
@@ -62,7 +62,7 @@ namespace GUI.Types.Renderer
                         continue;
                     }
 
-                    var modelNode = new ModelSceneNode(scene, (Model)newResource.DataBlock, null, optimizeForMapLoad: true)
+                    var modelNode = new ModelSceneNode(scene, (Model)newResource.DataBlock, null)
                     {
                         Transform = matrix,
                         Tint = tintColor,

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -85,6 +85,10 @@ namespace ValveResourceFormat.ResourceTypes
             //cachedSkeleton ??= Skeleton.FromModelData(Data, filterBonesUsedByLod0: true);
         }
 
+        /// <summary>
+        /// Get the bone remap table of a specific mesh.
+        /// This is used to remap bone indices in the mesh VBIB to bone indices of the model skeleton.
+        /// </summary>
         public int[] GetRemapTable(int meshIndex)
         {
             var remapTableStarts = Data.GetIntegerArray("m_remappingTableStarts");
@@ -94,14 +98,16 @@ namespace ValveResourceFormat.ResourceTypes
                 return null;
             }
 
-            // Get the remap table and invert it for our construction method
             var remapTable = Data.GetIntegerArray("m_remappingTable").Select(i => (int)i);
 
             var start = (int)remapTableStarts[meshIndex];
-            return remapTable
-                .Skip(start)
-                .Take(Skeleton.LocalRemapTable.Length)
-                .ToArray();
+
+            var nextMeshIndex = meshIndex + 1;
+            var stop = remapTableStarts.Length > nextMeshIndex
+                ? (int)remapTableStarts[nextMeshIndex]
+                : remapTableStarts.Length;
+
+            return remapTable.Skip(start).Take(start - stop).ToArray();
         }
 
         public VBIB RemapBoneIndices(VBIB vbib, int meshIndex)

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -80,41 +80,37 @@ namespace ValveResourceFormat.ResourceTypes
             Attachments ??= mesh.Attachments;
         }
 
-        public void SetSkeletonFilteredForLod0()
-        {
-            //cachedSkeleton ??= Skeleton.FromModelData(Data, filterBonesUsedByLod0: true);
-        }
-
         /// <summary>
         /// Get the bone remap table of a specific mesh.
         /// This is used to remap bone indices in the mesh VBIB to bone indices of the model skeleton.
         /// </summary>
         public int[] GetRemapTable(int meshIndex)
         {
-            var remapTableStarts = Data.GetIntegerArray("m_remappingTableStarts");
+            var remappingTableStarts = Data.GetIntegerArray("m_remappingTableStarts");
 
-            if (remapTableStarts.Length <= meshIndex)
+            if (remappingTableStarts.Length <= meshIndex)
             {
                 return null;
             }
 
-            var remapTable = Data.GetIntegerArray("m_remappingTable");
+            var remappingTable = Data.GetIntegerArray("m_remappingTable");
 
-            var start = (int)remapTableStarts[meshIndex];
+            var remappingTableStart = (int)remappingTableStarts[meshIndex];
 
             var nextMeshIndex = meshIndex + 1;
-            var stop = remapTableStarts.Length > nextMeshIndex
-                ? remapTableStarts[nextMeshIndex] + 1
-                : remapTable.Length;
-            var meshBoneCount = stop - start;
+            var nextMeshStart = remappingTableStarts.Length > nextMeshIndex
+                ? remappingTableStarts[nextMeshIndex]
+                : remappingTable.Length;
 
-            var meshRemapTable = new int[meshBoneCount];
+            var meshBoneCount = nextMeshStart - remappingTableStart;
+
+            var meshRemappingTable = new int[meshBoneCount];
             for (var i = 0; i < meshBoneCount; i++)
             {
-                meshRemapTable[i] = (int)remapTable[start + i];
+                meshRemappingTable[i] = (int)remappingTable[remappingTableStart + i];
             }
 
-            return meshRemapTable;
+            return meshRemappingTable;
         }
 
         public VBIB RemapBoneIndices(VBIB vbib, int meshIndex)
@@ -126,7 +122,7 @@ namespace ValveResourceFormat.ResourceTypes
 
             return vbib.RemapBoneIndices(VBIB.CombineRemapTables([
                 GetRemapTable(meshIndex),
-                Skeleton.LocalRemapTable,
+                Enumerable.Range(0, Skeleton.Bones.Length).ToArray(),
             ]));
         }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -33,7 +33,6 @@ namespace ValveResourceFormat.ResourceTypes
         private List<Animation> CachedAnimations;
         private Skeleton cachedSkeleton { get; set; }
         private FlexController[] cachedFlexControllers { get; set; }
-        private readonly Dictionary<(VBIB VBIB, int MeshIndex), VBIB> remappedVBIBCache = [];
         public Dictionary<string, Hitbox[]> HitboxSets { get; private set; }
         public Dictionary<string, Attachment> Attachments { get; private set; }
 
@@ -111,16 +110,11 @@ namespace ValveResourceFormat.ResourceTypes
             {
                 return vbib;
             }
-            if (remappedVBIBCache.TryGetValue((vbib, meshIndex), out var res))
-            {
-                return res;
-            }
-            res = vbib.RemapBoneIndices(VBIB.CombineRemapTables([
+
+            return vbib.RemapBoneIndices(VBIB.CombineRemapTables([
                 GetRemapTable(meshIndex),
                 Skeleton.LocalRemapTable,
             ]));
-            remappedVBIBCache.Add((vbib, meshIndex), res);
-            return res;
         }
 
         public IEnumerable<(int MeshIndex, string MeshName, long LoDMask)> GetReferenceMeshNamesAndLoD()

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -98,16 +98,23 @@ namespace ValveResourceFormat.ResourceTypes
                 return null;
             }
 
-            var remapTable = Data.GetIntegerArray("m_remappingTable").Select(i => (int)i);
+            var remapTable = Data.GetIntegerArray("m_remappingTable");
 
             var start = (int)remapTableStarts[meshIndex];
 
             var nextMeshIndex = meshIndex + 1;
             var stop = remapTableStarts.Length > nextMeshIndex
-                ? (int)remapTableStarts[nextMeshIndex]
-                : remapTableStarts.Length;
+                ? remapTableStarts[nextMeshIndex] + 1
+                : remapTable.Length;
+            var meshBoneCount = stop - start;
 
-            return remapTable.Skip(start).Take(start - stop).ToArray();
+            var meshRemapTable = new int[meshBoneCount];
+            for (var i = 0; i < meshBoneCount; i++)
+            {
+                meshRemapTable[i] = (int)remapTable[start + i];
+            }
+
+            return meshRemapTable;
         }
 
         public VBIB RemapBoneIndices(VBIB vbib, int meshIndex)

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -17,7 +17,7 @@ namespace ValveResourceFormat.ResourceTypes
         {
             get
             {
-                cachedSkeleton ??= Skeleton.FromModelData(Data, filterBonesUsedByLod0: false);
+                cachedSkeleton ??= Skeleton.FromModelData(Data);
                 return cachedSkeleton;
             }
         }
@@ -82,7 +82,7 @@ namespace ValveResourceFormat.ResourceTypes
 
         public void SetSkeletonFilteredForLod0()
         {
-            cachedSkeleton ??= Skeleton.FromModelData(Data, filterBonesUsedByLod0: true);
+            //cachedSkeleton ??= Skeleton.FromModelData(Data, filterBonesUsedByLod0: true);
         }
 
         public int[] GetRemapTable(int meshIndex)

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -267,7 +267,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         {
             foreach (var root in skeleton.Roots)
             {
-                GetAnimationMatrixRecursive(root, Matrix4x4.Identity, Matrix4x4.Identity, frame, matrices);
+                GetAnimationMatrixRecursive(root, Matrix4x4.Identity, Matrix4x4.Identity, frame, skeleton.LocalRemapTable, matrices);
             }
         }
 
@@ -292,7 +292,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// <summary>
         /// Get animation matrix recursively.
         /// </summary>
-        private static void GetAnimationMatrixRecursive(Bone bone, Matrix4x4 bindPose, Matrix4x4 invBindPose, Frame frame, Span<Matrix4x4> matrices)
+        private static void GetAnimationMatrixRecursive(Bone bone, Matrix4x4 bindPose, Matrix4x4 invBindPose, Frame frame, int[] meshSkeleton, Span<Matrix4x4> matrices)
         {
             // Calculate world space inverse bind pose
             invBindPose *= bone.InverseBindPose;
@@ -313,12 +313,17 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
             // Store result
             var skinMatrix = invBindPose * bindPose;
-            matrices[bone.Index] = skinMatrix;
+
+            var meshBoneIndex = meshSkeleton[bone.Index];
+            if (meshBoneIndex != -1)
+            {
+                matrices[meshBoneIndex] = skinMatrix;
+            }
 
             // Propagate to childen
             foreach (var child in bone.Children)
             {
-                GetAnimationMatrixRecursive(child, bindPose, invBindPose, frame, matrices);
+                GetAnimationMatrixRecursive(child, bindPose, invBindPose, frame, meshSkeleton, matrices);
             }
         }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -156,7 +156,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
 #if DEBUG
                 Console.WriteLine($"Unhandled animation bone decoder type '{decoder}' for attribute '{localChannel.Attribute}'");
-#endif            
+#endif
             }
 
             return animArray
@@ -267,7 +267,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         {
             foreach (var root in skeleton.Roots)
             {
-                GetAnimationMatrixRecursive(root, Matrix4x4.Identity, Matrix4x4.Identity, frame, skeleton.LocalRemapTable, matrices);
+                GetAnimationMatrixRecursive(root, Matrix4x4.Identity, Matrix4x4.Identity, frame, matrices);
             }
         }
 
@@ -292,7 +292,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// <summary>
         /// Get animation matrix recursively.
         /// </summary>
-        private static void GetAnimationMatrixRecursive(Bone bone, Matrix4x4 bindPose, Matrix4x4 invBindPose, Frame frame, int[] meshSkeleton, Span<Matrix4x4> matrices)
+        private static void GetAnimationMatrixRecursive(Bone bone, Matrix4x4 bindPose, Matrix4x4 invBindPose, Frame frame, Span<Matrix4x4> matrices)
         {
             // Calculate world space inverse bind pose
             invBindPose *= bone.InverseBindPose;
@@ -313,17 +313,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
             // Store result
             var skinMatrix = invBindPose * bindPose;
-
-            var meshBoneIndex = meshSkeleton[bone.Index];
-            if (meshBoneIndex != -1)
-            {
-                matrices[meshBoneIndex] = skinMatrix;
-            }
+            matrices[bone.Index] = skinMatrix;
 
             // Propagate to childen
             foreach (var child in bone.Children)
             {
-                GetAnimationMatrixRecursive(child, bindPose, invBindPose, frame, meshSkeleton, matrices);
+                GetAnimationMatrixRecursive(child, bindPose, invBindPose, frame, matrices);
             }
         }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationDataChannel.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationDataChannel.cs
@@ -45,7 +45,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 int id;
                 if (Attribute == AnimationChannelAttribute.Data)
                 {
-                    id = Array.FindIndex(flexControllers, contr => contr.Name == elementName);
+                    id = Array.FindIndex(flexControllers, ctrl => ctrl.Name == elementName);
                 }
                 else
                 {

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Bone.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Bone.cs
@@ -3,6 +3,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
     public class Bone
     {
         public int Index { get; }
+        public ModelSkeletonBoneFlags Flags { get; }
         public Bone Parent { get; private set; }
         public List<Bone> Children { get; } = [];
 
@@ -14,10 +15,11 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public Matrix4x4 BindPose { get; }
         public Matrix4x4 InverseBindPose { get; }
 
-        public Bone(int index, string name, Vector3 position, Quaternion rotation)
+        public Bone(int index, string name, Vector3 position, Quaternion rotation, ModelSkeletonBoneFlags flags)
         {
             Index = index;
             Name = name;
+            Flags = flags;
 
             Position = position;
             Angle = rotation;

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
@@ -13,7 +13,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// <summary>
         /// Initializes a new instance of the <see cref="Skeleton"/> class.
         /// </summary>
-        public static Skeleton FromModelData(KVObject modelData, bool filterBonesUsedByLod0)
+        public static Skeleton FromModelData(KVObject modelData)
         {
             // Check if there is any skeleton data present at all
             if (!modelData.ContainsKey("m_modelSkeleton"))
@@ -22,13 +22,13 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
 
             // Construct the armature from the skeleton KV
-            return new Skeleton(modelData.GetSubCollection("m_modelSkeleton"), filterBonesUsedByLod0);
+            return new Skeleton(modelData.GetSubCollection("m_modelSkeleton"));
         }
 
         /// <summary>
         /// Construct the Armature object from mesh skeleton KV data.
         /// </summary>
-        private Skeleton(KVObject skeletonData, bool filterBonesUsedByLod0)
+        private Skeleton(KVObject skeletonData)
         {
             var boneNames = skeletonData.GetArray<string>("m_boneName");
             var boneParents = skeletonData.GetIntegerArray("m_nParent");
@@ -38,41 +38,28 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             var bonePositions = skeletonData.GetArray("m_bonePosParent", v => v.ToVector3());
             var boneRotations = skeletonData.GetArray("m_boneRotParent", v => v.ToQuaternion());
 
-            var boneIds = Enumerable.Range(0, boneNames.Length);
+            var boneCount = boneNames.Length;
+            Bones = new Bone[boneCount];
 
-            if (filterBonesUsedByLod0)
+            for (var i = 0; i < boneCount; i++)
             {
-                LocalRemapTable = new int[boneNames.Length];
-                var currentRemappedBone = 0;
-                for (var i = 0; i < LocalRemapTable.Length; i++)
+                Bones[i] = new Bone(i, boneNames[i], bonePositions[i], boneRotations[i]);
+            }
+
+            var roots = new List<Bone>();
+            foreach (var bone in Bones)
+            {
+                var parentId = boneParents[bone.Index];
+                if (parentId != -1)
                 {
-                    LocalRemapTable[i] = (boneFlags[i] & ModelSkeletonBoneFlags.BoneUsedByVertexLod0) != 0
-                        ? currentRemappedBone++
-                        : -1;
+                    bone.SetParent(Bones[parentId]);
+                    continue;
                 }
-            }
-            else
-            {
-                LocalRemapTable = boneIds.ToArray();
+
+                roots.Add(bone);
             }
 
-            // Initialise bone array
-            Bones = (filterBonesUsedByLod0 ? boneIds.Where(i => (boneFlags[i] & ModelSkeletonBoneFlags.BoneUsedByVertexLod0) != 0) : boneIds)
-                .Select((boneID, i) => new Bone(i, boneNames[boneID], bonePositions[boneID], boneRotations[boneID]))
-                .ToArray();
-
-            for (var i = 0; i < LocalRemapTable.Length; i++)
-            {
-                var remappeBoneID = LocalRemapTable[i];
-                if (remappeBoneID != -1 && boneParents[i] != -1)
-                {
-                    var remappedParent = LocalRemapTable[boneParents[i]];
-                    Bones[remappeBoneID].SetParent(Bones[remappedParent]);
-                }
-            }
-
-            // Create an empty root list
-            Roots = Bones.Where(bone => bone.Parent == null).ToArray();
+            Roots = roots.ToArray();
         }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
@@ -8,7 +8,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
     {
         public Bone[] Roots { get; private set; }
         public Bone[] Bones { get; private set; }
-        public int[] LocalRemapTable { get; private set; }
+        public int[] LocalRemapTable { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Skeleton"/> class.
@@ -60,6 +60,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
 
             Roots = roots.ToArray();
+            LocalRemapTable = Enumerable.Range(0, boneCount).ToArray();
         }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
@@ -8,7 +8,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
     {
         public Bone[] Roots { get; private set; }
         public Bone[] Bones { get; private set; }
-        public int[] LocalRemapTable { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Skeleton"/> class.
@@ -43,7 +42,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
             for (var i = 0; i < boneCount; i++)
             {
-                Bones[i] = new Bone(i, boneNames[i], bonePositions[i], boneRotations[i]);
+                Bones[i] = new Bone(i, boneNames[i], bonePositions[i], boneRotations[i], boneFlags[i]);
             }
 
             var roots = new List<Bone>();
@@ -60,7 +59,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
 
             Roots = roots.ToArray();
-            LocalRemapTable = Enumerable.Range(0, boneCount).ToArray();
         }
     }
 }


### PR DESCRIPTION
* Currently, we remap mesh bone indices to use indices from the model's skeleton. This adds:
  * Loading time and processing
  * Has overflow bugs. If the on disk VBIB is RGBA8888, and the remap table says index 0 corresponds to model bone 300, it overflows. (todo: fix this for exporting)
* A better approach is to adjust the indices on the animation texture so that each mesh can essentially have its own set of bones it can fetch starting from 0. The only drawback is that the animation texture becomes bigger, and many bones get duplicated.

Tested:
- [x] chicken.vmdl cs2
- [x] abrams.vmdl citadel
- [x] gman.vmdl hlvr
- [x] cs2, citadel, steamvr maps
- [x] ak47 glTF export