### PR TITLE
Bind cubemap and light probe entity preview nodes to their own volumes

### DIFF
--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -1597,6 +1597,13 @@ namespace ValveResourceFormat.Renderer
 
             foreach (var node in AllNodes)
             {
+                if (node.EntityData is { } entityData
+                    && LightingInfo.LightProbes.Find(p => ReferenceEquals(p.EntityData, entityData)) is { } selfProbe)
+                {
+                    node.LightProbeBinding = selfProbe;
+                    continue;
+                }
+
                 var precomputedHandshake = node.LightProbeVolumePrecomputedHandshake;
                 if (precomputedHandshake == 0)
                 {
@@ -1732,7 +1739,13 @@ namespace ValveResourceFormat.Renderer
                 var precomputedHandshake = node.CubeMapPrecomputedHandshake;
                 SceneEnvMap? preComputed = default;
 
-                if (precomputedHandshake > 0)
+                if (node.EntityData is { } entityData
+                    && LightingInfo.EnvMaps.Find(e => ReferenceEquals(e.EntityData, entityData)) is { } selfEnvMap)
+                {
+                    node.EnvMaps.Clear();
+                    node.EnvMaps.Add(selfEnvMap);
+                }
+                else if (precomputedHandshake > 0)
                 {
                     if (LightingInfo.CubemapType == CubemapType.IndividualCubemaps
                         && precomputedHandshake <= LightingInfo.EnvMaps.Count)

--- a/Renderer/Renderer/World/WorldLoader.cs
+++ b/Renderer/Renderer/World/WorldLoader.cs
@@ -847,6 +847,7 @@ namespace ValveResourceFormat.Renderer.World
                             {
                                 LayerName = layerName,
                                 Transform = transformationMatrix,
+                                EntityData = entity,
                                 HandShake = handShake,
                                 ArrayIndex = arrayIndex,
                                 IndoorOutdoorLevel = indoorOutdoorLevel,
@@ -873,6 +874,7 @@ namespace ValveResourceFormat.Renderer.World
                         {
                             LayerName = layerName,
                             Transform = transformationMatrix,
+                            EntityData = entity,
                             HandShake = handShake,
                             Irradiance = irradianceTexture,
                             IndoorOutdoorLevel = indoorOutdoorLevel,


### PR DESCRIPTION
Bind probe and cubemap entity preview nodes to their own volumes via entity identity