### PR TITLE
decompile support for softbody physics

### DIFF
--- a/ValveResourceFormat/IO/ModelExtract.ValveModel.cs
+++ b/ValveResourceFormat/IO/ModelExtract.ValveModel.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using ValveResourceFormat.ResourceTypes.SoftbodyPhysics;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
 using ValveResourceFormat.ResourceTypes.ModelData;
@@ -380,6 +381,7 @@ partial class ModelExtract
         var bodyGroupList = MakeLazyList("BodyGroupList");
         var animationList = MakeLazyList("AnimationList");
         var physicsShapeList = MakeLazyList("PhysicsShapeList");
+        var softbody = MakeLazyList("Softbody");
         var attachmentList = MakeLazyList("AttachmentList");
         var skeleton = MakeLazyList("Skeleton");
         var modelModifierList = MakeLazyList("ModelModifierList");
@@ -719,6 +721,40 @@ partial class ModelExtract
                     );
 
                     AddItem(physicsShapeList.Value, physicsShapeCapsule);
+                }
+            }
+
+            var pFeModel = physAggregateData.Data.GetSubCollection("m_pFeModel");
+
+            if (pFeModel is not null)
+            {
+                var controlNames = pFeModel.GetArray<string>("m_CtrlName");
+                controlNames ??= [];
+
+                var taperedCapsuleRigids = pFeModel.GetArray<KVObject>("m_TaperedCapsuleRigids")
+                    .Select(c => new TaperedCapsuleRigid(c));
+
+                foreach (var capsule in taperedCapsuleRigids)
+                {
+                    var taperedCapsuleRigid = MakeNode(
+                        "ClothShapeCapsule",
+                        ("parent_bone", controlNames.ElementAtOrDefault(capsule.Node) ?? ""),
+                        ("cloth_collision_priority", 0), // TODO nFlags (assumed)
+                        ("vertex_map", ""), // TODO read from nVertexMapIndex
+                        ("inverted_collision", false), // TODO nFlags (assumed)
+                        ("planarize", false), // TODO nFlags (assumed)
+                        ("radius0", capsule.Radius[0]),
+                        ("point0", capsule.Center[0]),
+                        ("radius1", capsule.Radius[1]),
+                        ("point1", capsule.Center[1])
+                    );
+
+                    for (var i = 0; i < 4; i++)
+                    {
+                        taperedCapsuleRigid.AddProperty("cloth_collision_layer" + i, MakeValue(capsule.CollissionMask[i]));
+                    }
+
+                    AddItem(softbody.Value, taperedCapsuleRigid);
                 }
             }
         }

--- a/ValveResourceFormat/Resource/ResourceTypes/SoftbodyPhysics/SoftbodyCollider.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/SoftbodyPhysics/SoftbodyCollider.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ValveResourceFormat.Serialization;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.ResourceTypes.SoftbodyPhysics;
+public class SoftbodyCollider
+{
+    public Int32 Node { get; set; }
+
+    public UInt32 Flags { get; set; }
+
+    public UInt32 VertexMapIndex { get; set; }
+
+    public bool[] CollissionMask { get; set; }
+
+    public SoftbodyCollider(KVObject data)
+    {
+        Node = data.GetInt32Property("nNode");
+        Flags = data.GetUInt32Property("nFlags");
+        VertexMapIndex = data.GetUInt32Property("nVertexMapIndex");
+
+        var bitMask = data.GetUInt32Property("nCollisionMask");
+        CollissionMask = new bool[4];
+        for (var i = 0; i < 4; i++)
+        {
+            CollissionMask[i] = (bitMask & (1 << i)) != 0;
+        }
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/SoftbodyPhysics/TaperedCapsuleRigid.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/SoftbodyPhysics/TaperedCapsuleRigid.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using ValveResourceFormat.Serialization;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.ResourceTypes.SoftbodyPhysics;
+public class TaperedCapsuleRigid : SoftbodyCollider
+{
+    public Vector3[] Center { get; set; }
+
+    public float[] Radius { get; set; }
+
+    public TaperedCapsuleRigid(KVObject data) : base(data)
+    {
+        Center = data.GetArray("vSphere").Select(v => v.ToVector3()).ToArray();
+        Radius = data.GetArray("vSphere").Select(v => v.GetFloatProperty("3")).ToArray();
+    }
+}


### PR DESCRIPTION
Compiled model files can have a property called `m_pFeModel` in the PHYS 
block, which appears to be an aggregate of compiled softbody physics. At 
the moment, no part of it gets decompiled. 

I am far from understanding, let alone implementing, all parts of it, so for now 
this PR is mostly a log on my progress with both of these for anyone interested 
in helping with either.

## Progress Overview
This is from a `.vmdl` format perspective.

- [ ] Global parameters
- [ ] Individual physics nodes
   - [ ] ClothNode
   - [ ] ClothSpring
   - [ ] ClothStiffHinge
   - [ ] Tris and Quads
- [ ] Rigid colliders (spheres, tapered capsules, boxes)
- [ ] Aggregate physics nodes (I am not sure to what extent these can be restored)
- [ ] Cloth Effects


## Structure of pFeModel 
I'll omit "redundant" fields like hashes, SIMD aggregates or length indicators, as well as things I have 
nothing relevant to say about.

`m_CtrlName`: Names of all bones and procedural nodes involved in the softbody sim. 
Most `nNode` properties in other structures seem to be indices into this list. 
The fields `m_nRotLockStaticNodes` and `m_nStaticNodes`  seem to correspond to 
the `Simulate` and `Allow Rotation` flags you can set in ClothChains for example, 
each describing the number of elements from the beginning of the list.

`m_Ropes`: Seems to describe ClothChains. The first `m_nRopeCount` entries 
are index boundaries into the list itself, each describing a chain while the ones behind
that are indices into `m_CtrlName`.
So the first rope is between `m_nRopeCount` inclusive and `m_Ropes[0]`
exclusive, the second between `m_Ropes[0]` and `m_Ropes[1]` and so on.

`m_TaperedCapsuleRigids`: Basic Colliders. `vSphere` encodes the caps in the 
form `[x, y, z, r]` where `[x, y, z]` are the point coordinates and `r` the sphere 
radius. `nNode` is the index of the parent bone. 

`m_NodeBases`: Data for individual and generated cloth nodes. Nodes for bones 
that are directly part of a ClothChain do not show up here, but `Extrude Sides` for 
example will generate nodes that do.
I haven't found a way to differentiate between true ClothNodes and generated
ones yet other than checking whether the associated name is prefixed with $.

`m_Rods`: Some basic data for springs, both manual and generated ones.
`nNode` contains the endpoints. I haven't found a way to tell apart generated
nodes here either.

`m_NodeIntegrator`: Each entry seems to belong to the bone at the same index
in `m_CtrlName`, but probably contain compiled simulation parameters. At least
there does not seem to be any value match to a physics property. 

`m_NodeCollisionRadii`: Based on the list's length I think these values should 
also map to the `m_CtrlName` list, albeit excluding the static nodes at the beginning.
