### PR TITLE
Sequenceanim decode refactor

### DIFF
--- a/Renderer/Renderer/AnimationPlayer.cs
+++ b/Renderer/Renderer/AnimationPlayer.cs
@@ -222,6 +222,7 @@ namespace ValveResourceFormat.Renderer
 
             if (animation != null)
             {
+                FrameCache.EnsureBinding(animation);
                 TransitionToClip(animation, blendTime, looping);
             }
             else

--- a/ValveResourceFormat/IO/AnimationGroupLoader.cs
+++ b/ValveResourceFormat/IO/AnimationGroupLoader.cs
@@ -16,10 +16,8 @@ namespace ValveResourceFormat.IO
         /// </summary>
         /// <param name="resource">The animation group resource to load from.</param>
         /// <param name="fileLoader">File loader for loading external animation files.</param>
-        /// <param name="skeleton">The skeleton to apply animations to.</param>
-        /// <param name="flexControllers">Flex controllers for facial animations.</param>
         /// <returns>Collection of loaded animations.</returns>
-        public static IEnumerable<SequenceAnimation> LoadAnimationGroup(Resource resource, IFileLoader fileLoader, Skeleton skeleton, FlexController[] flexControllers)
+        public static IEnumerable<SequenceAnimation> LoadAnimationGroup(Resource resource, IFileLoader fileLoader)
         {
             var dataBlock = resource.DataBlock;
 
@@ -38,7 +36,7 @@ namespace ValveResourceFormat.IO
 
             if (animBlock != null)
             {
-                animationList.AddRange(SequenceAnimation.FromData(animBlock.Data, decodeKey, skeleton, flexControllers));
+                animationList.AddRange(SequenceAnimation.FromData(animBlock.Data, decodeKey));
                 return animationList;
             }
 
@@ -53,7 +51,7 @@ namespace ValveResourceFormat.IO
                 if (animResource != null)
                 {
                     // Build animation classes
-                    animationList.AddRange(SequenceAnimation.FromResource(animResource, decodeKey, skeleton, flexControllers));
+                    animationList.AddRange(SequenceAnimation.FromResource(animResource, decodeKey));
                 }
             }
 

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -20,8 +20,8 @@ public partial class GltfModelExporter
     public class AnimationWriter
     {
         Skeleton Skeleton { get; init; }
-        Frame Frame { get; init; }
         FlexController[] FlexControllers { get; init; }
+        Frame Frame { get; init; }
         int BoneCount => Frame.Bones.Length;
 
         AnimationChannelWriter<Quaternion> RotationWriter;
@@ -43,8 +43,8 @@ public partial class GltfModelExporter
         public AnimationWriter(Skeleton skeleton, FlexController[] flexControllers)
         {
             Skeleton = skeleton;
-            Frame = new(skeleton, flexControllers);
             FlexControllers = flexControllers;
+            Frame = new(skeleton, flexControllers);
 
             RotationWriter = AnimationChannelWriter<Quaternion>.Create(BoneCount);
             PositionWriter = AnimationChannelWriter<Vector3>.Create(BoneCount);

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -411,28 +411,11 @@ namespace ValveResourceFormat.ResourceTypes
                     return SequenceAnimation.FromSequenceData(
                         sequenceDataBlock.Data,
                         animationDataBlock.Data,
-                        decodeKey,
-                        Skeleton,
-                        FlexControllers);
+                        decodeKey);
                 }
             }
 
-            return SequenceAnimation.FromData(animationDataBlock.Data, decodeKey, Skeleton, FlexControllers);
-        }
-
-        /// <summary>
-        /// Get the embedded animations with a different skeleton as animation target.
-        /// </summary>
-        /// <returns></returns>
-        public static IEnumerable<Animation> GetEmbeddedAnimationsWithSkeleton(IFileLoader fileLoader, Skeleton skeleton, Model model)
-        {
-            var old = model.cachedSkeleton;
-
-            model.cachedSkeleton = skeleton;
-            var anims = model.GetAllAnimations(fileLoader);
-
-            model.cachedSkeleton = old;
-            return anims;
+            return SequenceAnimation.FromData(animationDataBlock.Data, decodeKey);
         }
 
         /// <summary>
@@ -462,8 +445,7 @@ namespace ValveResourceFormat.ResourceTypes
                     continue;
                 }
 
-                var anims = GetEmbeddedAnimationsWithSkeleton(fileLoader, Skeleton, model);
-                allAnims.AddRange(anims);
+                allAnims.AddRange(model.GetAllAnimations(fileLoader));
             }
 
             return allAnims;
@@ -490,7 +472,7 @@ namespace ValveResourceFormat.ResourceTypes
                 using var animGroup = fileLoader.LoadFileCompiled(animGroupPath);
                 if (animGroup != default)
                 {
-                    animations.AddRange(AnimationGroupLoader.LoadAnimationGroup(animGroup, fileLoader, Skeleton, FlexControllers));
+                    animations.AddRange(AnimationGroupLoader.LoadAnimationGroup(animGroup, fileLoader));
                 }
             }
 
@@ -543,6 +525,7 @@ namespace ValveResourceFormat.ResourceTypes
                 var sequenceName = animation.Name.StartsWith('@') ? animation.Name[1..] : animation.Name;
 
                 sequenceAnimation.IsAdditive |= additiveSequences.Contains(sequenceName);
+                sequenceAnimation.EnsureBinding(Skeleton, FlexControllers);
             }
 
             CachedAnimations = animations;

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -99,7 +99,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// Gets the resource name of the skeleton this animation is authored on. A model's own
         /// skeleton is named after the vmdl it came from, so animations on it carry that name.
         /// </summary>
-        public string TargetSkeletonName { get; protected init; } = string.Empty;
+        public abstract string TargetSkeletonName { get; }
 
         /// <summary>
         /// The delta a decoded bone of an additive frame contributes, in the one convention everything

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationBinding.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationBinding.cs
@@ -1,0 +1,28 @@
+namespace ValveResourceFormat.ResourceTypes.ModelAnimation
+{
+    /// <summary>
+    /// Binds one ANIM block's segments to one target skeleton.
+    /// </summary>
+    /// <remarks>Cached and shared, so immutable.</remarks>
+    internal sealed class AnimationBinding
+    {
+        /// <summary>
+        /// Gets the skeleton this binding resolves onto. Decoding with a frame shaped for any other
+        /// skeleton is invalid.
+        /// </summary>
+        public Skeleton Skeleton { get; }
+
+        private readonly ElementRemap[][] segmentRemaps;
+
+        internal AnimationBinding(Skeleton skeleton, ElementRemap[][] segmentRemaps)
+        {
+            Skeleton = skeleton;
+            this.segmentRemaps = segmentRemaps;
+        }
+
+        /// <summary>
+        /// Gets the elements the given segment writes on this skeleton.
+        /// </summary>
+        internal ReadOnlySpan<ElementRemap> GetRemaps(int segmentIndex) => segmentRemaps[segmentIndex];
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationDataChannel.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationDataChannel.cs
@@ -5,28 +5,26 @@ using ValveResourceFormat.Serialization.KeyValues;
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 {
     /// <summary>
-    /// Represents a data channel in an animation, mapping bones or flex controllers to animation elements.
+    /// Represents a data channel in an animation, naming the bones or flex controllers it drives.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/animationsystem/CAnimDataChannelDesc">CAnimDataChannelDesc</seealso>
     public class AnimationDataChannel
     {
         /// <summary>
-        /// Gets the remap table that maps bone or flex controller IDs to element indices.
-        /// </summary>
-        public int[] RemapTable { get; }
-
-        /// <summary>
         /// Gets the attribute type of this channel.
         /// </summary>
         public AnimationChannelAttribute Attribute { get; }
 
+        private readonly string[] elementNameArray;
+        private readonly long[] elementIndexArray;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AnimationDataChannel"/> class.
         /// </summary>
-        public AnimationDataChannel(Skeleton skeleton, FlexController[] flexControllers, KVObject dataChannel)
+        public AnimationDataChannel(KVObject dataChannel)
         {
-            var elementNameArray = dataChannel.GetArray<string>("m_szElementNameArray");
-            var elementIndexArray = dataChannel.GetIntegerArray("m_nElementIndexArray");
+            elementNameArray = dataChannel.GetArray<string>("m_szElementNameArray");
+            elementIndexArray = dataChannel.GetIntegerArray("m_nElementIndexArray");
 
             var channelAttribute = dataChannel.GetStringProperty("m_szVariableName");
             Attribute = channelAttribute switch
@@ -37,7 +35,15 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 "data" => AnimationChannelAttribute.Data,
                 _ => AnimationChannelAttribute.Unknown,
             };
+        }
 
+        /// <summary>
+        /// Resolves this channel's element names against a target skeleton, producing a table that maps
+        /// each bone (or flex controller, for <see cref="AnimationChannelAttribute.Data"/> channels) to the
+        /// element index driving it, or -1 when this channel carries nothing for it.
+        /// </summary>
+        public int[] CreateRemapTable(Skeleton skeleton, FlexController[] flexControllers)
+        {
             int remapLength;
             if (Attribute == AnimationChannelAttribute.Data)
             {
@@ -72,7 +78,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 }
             }
 
-            RemapTable = remapTable;
+            return remapTable;
         }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationFrameCache.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationFrameCache.cs
@@ -134,6 +134,17 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         }
 
         /// <summary>
+        /// Resolves an animation onto this cache's skeleton ahead of decoding it.
+        /// </summary>
+        public void EnsureBinding(Animation anim)
+        {
+            if (anim is SequenceAnimation sequenceAnimation)
+            {
+                sequenceAnimation.EnsureBinding(Skeleton, FlexControllers);
+            }
+        }
+
+        /// <summary>
         /// Purges the frame cache, resetting both previous and next frames.
         /// </summary>
         public void PurgeCache()

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationSegmentDecoder.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationSegmentDecoder.cs
@@ -1,19 +1,24 @@
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 {
     /// <summary>
+    /// Maps one element of an animation segment onto the bone or flex controller it drives.
+    /// </summary>
+    public readonly record struct ElementRemap(int Source, int Dest);
+
+    /// <summary>
     /// Base class for animation segment decoders that read compressed animation data.
     /// </summary>
+    /// <remarks>
+    /// Decoders hold only the segment's own data and are independent of any target skeleton. Which bones
+    /// or flex controllers a segment writes to arrives per call, from an <see cref="AnimationBinding"/>.
+    /// </remarks>
     public abstract class AnimationSegmentDecoder
     {
         /// <summary>
         /// Gets the raw animation data segment.
         /// </summary>
-        protected ArraySegment<byte> Data { get; private set; }
-
-        /// <summary>
-        /// Gets the array of element indices to decode.
-        /// </summary>
-        protected int[] WantedElements { get; private set; } = [];
+        /// <remarks>References the kv3 blob, not a copy.</remarks>
+        protected ReadOnlyMemory<byte> Data { get; private set; }
 
         /// <summary>
         /// Gets the total number of elements in the segment.
@@ -21,32 +26,18 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         protected int ElementCount { get; private set; }
 
         /// <summary>
-        /// Gets the remap table for mapping elements to bones or flex controllers.
-        /// </summary>
-        public int[] RemapTable { get; private set; } = [];
-
-        /// <summary>
         /// Gets the channel attribute type.
         /// </summary>
         public AnimationChannelAttribute ChannelAttribute { get; private set; }
 
         /// <summary>
-        /// Initializes the decoder with data and mapping information.
+        /// Initializes the decoder with its segment data.
         /// </summary>
-        public void Initialize(ArraySegment<byte> data, int[] wantedElements, int[] remapTable, AnimationChannelAttribute channelAttribute,
-            int elementCount = 1)
+        public void Initialize(ReadOnlyMemory<byte> data, AnimationChannelAttribute channelAttribute, int elementCount = 1)
         {
             Data = data;
-            WantedElements = wantedElements;
             ElementCount = elementCount;
-
-            RemapTable = remapTable;
             ChannelAttribute = channelAttribute;
-
-            if (RemapTable.Length != WantedElements.Length)
-            {
-                throw new ArgumentException("RemapTable and WantedElements must be the same length");
-            }
         }
 
         /// <summary>
@@ -54,6 +45,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// </summary>
         /// <param name="frameIndex">The index of the frame to read.</param>
         /// <param name="outFrame">The frame object to populate with decoded data.</param>
-        public abstract void Read(int frameIndex, Frame outFrame);
+        /// <param name="remaps">The elements to write, and the bone or flex controller each one drives.</param>
+        public abstract void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps);
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationSegmentSource.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationSegmentSource.cs
@@ -1,0 +1,279 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+using ValveKeyValue;
+using ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders;
+using ValveResourceFormat.ResourceTypes.ModelFlex;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.ResourceTypes.ModelAnimation
+{
+    /// <summary>
+    /// Owns the decoders for one ANIM block, and the per-skeleton bindings onto them. Every
+    /// <see cref="SequenceAnimation"/> in the block shares a single instance.
+    /// </summary>
+    internal sealed class AnimationSegmentSource
+    {
+        /// <summary>
+        /// One segment's decoder, and which remap group it draws its bone mapping from.
+        /// Contains no reference to any target skeleton.
+        /// </summary>
+        internal readonly struct Segment
+        {
+            /// <summary>The decoder, or <see langword="null"/> for an unsupported or unknown segment.</summary>
+            public AnimationSegmentDecoder? Decoder { get; init; }
+
+            /// <summary>Index into the block's remap groups, or -1 when <see cref="Decoder"/> is null.</summary>
+            public int GroupIndex { get; init; }
+        }
+
+        /// <summary>
+        /// A distinct (channel, element list) pair. Frame blocks of the same channel repeat the same
+        /// element list, so many segments share one group and therefore one resolved remap.
+        /// </summary>
+        private readonly struct RemapGroup
+        {
+            public int ChannelIndex { get; init; }
+            public ReadOnlyMemory<byte> Elements { get; init; }
+        }
+
+        private readonly KVObject animationData;
+        private readonly KVObject decodeKey;
+
+        private AnimationDataChannel[]? channels;
+        private RemapGroup[]? groups;
+        private Segment[]? segments;
+
+        // Keyed by skeleton reference: Skeleton does not override equality, and a model exposes a single
+        // instance, so reference identity is the intended key.
+        private readonly Dictionary<Skeleton, AnimationBinding> bindings = [];
+
+        /// <summary>
+        /// Gets the block's segments, building them on first access.
+        /// </summary>
+        public Segment[] Segments
+        {
+            get
+            {
+                EnsureSegments();
+                return segments!;
+            }
+        }
+
+        public AnimationSegmentSource(KVObject animationData, KVObject decodeKey)
+        {
+            this.animationData = animationData;
+            this.decodeKey = decodeKey;
+        }
+
+        /// <summary>
+        /// Gets the binding of this block's segments onto the given skeleton, building it on first request.
+        /// </summary>
+        public AnimationBinding GetBinding(Skeleton skeleton, FlexController[] flexControllers)
+        {
+            EnsureSegments();
+
+            if (!bindings.TryGetValue(skeleton, out var binding))
+            {
+                binding = BuildBinding(skeleton, flexControllers);
+                bindings[skeleton] = binding;
+            }
+
+            return binding;
+        }
+
+        private void EnsureSegments()
+        {
+            if (segments != null)
+            {
+                return;
+            }
+
+            var dataChannelArrayKV = decodeKey.GetArray("m_dataChannelArray");
+            var builtChannels = new AnimationDataChannel[dataChannelArrayKV.Count];
+            for (var i = 0; i < dataChannelArrayKV.Count; i++)
+            {
+                builtChannels[i] = new AnimationDataChannel(dataChannelArrayKV[i]);
+            }
+
+            var builtGroups = new List<RemapGroup>();
+            var builtSegments = BuildSegments(builtChannels, builtGroups);
+
+            channels = builtChannels;
+            groups = [.. builtGroups];
+            segments = builtSegments;
+        }
+
+        private Segment[] BuildSegments(AnimationDataChannel[] dataChannelArray, List<RemapGroup> groupList)
+        {
+            var decoderArrayKV = animationData.GetArray("m_decoderArray");
+            var decoderArray = new string[decoderArrayKV.Count];
+            for (var i = 0; i < decoderArrayKV.Count; i++)
+            {
+                decoderArray[i] = decoderArrayKV[i].GetStringProperty("m_szName");
+            }
+
+            var segmentArrayKV = animationData.GetArray("m_segmentArray");
+            var segmentArray = new Segment[segmentArrayKV.Count];
+            for (var i = 0; i < segmentArrayKV.Count; i++)
+            {
+                segmentArray[i] = new Segment { GroupIndex = -1 };
+
+                var segmentKV = segmentArrayKV[i];
+                var container = segmentKV.GetArray<byte>("m_container");
+                var containerSpan = container.AsSpan();
+                var localChannelIndex = segmentKV.GetInt32Property("m_nLocalChannel");
+                var localChannel = dataChannelArray[localChannelIndex];
+
+                // Read header
+                var decoder = decoderArray[BitConverter.ToInt16(containerSpan[0..2])];
+                //var cardinality = BitConverter.ToInt16(containerSpan[2..4]);
+                var numElements = BitConverter.ToInt16(containerSpan[4..6]);
+                //var totalLength = BitConverter.ToInt16(containerSpan[6..8]);
+
+                if (localChannel.Attribute == AnimationChannelAttribute.Unknown)
+                {
+                    Console.Error.WriteLine($"Unknown channel attribute encountered with '{decoder}' decoder");
+                    continue;
+                }
+
+                // Look at the decoder to see what to read
+                AnimationSegmentDecoder? segment = decoder switch
+                {
+                    nameof(CCompressedStaticFullVector3) => new CCompressedStaticFullVector3(),
+                    nameof(CCompressedStaticVector3) => new CCompressedStaticVector3(),
+                    nameof(CCompressedStaticQuaternion) => new CCompressedStaticQuaternion(),
+                    nameof(CCompressedStaticFloat) => new CCompressedStaticFloat(),
+
+                    nameof(CCompressedFullVector3) => new CCompressedFullVector3(),
+                    nameof(CCompressedDeltaVector3) => new CCompressedDeltaVector3(),
+                    nameof(CCompressedAnimVector3) => new CCompressedAnimVector3(),
+                    nameof(CCompressedAnimQuaternion) => new CCompressedAnimQuaternion(),
+                    nameof(CCompressedFullQuaternion) => new CCompressedFullQuaternion(),
+                    nameof(CCompressedFullFloat) => new CCompressedFullFloat(),
+                    _ => null,
+                };
+
+                if (segment == null)
+                {
+#if DEBUG
+                    Console.WriteLine($"Unhandled animation bone decoder type '{decoder}' for attribute '{localChannel.Attribute}'");
+#endif
+                    continue;
+                }
+
+                // Read bone list
+                var end = 8 + numElements * 2;
+                segment.Initialize(container.AsMemory(end), localChannel.Attribute, numElements);
+
+                segmentArray[i] = new Segment
+                {
+                    Decoder = segment,
+                    GroupIndex = FindOrAddGroup(groupList, localChannelIndex, container.AsMemory(8, end - 8)),
+                };
+            }
+
+            return segmentArray;
+        }
+
+        /// <summary>
+        /// Finds the group matching this channel and element list, adding it when new.
+        /// </summary>
+        /// <remarks>
+        /// The search is linear: a block's distinct groups number in the single digits to low tens even
+        /// when it holds hundreds of segments, which is small enough that hashing costs more than it saves.
+        /// </remarks>
+        private static int FindOrAddGroup(List<RemapGroup> groupList, int channelIndex, ReadOnlyMemory<byte> elements)
+        {
+            for (var i = 0; i < groupList.Count; i++)
+            {
+                var group = groupList[i];
+
+                if (group.ChannelIndex == channelIndex && group.Elements.Span.SequenceEqual(elements.Span))
+                {
+                    return i;
+                }
+            }
+
+            groupList.Add(new RemapGroup { ChannelIndex = channelIndex, Elements = elements });
+            return groupList.Count - 1;
+        }
+
+        private AnimationBinding BuildBinding(Skeleton skeleton, FlexController[] flexControllers)
+        {
+            var channelRemapTables = new int[channels!.Length][];
+
+            var groupRemaps = new ElementRemap[groups!.Length][];
+            for (var i = 0; i < groups.Length; i++)
+            {
+                var group = groups[i];
+
+                var channelRemapTable = channelRemapTables[group.ChannelIndex]
+                    ??= channels[group.ChannelIndex].CreateRemapTable(skeleton, flexControllers);
+
+                groupRemaps[i] = BuildRemap(MemoryMarshal.Cast<byte, short>(group.Elements.Span), channelRemapTable);
+            }
+
+            var segmentRemaps = new ElementRemap[segments!.Length][];
+            for (var i = 0; i < segments.Length; i++)
+            {
+                var groupIndex = segments[i].GroupIndex;
+                segmentRemaps[i] = groupIndex == -1 ? [] : groupRemaps[groupIndex];
+            }
+
+            return new AnimationBinding(skeleton, segmentRemaps);
+        }
+
+        /// <summary>
+        /// Inverts a group's element list against a channel's remap table, producing one entry
+        /// per bone or flex controller that its segments actually carry data for.
+        /// </summary>
+        private static ElementRemap[] BuildRemap(ReadOnlySpan<short> elements, int[] channelRemapTable)
+        {
+            var length = channelRemapTable.Length;
+            int[]? rented = null;
+
+            const int MaxStackElements = 512;
+
+            var scratch = length <= MaxStackElements
+                ? stackalloc int[MaxStackElements]
+                : (rented = ArrayPool<int>.Shared.Rent(length)).AsSpan();
+
+            try
+            {
+                var positions = scratch[..length];
+                var wanted = 0;
+
+                for (var i = 0; i < length; i++)
+                {
+                    var position = elements.IndexOf((short)channelRemapTable[i]);
+                    positions[i] = position;
+
+                    if (position != -1)
+                    {
+                        wanted++;
+                    }
+                }
+
+                var remaps = new ElementRemap[wanted];
+                var next = 0;
+
+                for (var i = 0; i < length; i++)
+                {
+                    if (positions[i] != -1)
+                    {
+                        remaps[next++] = new ElementRemap(positions[i], i);
+                    }
+                }
+
+                return remaps;
+            }
+            finally
+            {
+                if (rented != null)
+                {
+                    ArrayPool<int>.Shared.Return(rented);
+                }
+            }
+        }
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/ClipAnimation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/ClipAnimation.cs
@@ -22,7 +22,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             // NumFrames samples span Duration, so the frame rate counts the intervals between them.
             Fps = clip.Duration > 0 && clip.NumFrames > 1 ? (clip.NumFrames - 1) / clip.Duration : 1;
             IsAdditive = clip.IsAdditive;
-            TargetSkeletonName = clip.SkeletonName;
 
             Clip = clip;
         }
@@ -38,6 +37,9 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// Consumers filter for the event types they are interested in (e.g. <see cref="NmSoundEvent"/>).
         /// </summary>
         public NmClipEvent[] Events => Clip.Events;
+
+        /// <inheritdoc/>
+        public override string TargetSkeletonName => Clip.SkeletonName;
 
         /// <summary>
         /// A decoded clip bone is already the delta: clips store one for every bone, un-animated ones

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
@@ -28,10 +28,22 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public AnimationMovement.MovementData Movement { get; set; }
 
         /// <summary>
+        /// Gets the skeleton this frame is shaped for.
+        /// </summary>
+        public Skeleton Skeleton { get; }
+
+        /// <summary>
+        /// Gets the flex controllers this frame is shaped for.
+        /// </summary>
+        public FlexController[] FlexControllers { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Frame"/> class.
         /// </summary>
         public Frame(Skeleton skeleton, FlexController[] flexControllers)
         {
+            Skeleton = skeleton;
+            FlexControllers = flexControllers;
             Bones = new FrameBone[skeleton.Bones.Length];
             Datas = new float[flexControllers.Length];
             Clear(skeleton);

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedAnimQuaternion.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedAnimQuaternion.cs
@@ -9,19 +9,18 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads compressed quaternion data and decompresses it into the output frame.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
             var offset = frameIndex * ElementCount;
+            var data = Data.Span;
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                var elementIndex = WantedElements[i];
-
                 outFrame.SetAttribute(
-                    RemapTable[i],
+                    remap.Dest,
                     ChannelAttribute,
-                    SegmentHelpers.ReadQuaternion(Data.AsSpan(
-                        (offset + elementIndex) * SegmentHelpers.CompressedQuaternionSize,
+                    SegmentHelpers.ReadQuaternion(data.Slice(
+                        (offset + remap.Source) * SegmentHelpers.CompressedQuaternionSize,
                         SegmentHelpers.CompressedQuaternionSize
                     ))
                 );

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedAnimVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedAnimVector3.cs
@@ -11,19 +11,17 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads half-precision Vector3 data and converts it to full precision for the output frame.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
             var offset = frameIndex * ElementCount;
-            var halfVectorData = MemoryMarshal.Cast<byte, Half3>(Data);
+            var halfVectorData = MemoryMarshal.Cast<byte, Half3>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                var elementIndex = WantedElements[i];
-
                 outFrame.SetAttribute(
-                    RemapTable[i],
+                    remap.Dest,
                     ChannelAttribute,
-                    halfVectorData[offset + elementIndex]
+                    halfVectorData[offset + remap.Source]
                 );
             }
         }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedDeltaVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedDeltaVector3.cs
@@ -11,24 +11,23 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads a base Vector3 and adds a half-precision delta to produce the final value.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
             var offset = frameIndex * ElementCount;
 
             const int BaseElementSize = sizeof(float) * 3; // sizeof(Vector3)
-            var baseData = MemoryMarshal.Cast<byte, Vector3>(Data.AsSpan(0, ElementCount * BaseElementSize));
-            var deltaData = MemoryMarshal.Cast<byte, Half3>(Data.AsSpan(ElementCount * BaseElementSize));
+            var data = Data.Span;
+            var baseData = MemoryMarshal.Cast<byte, Vector3>(data.Slice(0, ElementCount * BaseElementSize));
+            var deltaData = MemoryMarshal.Cast<byte, Half3>(data.Slice(ElementCount * BaseElementSize));
             //var numFrames = deltaData.Length / ElementCount;
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                var elementIndex = WantedElements[i];
-
-                var baseVector = baseData[elementIndex];
-                var deltaVector = deltaData[offset + elementIndex];
+                var baseVector = baseData[remap.Source];
+                var deltaVector = deltaData[offset + remap.Source];
 
                 outFrame.SetAttribute(
-                    RemapTable[i],
+                    remap.Dest,
                     ChannelAttribute,
                     baseVector + deltaVector
                 );

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullFloat.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullFloat.cs
@@ -11,14 +11,14 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads full-precision float data directly from the data buffer.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
             var offset = frameIndex * ElementCount;
-            var floatData = MemoryMarshal.Cast<byte, float>(Data);
+            var floatData = MemoryMarshal.Cast<byte, float>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, floatData[offset + WantedElements[i]]);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, floatData[offset + remap.Source]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullQuaternion.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullQuaternion.cs
@@ -11,14 +11,14 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads full-precision quaternion data directly from the data buffer.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
             var offset = frameIndex * ElementCount;
-            var quaternionData = MemoryMarshal.Cast<byte, Quaternion>(Data);
+            var quaternionData = MemoryMarshal.Cast<byte, Quaternion>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, quaternionData[offset + WantedElements[i]]);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, quaternionData[offset + remap.Source]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullVector3.cs
@@ -11,14 +11,14 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads full-precision Vector3 data directly from the data buffer.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
             var offset = frameIndex * ElementCount;
-            var vectorData = MemoryMarshal.Cast<byte, Vector3>(Data);
+            var vectorData = MemoryMarshal.Cast<byte, Vector3>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, vectorData[offset + WantedElements[i]]);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, vectorData[offset + remap.Source]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFloat.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFloat.cs
@@ -11,13 +11,13 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads static float values that remain constant across all frames.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
-            var floatData = MemoryMarshal.Cast<byte, float>(Data);
+            var floatData = MemoryMarshal.Cast<byte, float>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, floatData[WantedElements[i]]);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, floatData[remap.Source]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFullVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFullVector3.cs
@@ -11,13 +11,13 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads static Vector3 values that remain constant across all frames.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
-            var vectorData = MemoryMarshal.Cast<byte, Vector3>(Data);
+            var vectorData = MemoryMarshal.Cast<byte, Vector3>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, vectorData[WantedElements[i]]);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, vectorData[remap.Source]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticQuaternion.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticQuaternion.cs
@@ -9,18 +9,20 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads static compressed quaternion values that remain constant across all frames.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
-            for (var i = 0; i < RemapTable.Length; i++)
+            var data = Data.Span;
+
+            foreach (var remap in remaps)
             {
-                var compressedQuaternionBytes = Data.Slice(
-                    WantedElements[i] * SegmentHelpers.CompressedQuaternionSize,
+                var compressedQuaternionBytes = data.Slice(
+                    remap.Source * SegmentHelpers.CompressedQuaternionSize,
                     SegmentHelpers.CompressedQuaternionSize
                 );
 
                 var quaternion = SegmentHelpers.ReadQuaternion(compressedQuaternionBytes);
 
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, quaternion);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, quaternion);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticVector3.cs
@@ -11,13 +11,13 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         /// <remarks>
         /// Reads static half-precision Vector3 values that remain constant across all frames.
         /// </remarks>
-        public override void Read(int frameIndex, Frame outFrame)
+        public override void Read(int frameIndex, Frame outFrame, ReadOnlySpan<ElementRemap> remaps)
         {
-            var halfVectorData = MemoryMarshal.Cast<byte, Half3>(Data);
+            var halfVectorData = MemoryMarshal.Cast<byte, Half3>(Data.Span);
 
-            for (var i = 0; i < RemapTable.Length; i++)
+            foreach (var remap in remaps)
             {
-                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, halfVectorData[WantedElements[i]]);
+                outFrame.SetAttribute(remap.Dest, ChannelAttribute, halfVectorData[remap.Source]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SequenceAnimation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SequenceAnimation.cs
@@ -1,7 +1,5 @@
 using System.Linq;
-using System.Runtime.InteropServices;
 using ValveKeyValue;
-using ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders;
 using ValveResourceFormat.ResourceTypes.ModelFlex;
 using ValveResourceFormat.Serialization.KeyValues;
 
@@ -49,13 +47,20 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public bool Autoplay { get; init; }
 
         private AnimationFrameBlock[] FrameBlocks { get; } = [];
-        private AnimationSegmentDecoder?[] SegmentArray { get; } = [];
+        private readonly AnimationSegmentSource segmentSource;
 
         private bool? hasFlexData;
 
         /// <inheritdoc/>
         public override bool HasFlexData => hasFlexData ??=
-            Array.Exists(SegmentArray, segment => segment?.ChannelAttribute == AnimationChannelAttribute.Data);
+            Array.Exists(segmentSource.Segments, segment => segment.Decoder?.ChannelAttribute == AnimationChannelAttribute.Data);
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// The skeleton this animation was last bound to, so it is empty until it has been bound or
+        /// decoded once.
+        /// </remarks>
+        public override string TargetSkeletonName => skeletonBinding?.Skeleton.Name ?? string.Empty;
 
         /// <summary>
         /// Gets the movement data for this animation.
@@ -101,12 +106,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         private static AnimationLocalHierarchy[] GetLocalHierarchy(KVObject animDesc)
             => animDesc.GetArray("m_hierarchyArray")?.Select(static x => new AnimationLocalHierarchy(x)).ToArray() ?? [];
 
-        private SequenceAnimation(KVObject animDesc, AnimationSegmentDecoder?[] segmentArray)
+        private SequenceAnimation(KVObject animDesc, AnimationSegmentSource segmentSource)
         {
             // Get animation properties
             Name = animDesc.GetStringProperty("m_name");
             Fps = animDesc.GetFloatProperty("fps");
-            SegmentArray = segmentArray;
+            this.segmentSource = segmentSource;
 
             var flags = animDesc.GetSubCollection("m_flags");
             IsLooping = flags.GetBooleanProperty("m_bLooping");
@@ -152,7 +157,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// <summary>
         /// Constructor for creating animation from sequence descriptor (ASEQ) and animation data (ANIM).
         /// </summary>
-        private SequenceAnimation(KVObject seqDesc, KVObject animDesc, AnimationSegmentDecoder?[] segmentArray)
+        private SequenceAnimation(KVObject seqDesc, KVObject animDesc, AnimationSegmentSource segmentSource)
         {
             // Name and metadata from sequence descriptor
             Name = seqDesc.GetStringProperty("m_sName");
@@ -184,7 +189,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
             // Animation data from ANIM block
             Fps = animDesc.GetFloatProperty("fps");
-            SegmentArray = segmentArray;
+            this.segmentSource = segmentSource;
 
             var pData = animDesc.GetSubCollection("m_pData");
             FrameCount = pData.GetInt32Property("m_nFrames");
@@ -224,106 +229,9 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         }
 
         /// <summary>
-        /// Builds animation segment decoders from animation data and decode key.
-        /// </summary>
-        private static AnimationSegmentDecoder?[] BuildSegmentArray(
-            KVObject animationData,
-            KVObject decodeKey,
-            Skeleton skeleton,
-            FlexController[] flexControllers)
-        {
-            var decoderArrayKV = animationData.GetArray("m_decoderArray");
-            var decoderArray = new string[decoderArrayKV.Count];
-            for (var i = 0; i < decoderArrayKV.Count; i++)
-            {
-                decoderArray[i] = decoderArrayKV[i].GetStringProperty("m_szName");
-            }
-
-            //var channelElements = decodeKey.GetInt32Property("m_nChannelElements");
-            var dataChannelArrayKV = decodeKey.GetArray("m_dataChannelArray");
-            var dataChannelArray = new AnimationDataChannel[dataChannelArrayKV.Count];
-            for (var i = 0; i < dataChannelArrayKV.Count; i++)
-            {
-                dataChannelArray[i] = new AnimationDataChannel(skeleton, flexControllers, dataChannelArrayKV[i]);
-            }
-
-            var segmentArrayKV = animationData.GetArray("m_segmentArray");
-            var segmentArray = new AnimationSegmentDecoder?[segmentArrayKV.Count];
-            for (var i = 0; i < segmentArrayKV.Count; i++)
-            {
-                var segmentKV = segmentArrayKV[i];
-                var container = segmentKV.GetArray<byte>("m_container");
-                var containerSpan = container.AsSpan();
-                var localChannel = dataChannelArray[segmentKV.GetInt32Property("m_nLocalChannel")];
-
-                // Read header
-                var decoder = decoderArray[BitConverter.ToInt16(containerSpan[0..2])];
-                //var cardinality = BitConverter.ToInt16(containerSpan[2..4]);
-                var numElements = BitConverter.ToInt16(containerSpan[4..6]);
-                //var totalLength = BitConverter.ToInt16(containerSpan[6..8]);
-
-                // Read bone list
-                var end = 8 + numElements * 2;
-                var elements = MemoryMarshal.Cast<byte, short>(containerSpan[8..end]);
-                var remapTable = new int[localChannel.RemapTable.Length];
-
-                for (var j = 0; j < remapTable.Length; j++)
-                {
-                    remapTable[j] = elements.IndexOf((short)localChannel.RemapTable[j]);
-                }
-
-                var wantedElements = remapTable.Where(boneID => boneID != -1).ToArray();
-                remapTable = remapTable
-                    .Select((boneID, i) => (boneID, i))
-                    .Where(t => t.boneID != -1)
-                    .Select(t => t.i)
-                    .ToArray();
-
-                if (localChannel.Attribute == AnimationChannelAttribute.Unknown)
-                {
-                    Console.Error.WriteLine($"Unknown channel attribute encountered with '{decoder}' decoder");
-                    continue;
-                }
-
-                var containerSegment = new ArraySegment<byte>(container, end, container.Length - end);
-
-                // Look at the decoder to see what to read
-                segmentArray[i] = decoder switch
-                {
-                    nameof(CCompressedStaticFullVector3) => new CCompressedStaticFullVector3(),
-                    nameof(CCompressedStaticVector3) => new CCompressedStaticVector3(),
-                    nameof(CCompressedStaticQuaternion) => new CCompressedStaticQuaternion(),
-                    nameof(CCompressedStaticFloat) => new CCompressedStaticFloat(),
-
-                    nameof(CCompressedFullVector3) => new CCompressedFullVector3(),
-                    nameof(CCompressedDeltaVector3) => new CCompressedDeltaVector3(),
-                    nameof(CCompressedAnimVector3) => new CCompressedAnimVector3(),
-                    nameof(CCompressedAnimQuaternion) => new CCompressedAnimQuaternion(),
-                    nameof(CCompressedFullQuaternion) => new CCompressedFullQuaternion(),
-                    nameof(CCompressedFullFloat) => new CCompressedFullFloat(),
-                    _ => null,
-                };
-
-                var segment = segmentArray[i];
-                if (segment != null)
-                {
-                    segment.Initialize(containerSegment, wantedElements, remapTable, localChannel.Attribute, numElements);
-                    continue;
-                }
-
-#if DEBUG
-                Console.WriteLine($"Unhandled animation bone decoder type '{decoder}' for attribute '{localChannel.Attribute}'");
-#endif
-            }
-
-            return segmentArray;
-        }
-
-        /// <summary>
         /// Creates animation instances from the provided animation data and decode key.
         /// </summary>
-        public static IEnumerable<SequenceAnimation> FromData(KVObject animationData, KVObject decodeKey,
-            Skeleton skeleton, FlexController[] flexControllers)
+        public static IEnumerable<SequenceAnimation> FromData(KVObject animationData, KVObject decodeKey)
         {
             var animArray = animationData.GetArray("m_animArray");
 
@@ -332,10 +240,10 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 return [];
             }
 
-            var segmentArray = BuildSegmentArray(animationData, decodeKey, skeleton, flexControllers);
+            var segmentSource = new AnimationSegmentSource(animationData, decodeKey);
 
             return animArray
-                .Select(anim => new SequenceAnimation(anim, segmentArray) { TargetSkeletonName = skeleton.Name })
+                .Select(anim => new SequenceAnimation(anim, segmentSource))
                 .ToArray();
         }
 
@@ -347,9 +255,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public static IEnumerable<SequenceAnimation> FromSequenceData(
             KVObject sequenceData,
             KVObject animationData,
-            KVObject decodeKey,
-            Skeleton skeleton,
-            FlexController[] flexControllers)
+            KVObject decodeKey)
         {
             var animArray = animationData.GetArray("m_animArray");
 
@@ -358,8 +264,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 return [];
             }
 
-            // Build segment array from animation data
-            var segmentArray = BuildSegmentArray(animationData, decodeKey, skeleton, flexControllers);
+            var segmentSource = new AnimationSegmentSource(animationData, decodeKey);
             var sequenceNameArray = sequenceData.GetArray<string>("m_localSequenceNameArray");
 
             var animLookup = new Dictionary<string, KVObject>();
@@ -401,7 +306,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 var seqName = seqDesc.GetStringProperty("m_sName");
                 processedAnimNames.Add(seqName);
 
-                animations.Add(new SequenceAnimation(seqDesc, animDesc, segmentArray) { TargetSkeletonName = skeleton.Name });
+                animations.Add(new SequenceAnimation(seqDesc, animDesc, segmentSource));
             }
 
             // Add remaining animations not already output as sequences
@@ -414,7 +319,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                     continue;
                 }
 
-                animations.Add(new SequenceAnimation(anim, segmentArray) { TargetSkeletonName = skeleton.Name });
+                animations.Add(new SequenceAnimation(anim, segmentSource));
             }
 
             return animations;
@@ -423,8 +328,8 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// <summary>
         /// Creates animation instances from a resource file.
         /// </summary>
-        public static IEnumerable<SequenceAnimation> FromResource(Resource resource, KVObject decodeKey, Skeleton skeleton, FlexController[] flexControllers)
-            => FromData(GetAnimationData(resource), decodeKey, skeleton, flexControllers);
+        public static IEnumerable<SequenceAnimation> FromResource(Resource resource, KVObject decodeKey)
+            => FromData(GetAnimationData(resource), decodeKey);
 
         private static KVObject GetAnimationData(Resource resource)
             => (resource.DataBlock ?? throw new InvalidOperationException("Resource has no data block.")).AsKeyValueCollection();
@@ -513,6 +418,17 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             t = Math.Min(1f, elapsedTime / movementDuration);
         }
 
+        private AnimationBinding? skeletonBinding;
+
+        /// <summary>
+        /// Builds this animation's decoders and its mapping onto the given skeleton, so that a following
+        /// <see cref="DecodeFrame(Frame)"/> for that skeleton does no setup work.
+        /// </summary>
+        internal void EnsureBinding(Skeleton skeleton, FlexController[] flexControllers)
+        {
+            skeletonBinding = segmentSource.GetBinding(skeleton, flexControllers);
+        }
+
         private enum AnimatedChannels : byte
         {
             None = 0,
@@ -522,12 +438,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
         /// <summary>
         /// Sequences decode into a bind-pose frame and only write the channels they animate (see
-        /// <see cref="BuildAnimatedChannels"/>), so a channel the animation leaves alone holds the bind
+        /// <see cref="GetAnimatedChannels"/>), so a channel the animation leaves alone holds the bind
         /// pose rather than a delta, and has to be neutralized before it is composed onto a pose.
         /// </summary>
         public override FrameBone GetAdditiveDelta(int boneIndex, FrameBone bone)
         {
-            var animated = animatedChannelsCache ??= BuildAnimatedChannels();
+            var animated = GetAnimatedChannels();
             var channels = boneIndex < animated.Length ? animated[boneIndex] : AnimatedChannels.None;
 
             var position = (channels & AnimatedChannels.Position) != 0 ? bone.Position : Vector3.Zero;
@@ -538,35 +454,34 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             return new FrameBone(position, bone.Scale - 1f, angle);
         }
 
+        private AnimationBinding? animatedChannelsBinding;
         private AnimatedChannels[]? animatedChannelsCache;
 
         /// <summary>
-        /// Returns, per bone, which transform channels this animation actually writes, derived from
-        /// the segment decoders' bone targets and channel attributes. Bones past the end of it are
-        /// animated by nothing.
+        /// Returns, per bone, which transform channels this animation writes on the skeleton it is bound
+        /// to: the binding already resolved which element of each segment drives which bone, so this is
+        /// that grouped by channel attribute. Empty until the animation has been bound.
         /// </summary>
-        private AnimatedChannels[] BuildAnimatedChannels()
+        private AnimatedChannels[] GetAnimatedChannels()
         {
-            var boneCount = 0;
+            var binding = skeletonBinding;
 
-            foreach (var segment in SegmentArray)
+            if (binding == null)
             {
-                foreach (var boneIndex in segment?.RemapTable ?? [])
-                {
-                    boneCount = Math.Max(boneCount, boneIndex + 1);
-                }
+                return [];
             }
 
-            var animated = new AnimatedChannels[boneCount];
-
-            foreach (var segment in SegmentArray)
+            if (animatedChannelsBinding == binding)
             {
-                if (segment is null)
-                {
-                    continue;
-                }
+                return animatedChannelsCache!;
+            }
 
-                var channel = segment.ChannelAttribute switch
+            var segments = segmentSource.Segments;
+            var animated = new AnimatedChannels[binding.Skeleton.Bones.Length];
+
+            for (var i = 0; i < segments.Length; i++)
+            {
+                var channel = segments[i].Decoder?.ChannelAttribute switch
                 {
                     AnimationChannelAttribute.Position => AnimatedChannels.Position,
                     AnimationChannelAttribute.Angle => AnimatedChannels.Angle,
@@ -578,21 +493,37 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                     continue;
                 }
 
-                foreach (var boneIndex in segment.RemapTable)
+                // Only bone channels get this far, so every remap lands on a bone.
+                foreach (var remap in binding.GetRemaps(i))
                 {
-                    if (boneIndex >= 0)
-                    {
-                        animated[boneIndex] |= channel;
-                    }
+                    animated[remap.Dest] |= channel;
                 }
             }
 
+            animatedChannelsCache = animated;
+            animatedChannelsBinding = binding;
             return animated;
         }
 
         /// <inheritdoc/>
+        /// <remarks>The binding for the frame's skeleton is resolved here, and remembered for the next call.</remarks>
         public override void DecodeFrame(Frame outFrame)
         {
+            var binding = skeletonBinding;
+
+            if (binding == null || binding.Skeleton != outFrame.Skeleton)
+            {
+                binding = segmentSource.GetBinding(outFrame.Skeleton, outFrame.FlexControllers);
+                skeletonBinding = binding;
+            }
+
+            DecodeFrame(outFrame, binding);
+        }
+
+        private void DecodeFrame(Frame outFrame, AnimationBinding binding)
+        {
+            var segmentArray = segmentSource.Segments;
+
             // Read all frame blocks
             foreach (var frameBlock in FrameBlocks)
             {
@@ -601,9 +532,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 {
                     foreach (var segmentIndex in frameBlock.SegmentIndexArray)
                     {
-                        var segment = SegmentArray[segmentIndex];
-                        // Segment could be null for unknown decoders
-                        segment?.Read(outFrame.FrameIndex - frameBlock.StartFrame, outFrame);
+                        // Decoder could be null for unknown decoders
+                        var decoder = segmentArray[segmentIndex].Decoder;
+                        decoder?.Read(
+                            outFrame.FrameIndex - frameBlock.StartFrame,
+                            outFrame,
+                            binding.GetRemaps((int)segmentIndex));
                     }
                 }
             }


### PR DESCRIPTION
Lazy, skeleton-invariant animation decoding

Segment decoders were built eagerly at model load with the target skeleton's bone indices baked in.

Now we defer the build on first playback/DecodeFrame. This also lets us play an Animation resource on various models without going through the GetEmbeddedAnimationsWithSkeleton hack.

`Model.GetEmbeddedAnimationsWithSkeleton` and its cachedSkeleton swap deleted; the animation factories and LoadAnimationGroup no longer take Skeleton/FlexController[].

Two latent bugs gone: GetEmbeddedAnimationsWithSkeleton swapped cachedSkeleton then called GetAllAnimations, which short-circuits on CachedAnimations — so by load order it either ignored the swap or permanently cached another model's skeleton bindings.