### PR TITLE
extract node creation utils from ModelExtract into a separate class

### DIFF
--- a/ValveResourceFormat/IO/KVHelpers.cs
+++ b/ValveResourceFormat/IO/KVHelpers.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.IO;
+internal class KVHelpers
+{
+    internal static KVObject MakeNode(string className, KVObject @object)
+    {
+        var node = new KVObject(className, @object.Properties.Count + 1);
+        node.AddProperty("_class", className);
+
+        foreach (var property in @object.Properties)
+        {
+            if (property.Key == "_class")
+            {
+                continue;
+            }
+
+            node.AddProperty(property.Key, property.Value);
+        }
+
+        return node;
+    }
+    internal static KVObject MakeNode(string className, params (string Name, object Value)[] properties)
+    {
+        var node = new KVObject(className, capacity: properties.Length + 1);
+        node.AddProperty("_class", className);
+        foreach (var prop in properties)
+        {
+            node.AddProperty(prop.Name, prop.Value);
+        }
+        return node;
+    }
+
+    internal static (KVObject Node, KVObject Children) MakeListNode(string className, string containerName = "children")
+    {
+        var children = new KVObject(null, isArray: true);
+        var node = MakeNode(className, (containerName, children));
+        return (node, children);
+    }
+}

--- a/ValveResourceFormat/Serialization/KeyValues/KVObject.cs
+++ b/ValveResourceFormat/Serialization/KeyValues/KVObject.cs
@@ -41,6 +41,15 @@ namespace ValveResourceFormat.Serialization.KeyValues
             }
         }
 
+        public KVObject(string name, params (string Name, object Value)[] properties)
+            : this(name, properties.Length)
+        {
+            foreach (var prop in properties)
+            {
+                AddProperty(prop.Name, prop.Value);
+            }
+        }
+
         //Add a property to the structure
         public virtual void AddProperty(string name, KVValue value)
         {
@@ -55,6 +64,17 @@ namespace ValveResourceFormat.Serialization.KeyValues
             }
 
             Count++;
+        }
+
+        public void AddProperty(string name, object value)
+        {
+            AddProperty(name, new KVValue(value));
+        }
+
+        internal void AddItem(KVObject item)
+        {
+            Debug.Assert(IsArray);
+            AddProperty(null, item);
         }
 
         public void Serialize(IndentedTextWriter writer)


### PR DESCRIPTION
A minor refactor to take a bit of load off the huge module and make the utility functions more readily accessible to other extraction code.