### PR TITLE
Add NmSkel decompilation and extend NmClip decompilation

### DIFF
--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -210,7 +210,7 @@ namespace ValveResourceFormat.IO
                     break;
 
                 case ResourceType.NmClip:
-                    contentFile = new NmClipExtract(resource).ToContentFile();
+                    contentFile = new NmClipExtract(resource, fileLoader).ToContentFile();
                     break;
 
                 // These all just use ToString() and WriteText() to do the job

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text;
 using ValveResourceFormat.CompiledShader;
 using ValveResourceFormat.ResourceTypes;
+using ValveResourceFormat.ResourceTypes.ModelAnimation2;
 
 #nullable disable
 
@@ -209,32 +210,8 @@ namespace ValveResourceFormat.IO
                     break;
 
                 case ResourceType.NmClip:
-                    {
-                        var clip = (ResourceTypes.ModelAnimation2.AnimationClip)resource.DataBlock;
-
-                        // todo: improve
-                        var kv = new Serialization.KeyValues.KVObject(null);
-                        var sourceFileName = Path.ChangeExtension(resource.FileName, ".dmx");
-                        kv.AddProperty("m_sourceFilename", sourceFileName);
-                        kv.AddProperty("m_animationSkeletonName ", clip.SkeletonName);
-                        contentFile.Data = Encoding.UTF8.GetBytes(new Serialization.KeyValues.KV3File(kv).ToString());
-
-                        contentFile.AddSubFile(sourceFileName, () =>
-                        {
-                            using var skeletonResource = fileLoader.LoadFileCompiled(clip.SkeletonName);
-
-                            if (skeletonResource == null)
-                            {
-                                return null;
-                            }
-
-                            var skeleton = ResourceTypes.ModelAnimation.Skeleton.FromSkeletonData(((BinaryKV3)skeletonResource.DataBlock!).Data);
-
-                            return ModelExtract.ToDmxAnim(skeleton, [], new ResourceTypes.ModelAnimation.Animation(clip));
-                        });
-
-                        break;
-                    }
+                    contentFile = new NmClipExtract(resource).ToContentFile();
+                    break;
 
                 // These all just use ToString() and WriteText() to do the job
                 case ResourceType.PanoramaStyle:

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -204,6 +204,10 @@ namespace ValveResourceFormat.IO
                         break;
                     }
 
+                case ResourceType.NmSkeleton:
+                    contentFile = new NmSkeletonExtract(resource).ToContentFile();
+                    break;
+
                 case ResourceType.NmClip:
                     {
                         var clip = (ResourceTypes.ModelAnimation2.AnimationClip)resource.DataBlock;

--- a/ValveResourceFormat/IO/NmClipExtract.cs
+++ b/ValveResourceFormat/IO/NmClipExtract.cs
@@ -60,10 +60,11 @@ public class NmClipExtract
             var docEventTrack = BuildDocEventBasedOnEventClass(ev, ev.GetStringProperty("_class"));
             var startTimeSeconds = ev.GetFloatProperty("m_flStartTimeSeconds");
             var durationSeconds = ev.GetFloatProperty("m_flDurationSeconds");
+            var eventList = docEventTrack.GetArray<KVObject>("m_events").First();
             // Doc file event time stamps are given in frames they can be technically floats, but based on recompilation tests
             // these seem inconsistent, unless they're floored to int, then it matches up.
-            docEventTrack.GetArray<KVObject>("m_events").First().AddProperty("m_flStartTime", Math.Floor(startTimeSeconds * animation.Fps));
-            docEventTrack.GetArray<KVObject>("m_events").First().AddProperty("m_flDuration", Math.Floor(durationSeconds * animation.Fps));
+            eventList.AddProperty("m_flStartTime", Math.Floor(startTimeSeconds * animation.Fps));
+            eventList.AddProperty("m_flDuration", Math.Floor(durationSeconds * animation.Fps));
             docEventTracks.AddItem(docEventTrack);
         }
         kv.AddProperty("m_eventTracks", docEventTracks);
@@ -78,144 +79,73 @@ public class NmClipExtract
         // even though m_events is an array inside each track.
         var kvDocEventTrack = new KVObject(null);
         var kvDocEvent = new KVObject("m_event");
-        kvDocEventTrack.AddProperty("m_type", "Duration");
-        kvDocEventTrack.AddProperty("m_bIsSyncTrack", kvCompiledEvent.ContainsKey("m_syncID"));
-        switch (className)
-        {
-            case "CNmIDEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_ID");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_ID");
-                    kvDocEvent.AddProperty("m_ID", kvCompiledEvent.GetStringProperty("m_ID"));
-                    kvDocEvent.AddProperty("m_secondaryID", kvCompiledEvent.GetStringProperty("m_secondaryID"));
-                    break;
-                }
-            case "CNmEntityAttributeIntEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_EntityAttribute");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_EntityAttribute");
-                    kvDocEvent.AddProperty("m_attributeName", kvCompiledEvent.GetStringProperty("m_attributeName"));
-                    kvDocEvent.AddProperty("m_nValueType", "EVENT_ENTITY_ATTR_TYPE_INT");
-                    kvDocEvent.AddProperty("m_nIntValue", kvCompiledEvent.GetInt32Property("m_nIntValue"));
-                    break;
-                }
-            case "CNmEntityAttributeFloatEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_EntityAttribute");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_EntityAttribute");
-                    kvDocEvent.AddProperty("m_attributeName", kvCompiledEvent.GetStringProperty("m_attributeName"));
-                    kvDocEvent.AddProperty("m_nValueType", "EVENT_ENTITY_ATTR_TYPE_FLOAT");
-                    kvDocEvent.AddProperty("m_FloatValue", kvCompiledEvent.GetProperty<object>("m_FloatValue"));
-                    break;
-                }
 
-            case "CNmFloatCurveEvent":
+        kvDocEventTrack.AddProperty("m_type", "Duration"); // Doesn't seem to matter?
+        kvDocEventTrack.AddProperty("m_bIsSyncTrack", kvCompiledEvent.ContainsKey("m_syncID"));
+        // Get string between "CNm" and "Event".
+        var eventName = className[3..^5];
+        // Example: CNmIDEvent maps to CNmClipDocEvent_ID.
+        var docEventClass = "CNmClipDocEvent_" + eventName;
+        kvDocEventTrack.AddProperty("m_eventClassName", docEventClass);
+        kvDocEvent.AddProperty("_class", docEventClass);
+        foreach (var field in kvCompiledEvent)
+        {
+            // These were already handled and shouldn't be copied over.
+            if (field.Key == "m_flStartTimeSeconds" || field.Key == "m_flDurationSeconds")
+            {
+                continue;
+            }
+            // Handle special cases - a few doc fields are different to the compiled event definition.
+            switch (eventName)
+            {
+                case "Particle":
+                    {
+                        if (field.Key == "m_hParticleSystem")
+                        {
+                            kvDocEvent.AddProperty("m_particleSystem", field.Value);
+                        }
+                    }
+                    break;
+                case "Legacy":
+                    {
+                        if (field.Key == "m_animEventClassName")
+                        {
+                            kvDocEvent.AddProperty("m_eventClass", field.Value);
+                        }
+                        break;
+                    }
+                case "Transition":
+                    {
+                        if (field.Key == "m_ID")
+                        {
+                            kvDocEvent.AddProperty("m_optionalID", field.Value);
+                        }
+                        break;
+                    }
+                default:
+                    {
+                        kvDocEvent.AddProperty(field.Key, field.Value);
+                        break;
+                    }
+            }
+        }
+        // Handle special cases - only additional fields that need adding afterwards.
+        switch (eventName)
+        {
+            case "EntityAttributeInt":
                 {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_FloatCurve");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_FloatCurve");
-                    kvDocEvent.AddProperty("m_curve", kvCompiledEvent.GetProperty<object>("m_curve"));
-                    kvDocEvent.AddProperty("m_ID", kvCompiledEvent.GetStringProperty("m_ID"));
+                    kvDocEvent.AddProperty("m_nValueType", "EVENT_ENTITY_ATTR_TYPE_INT");
                     break;
                 }
-            case "CNmFootEvent":
+            case "EntityAttributeFloat":
                 {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Foot");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Foot");
-                    kvDocEvent.AddProperty("m_phase", kvCompiledEvent.GetProperty<object>("m_phase"));
-                    break;
-                }
-            case "CNmFrameSnapEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_FrameSnap");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_FrameSnap");
-                    kvDocEvent.AddProperty("m_frameSnapMode", kvCompiledEvent.GetProperty<object>("m_frameSnapMode"));
-                    break;
-                }
-            case "CNmLegacyEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Legacy");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Legacy");
-                    kvDocEvent.AddProperty("m_eventClass", kvCompiledEvent.GetStringProperty("m_animEventClassName"));
-                    kvDocEvent.AddProperty("m_KV", kvCompiledEvent.GetProperty<KVObject>("m_KV"));
-                    break;
-                }
-            case "CNmMaterialAttributeEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_MaterialAttribute");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_MaterialAttribute");
-                    kvDocEvent.AddProperty("m_attributeName", kvCompiledEvent.GetStringProperty("m_attributeName"));
-                    kvDocEvent.AddProperty("m_x", kvCompiledEvent.GetProperty<object>("m_x"));
-                    kvDocEvent.AddProperty("m_y", kvCompiledEvent.GetProperty<object>("m_y"));
-                    kvDocEvent.AddProperty("m_z", kvCompiledEvent.GetProperty<object>("m_z"));
-                    kvDocEvent.AddProperty("m_w", kvCompiledEvent.GetProperty<object>("m_w"));
-                    break;
-                }
-            case "CNmOrientationWarpEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_OrientationWarp");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_OrientationWarp");
-                    break;
-                }
-            case "CNmParticleEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Particle");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Particle");
-                    kvDocEvent.AddProperty("m_relevance", kvCompiledEvent.GetStringProperty("m_relevance"));
-                    kvDocEvent.AddProperty("m_type", kvCompiledEvent.GetStringProperty("m_type"));
-                    kvDocEvent.AddProperty("m_particleSystem", kvCompiledEvent.GetStringProperty("m_hParticleSystem"));
-                    kvDocEvent.AddProperty("m_bDetachFromOwner", kvCompiledEvent.GetProperty<bool>("m_bDetachFromOwner"));
-                    kvDocEvent.AddProperty("m_bStopImmediately", kvCompiledEvent.GetProperty<bool>("m_bStopImmediately"));
-                    kvDocEvent.AddProperty("m_bPlayEndCap", kvCompiledEvent.GetProperty<bool>("m_bPlayEndCap"));
-                    kvDocEvent.AddProperty("m_attachmentPoint0", kvCompiledEvent.GetStringProperty("m_attachmentPoint0"));
-                    kvDocEvent.AddProperty("m_attachmentType0", kvCompiledEvent.GetStringProperty("m_attachmentType0"));
-                    kvDocEvent.AddProperty("m_attachmentPoint1", kvCompiledEvent.GetStringProperty("m_attachmentPoint1"));
-                    kvDocEvent.AddProperty("m_attachmentType1", kvCompiledEvent.GetStringProperty("m_attachmentType1"));
-                    kvDocEvent.AddProperty("m_config", kvCompiledEvent.GetStringProperty("m_config"));
-                    kvDocEvent.AddProperty("m_effectForConfig", kvCompiledEvent.GetStringProperty("m_effectForConfig"));
-                    kvDocEvent.AddProperty("m_tags", kvCompiledEvent.GetStringProperty("m_tags"));
-                    break;
-                }
-            case "CNmRootMotionEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_RootMotion");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_RootMotion");
-                    kvDocEvent.AddProperty("m_flBlendTimeSeconds", kvCompiledEvent.GetFloatProperty("m_flBlendTimeSeconds"));
-                    break;
-                }
-            case "CNmSoundEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Sound");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Sound");
-                    kvDocEvent.AddProperty("m_relevance", kvCompiledEvent.GetStringProperty("m_relevance"));
-                    kvDocEvent.AddProperty("m_type", kvCompiledEvent.GetStringProperty("m_type"));
-                    kvDocEvent.AddProperty("m_bContinuePlayingSoundAtDurationEnd", kvCompiledEvent.GetProperty<bool>("m_bContinuePlayingSoundAtDurationEnd"));
-                    kvDocEvent.AddProperty("m_flDurationInterruptionThreshold", kvCompiledEvent.GetFloatProperty("m_flDurationInterruptionThreshold"));
-                    kvDocEvent.AddProperty("m_name", kvCompiledEvent.GetStringProperty("m_name"));
-                    kvDocEvent.AddProperty("m_position", kvCompiledEvent.GetStringProperty("m_position"));
-                    kvDocEvent.AddProperty("m_attachmentName", kvCompiledEvent.GetStringProperty("m_attachmentName"));
-                    kvDocEvent.AddProperty("m_tags", kvCompiledEvent.GetStringProperty("m_tags"));
-                    break;
-                }
-            case "CNmTargetWarpEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_TargetWarp");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_TargetWarp");
-                    kvDocEvent.AddProperty("m_rule", kvCompiledEvent.GetStringProperty("m_rule"));
-                    kvDocEvent.AddProperty("m_algorithm", kvCompiledEvent.GetStringProperty("m_algorithm"));
-                    break;
-                }
-            case "CNmTransitionEvent":
-                {
-                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Transition");
-                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Transition");
-                    kvDocEvent.AddProperty("m_rule", kvCompiledEvent.GetStringProperty("m_rule"));
-                    kvDocEvent.AddProperty("m_optionalID", kvCompiledEvent.GetStringProperty("m_ID"));
+                    kvDocEvent.AddProperty("m_nValueType", "EVENT_ENTITY_ATTR_TYPE_FLOAT");
                     break;
                 }
         }
-        var arr = new KVObject("m_events", true, 1);
-        arr.AddItem(kvDocEvent);
-        kvDocEventTrack.AddProperty("m_events", arr);
+        var eventsArray = new KVObject("m_events", true, 1);
+        eventsArray.AddItem(kvDocEvent);
+        kvDocEventTrack.AddProperty("m_events", eventsArray);
         return kvDocEventTrack;
     }
 }

--- a/ValveResourceFormat/IO/NmClipExtract.cs
+++ b/ValveResourceFormat/IO/NmClipExtract.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text;
+using ValveResourceFormat.IO;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.ResourceTypes.ModelAnimation2;
+public class NmClipExtract
+{
+    private readonly Resource resource;
+    private readonly AnimationClip clip;
+    private readonly IFileLoader fileLoader;
+    public NmClipExtract(Resource resource, IFileLoader fileLoader)
+    {
+        this.resource = resource;
+        clip = resource.DataBlock as AnimationClip
+            ?? throw new InvalidDataException("Resource DataBlock is not an AnimationClip.");
+        this.fileLoader = fileLoader;
+    }
+    public ContentFile ToContentFile()
+    {
+        var contentFile = new ContentFile();
+
+        var kv = new KVObject(null);
+        var sourceFileName = Path.ChangeExtension(resource.FileName, ".dmx");
+        kv.AddProperty("m_sourceFilename", sourceFileName);
+        kv.AddProperty("m_animationSkeletonName", clip.SkeletonName);
+        contentFile.Data = Encoding.UTF8.GetBytes(new KV3File(kv).ToString());
+
+        contentFile.AddSubFile(sourceFileName, () =>
+        {
+            using var skeletonResource = fileLoader.LoadFileCompiled(clip.SkeletonName);
+
+            if (skeletonResource == null)
+            {
+                return null;
+            }
+
+            var skeleton = ModelAnimation.Skeleton.FromSkeletonData(((BinaryKV3)skeletonResource.DataBlock!).Data);
+
+            return ModelExtract.ToDmxAnim(skeleton, [], new ModelAnimation.Animation(clip));
+        });
+
+        return contentFile;
+    }
+}

--- a/ValveResourceFormat/IO/NmClipExtract.cs
+++ b/ValveResourceFormat/IO/NmClipExtract.cs
@@ -1,5 +1,5 @@
-using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using ValveResourceFormat.IO;
 using ValveResourceFormat.Serialization.KeyValues;
@@ -25,22 +25,197 @@ public class NmClipExtract
         var sourceFileName = Path.ChangeExtension(resource.FileName, ".dmx");
         kv.AddProperty("m_sourceFilename", sourceFileName);
         kv.AddProperty("m_animationSkeletonName", clip.SkeletonName);
-        contentFile.Data = Encoding.UTF8.GetBytes(new KV3File(kv).ToString());
+        // TODO: figure out additive type.
 
-        contentFile.AddSubFile(sourceFileName, () =>
+        var animation = new ModelAnimation.Animation(clip);
+        var skeletonResource = fileLoader.LoadFileCompiled(clip.SkeletonName);
+        if (skeletonResource != null)
         {
-            using var skeletonResource = fileLoader.LoadFileCompiled(clip.SkeletonName);
-
-            if (skeletonResource == null)
-            {
-                return null;
-            }
-
             var skeleton = ModelAnimation.Skeleton.FromSkeletonData(((BinaryKV3)skeletonResource.DataBlock!).Data);
+            var modelSpaceSamplingChain = clip.Data.GetArray<KVObject>("m_modelSpaceSamplingChain");
+            // The array below indexes into the bone sampling chain, which in turn indexes into the skeleton bones.
+            var modelSpaceBoneSamplingIndices = clip.Data.GetIntegerArray("m_modelSpaceBoneSamplingIndices");
 
-            return ModelExtract.ToDmxAnim(skeleton, [], new ModelAnimation.Animation(clip));
-        });
+            var bonesToSampleInModelSpace = new KVObject("m_bonesToSampleInModelSpace", true, modelSpaceBoneSamplingIndices.Length);
+            foreach (var chainIdx in modelSpaceBoneSamplingIndices)
+            {
+                if (chainIdx < 0 || chainIdx >= modelSpaceSamplingChain.Length)
+                {
+                    throw new InvalidDataException($"Model space sampling chain index {chainIdx} is out of bounds (0..{modelSpaceSamplingChain.Length - 1}).");
+                }
+                var boneIdx = modelSpaceSamplingChain[chainIdx].GetInt32Property("m_nBoneIdx");
+                bonesToSampleInModelSpace.AddItem(skeleton.Bones[boneIdx].Name);
+            }
+            kv.AddProperty("m_bonesToSampleInModelSpace", bonesToSampleInModelSpace);
 
+            contentFile.AddSubFile(sourceFileName, () =>
+            {
+                return ModelExtract.ToDmxAnim(skeleton, [], animation);
+            });
+        }
+        var events = clip.Data.GetArray<KVObject>("m_events");
+        var docEventTracks = new KVObject("m_eventTracks", true, events.Length);
+        foreach (var ev in events)
+        {
+            var docEventTrack = BuildDocEventBasedOnEventClass(ev, ev.GetStringProperty("_class"));
+            var startTimeSeconds = ev.GetFloatProperty("m_flStartTimeSeconds");
+            var durationSeconds = ev.GetFloatProperty("m_flDurationSeconds");
+            // Doc file event time stamps are given in frames they can be technically floats, but based on recompilation tests
+            // these seem inconsistent, unless they're floored to int, then it matches up.
+            docEventTrack.GetArray<KVObject>("m_events").First().AddProperty("m_flStartTime", Math.Floor(startTimeSeconds * animation.Fps));
+            docEventTrack.GetArray<KVObject>("m_events").First().AddProperty("m_flDuration", Math.Floor(durationSeconds * animation.Fps));
+            docEventTracks.AddItem(docEventTrack);
+        }
+        kv.AddProperty("m_eventTracks", docEventTracks);
+        contentFile.Data = Encoding.UTF8.GetBytes(new KV3File(kv).ToString());
         return contentFile;
+    }
+
+    // Returns a full event track.
+    private static KVObject BuildDocEventBasedOnEventClass(KVObject kvCompiledEvent, string className)
+    {
+        // From testing one event track in doc seems to correspond to one event in compiled asset
+        // even though m_events is an array inside each track.
+        var kvDocEventTrack = new KVObject(null);
+        var kvDocEvent = new KVObject("m_event");
+        kvDocEventTrack.AddProperty("m_type", "Duration");
+        kvDocEventTrack.AddProperty("m_bIsSyncTrack", kvCompiledEvent.ContainsKey("m_syncID"));
+        switch (className)
+        {
+            case "CNmIDEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_ID");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_ID");
+                    kvDocEvent.AddProperty("m_ID", kvCompiledEvent.GetStringProperty("m_ID"));
+                    kvDocEvent.AddProperty("m_secondaryID", kvCompiledEvent.GetStringProperty("m_secondaryID"));
+                    break;
+                }
+            case "CNmEntityAttributeIntEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_EntityAttribute");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_EntityAttribute");
+                    kvDocEvent.AddProperty("m_attributeName", kvCompiledEvent.GetStringProperty("m_attributeName"));
+                    kvDocEvent.AddProperty("m_nValueType", "EVENT_ENTITY_ATTR_TYPE_INT");
+                    kvDocEvent.AddProperty("m_nIntValue", kvCompiledEvent.GetInt32Property("m_nIntValue"));
+                    break;
+                }
+            case "CNmEntityAttributeFloatEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_EntityAttribute");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_EntityAttribute");
+                    kvDocEvent.AddProperty("m_attributeName", kvCompiledEvent.GetStringProperty("m_attributeName"));
+                    kvDocEvent.AddProperty("m_nValueType", "EVENT_ENTITY_ATTR_TYPE_FLOAT");
+                    kvDocEvent.AddProperty("m_FloatValue", kvCompiledEvent.GetProperty<object>("m_FloatValue"));
+                    break;
+                }
+
+            case "CNmFloatCurveEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_FloatCurve");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_FloatCurve");
+                    kvDocEvent.AddProperty("m_curve", kvCompiledEvent.GetProperty<object>("m_curve"));
+                    kvDocEvent.AddProperty("m_ID", kvCompiledEvent.GetStringProperty("m_ID"));
+                    break;
+                }
+            case "CNmFootEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Foot");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Foot");
+                    kvDocEvent.AddProperty("m_phase", kvCompiledEvent.GetProperty<object>("m_phase"));
+                    break;
+                }
+            case "CNmFrameSnapEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_FrameSnap");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_FrameSnap");
+                    kvDocEvent.AddProperty("m_frameSnapMode", kvCompiledEvent.GetProperty<object>("m_frameSnapMode"));
+                    break;
+                }
+            case "CNmLegacyEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Legacy");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Legacy");
+                    kvDocEvent.AddProperty("m_eventClass", kvCompiledEvent.GetStringProperty("m_animEventClassName"));
+                    kvDocEvent.AddProperty("m_KV", kvCompiledEvent.GetProperty<KVObject>("m_KV"));
+                    break;
+                }
+            case "CNmMaterialAttributeEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_MaterialAttribute");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_MaterialAttribute");
+                    kvDocEvent.AddProperty("m_attributeName", kvCompiledEvent.GetStringProperty("m_attributeName"));
+                    kvDocEvent.AddProperty("m_x", kvCompiledEvent.GetProperty<object>("m_x"));
+                    kvDocEvent.AddProperty("m_y", kvCompiledEvent.GetProperty<object>("m_y"));
+                    kvDocEvent.AddProperty("m_z", kvCompiledEvent.GetProperty<object>("m_z"));
+                    kvDocEvent.AddProperty("m_w", kvCompiledEvent.GetProperty<object>("m_w"));
+                    break;
+                }
+            case "CNmOrientationWarpEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_OrientationWarp");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_OrientationWarp");
+                    break;
+                }
+            case "CNmParticleEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Particle");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Particle");
+                    kvDocEvent.AddProperty("m_relevance", kvCompiledEvent.GetStringProperty("m_relevance"));
+                    kvDocEvent.AddProperty("m_type", kvCompiledEvent.GetStringProperty("m_type"));
+                    kvDocEvent.AddProperty("m_particleSystem", kvCompiledEvent.GetStringProperty("m_hParticleSystem"));
+                    kvDocEvent.AddProperty("m_bDetachFromOwner", kvCompiledEvent.GetProperty<bool>("m_bDetachFromOwner"));
+                    kvDocEvent.AddProperty("m_bStopImmediately", kvCompiledEvent.GetProperty<bool>("m_bStopImmediately"));
+                    kvDocEvent.AddProperty("m_bPlayEndCap", kvCompiledEvent.GetProperty<bool>("m_bPlayEndCap"));
+                    kvDocEvent.AddProperty("m_attachmentPoint0", kvCompiledEvent.GetStringProperty("m_attachmentPoint0"));
+                    kvDocEvent.AddProperty("m_attachmentType0", kvCompiledEvent.GetStringProperty("m_attachmentType0"));
+                    kvDocEvent.AddProperty("m_attachmentPoint1", kvCompiledEvent.GetStringProperty("m_attachmentPoint1"));
+                    kvDocEvent.AddProperty("m_attachmentType1", kvCompiledEvent.GetStringProperty("m_attachmentType1"));
+                    kvDocEvent.AddProperty("m_config", kvCompiledEvent.GetStringProperty("m_config"));
+                    kvDocEvent.AddProperty("m_effectForConfig", kvCompiledEvent.GetStringProperty("m_effectForConfig"));
+                    kvDocEvent.AddProperty("m_tags", kvCompiledEvent.GetStringProperty("m_tags"));
+                    break;
+                }
+            case "CNmRootMotionEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_RootMotion");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_RootMotion");
+                    kvDocEvent.AddProperty("m_flBlendTimeSeconds", kvCompiledEvent.GetFloatProperty("m_flBlendTimeSeconds"));
+                    break;
+                }
+            case "CNmSoundEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Sound");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Sound");
+                    kvDocEvent.AddProperty("m_relevance", kvCompiledEvent.GetStringProperty("m_relevance"));
+                    kvDocEvent.AddProperty("m_type", kvCompiledEvent.GetStringProperty("m_type"));
+                    kvDocEvent.AddProperty("m_bContinuePlayingSoundAtDurationEnd", kvCompiledEvent.GetProperty<bool>("m_bContinuePlayingSoundAtDurationEnd"));
+                    kvDocEvent.AddProperty("m_flDurationInterruptionThreshold", kvCompiledEvent.GetFloatProperty("m_flDurationInterruptionThreshold"));
+                    kvDocEvent.AddProperty("m_name", kvCompiledEvent.GetStringProperty("m_name"));
+                    kvDocEvent.AddProperty("m_position", kvCompiledEvent.GetStringProperty("m_position"));
+                    kvDocEvent.AddProperty("m_attachmentName", kvCompiledEvent.GetStringProperty("m_attachmentName"));
+                    kvDocEvent.AddProperty("m_tags", kvCompiledEvent.GetStringProperty("m_tags"));
+                    break;
+                }
+            case "CNmTargetWarpEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_TargetWarp");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_TargetWarp");
+                    kvDocEvent.AddProperty("m_rule", kvCompiledEvent.GetStringProperty("m_rule"));
+                    kvDocEvent.AddProperty("m_algorithm", kvCompiledEvent.GetStringProperty("m_algorithm"));
+                    break;
+                }
+            case "CNmTransitionEvent":
+                {
+                    kvDocEventTrack.AddProperty("m_eventClassName", "CNmClipDocEvent_Transition");
+                    kvDocEvent.AddProperty("_class", "CNmClipDocEvent_Transition");
+                    kvDocEvent.AddProperty("m_rule", kvCompiledEvent.GetStringProperty("m_rule"));
+                    kvDocEvent.AddProperty("m_optionalID", kvCompiledEvent.GetStringProperty("m_ID"));
+                    break;
+                }
+        }
+        var arr = new KVObject("m_events", true, 1);
+        arr.AddItem(kvDocEvent);
+        kvDocEventTrack.AddProperty("m_events", arr);
+        return kvDocEventTrack;
     }
 }

--- a/ValveResourceFormat/IO/NmSkeletonExtract.cs
+++ b/ValveResourceFormat/IO/NmSkeletonExtract.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using ValveResourceFormat.ResourceTypes;
+using ValveResourceFormat.ResourceTypes.ModelAnimation;
+using ValveResourceFormat.ResourceTypes.ModelAnimation2;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.IO;
+public class NmSkeletonExtract
+{
+    private readonly Resource resource;
+    private readonly KVObject kvSkeleton;
+    public NmSkeletonExtract(Resource resource)
+    {
+        this.resource = resource;
+        var resourceData = resource.DataBlock as BinaryKV3
+            ?? throw new InvalidDataException("Resource DataBlock is not a BinaryKV3 or is null.");
+        kvSkeleton = resourceData.Data;
+    }
+    public ContentFile ToContentFile()
+    {
+        var kv = new KVObject(null);
+        var skel = Skeleton.FromSkeletonData(kvSkeleton);
+        var dmxFile = Path.ChangeExtension(resource.FileName, "dmx");
+        kv.AddProperty("m_sourceFileName", dmxFile);
+        kv.AddProperty("m_rootBoneName", skel.Roots.FirstOrDefault()?.Name);
+        kv.AddProperty("m_flGlobalScale", 1.0f);
+        kv.AddProperty("m_bIsAttachableProp", kvSkeleton.GetProperty<bool>("m_bIsPropSkeleton"));
+        kv.AddProperty("m_secondarySkeletons", kvSkeleton.GetProperty<object>("m_secondarySkeletons"));
+        var numLowLODBones = kvSkeleton.GetInt32Property("m_numBonesToSampleAtLowLOD");
+        var boneIDs = kvSkeleton.GetArray<string>("m_boneIDs")[numLowLODBones..];
+        var highLODBones = new KVObject("m_highLODBones", true, boneIDs.Length);
+        foreach (var boneID in boneIDs)
+        {
+            highLODBones.AddItem(boneID);
+        }
+        kv.AddProperty("m_highLODBones", highLODBones);
+        // Mask definitions seem to be 1:1 to the source.
+        kv.AddProperty("m_boneMaskSetDefinitions", kvSkeleton.GetProperty<object>("m_maskDefinitions"));
+
+        var contentFile = new ContentFile
+        {
+            Data = Encoding.UTF8.GetBytes(new KV3File(kv).ToString())
+        };
+        contentFile.AddSubFile(dmxFile, () =>
+        {
+            // Empty animation data
+            var anim = new Animation(new AnimationClip());
+            return ModelExtract.ToDmxAnim(skel, [], anim);
+        });
+        return contentFile;
+    }
+}

--- a/ValveResourceFormat/IO/NmSkeletonExtract.cs
+++ b/ValveResourceFormat/IO/NmSkeletonExtract.cs
@@ -7,6 +7,7 @@ using ValveResourceFormat.ResourceTypes.ModelAnimation2;
 using ValveResourceFormat.Serialization.KeyValues;
 
 namespace ValveResourceFormat.IO;
+
 public class NmSkeletonExtract
 {
     private readonly Resource resource;


### PR DESCRIPTION
I tested the NmClip export on a handful of assets, but I didn't try every implemented event type yet.

Side note: DMX export seems to be not working fully, at least for skeletal animations. Directly exported file neither works in-game or for external tools (like Blender Source Tools) so users need to find some other way to export the animation sequences themselves for now. I thought about creating an issue on Datamodel.NET repo, but there seems to be a similar issue already, and it wasn't updated for 9 years at least. It seems that changing version to binary 9 for the DMX export will work in Blender Source Tools, but will crash the game, I haven't changed it here though.