### PR TITLE
Fix KV3 text parser incorrectly adding double quotes when reading flagged value inside an array

### DIFF
--- a/Tests/Files/KeyValues/KeyValues3_LF.kv3
+++ b/Tests/Files/KeyValues/KeyValues3_LF.kv3
@@ -16,6 +16,9 @@ Second line of a multi-line string literal.
 	[
 		1,
 		2,
+        resource:"characters/models/shared/animsets/animset_ct.vmdl",
+        panorama:"hud/abilities/haze/haze_sleep_dagger.psd",
+        "hello world",
 	]
 	objectValue =
 	{

--- a/Tests/KeyValuesTest.cs
+++ b/Tests/KeyValuesTest.cs
@@ -61,6 +61,9 @@ namespace Tests
                 var arrayValue = properties["arrayValue"].Value as KVObject;
                 Assert.That(arrayValue.Properties["0"].Value, Is.EqualTo((long)1));
                 Assert.That(arrayValue.Properties["1"].Value, Is.EqualTo((long)2));
+                Assert.That(arrayValue.Properties["2"].Value, Is.EqualTo("characters/models/shared/animsets/animset_ct.vmdl"));
+                Assert.That(arrayValue.Properties["3"].Value, Is.EqualTo("hud/abilities/haze/haze_sleep_dagger.psd"));
+                Assert.That(arrayValue.Properties["4"].Value, Is.EqualTo("hello world"));
 
                 Assert.That(properties["objectValue"].Type, Is.EqualTo(KVType.OBJECT));
                 var objectValue = properties["objectValue"].Value as KVObject;

--- a/ValveResourceFormat/Serialization/KeyValues/KeyValues3.cs
+++ b/ValveResourceFormat/Serialization/KeyValues/KeyValues3.cs
@@ -472,7 +472,9 @@ namespace ValveResourceFormat.Serialization.KeyValues
                     "subclass" => KVFlag.SubClass,
                     _ => throw new InvalidDataException("Unknown flag " + strings[0]),
                 };
-                parser.ObjStack.Peek().AddProperty(parser.CurrentName, new KVFlaggedValue(KVType.STRING, flag, strings[1][1..^1]));
+                //If flagged value is in the array, it needs to include a comma
+                var end = parser.StateStack.Peek() == State.VALUE_ARRAY ? 2 : 1;
+                parser.ObjStack.Peek().AddProperty(parser.CurrentName, new KVFlaggedValue(KVType.STRING, flag, strings[1][1..^end]));
                 return;
             }
 


### PR DESCRIPTION
Repro:
```
<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
{
 a =
 [
  resource:"path",
 ]
}
```