### PR TITLE
Renderer library: add api for mounting custom shader folders

### DIFF
--- a/GUI/Types/GLViewers/GLTextureDecoder.cs
+++ b/GUI/Types/GLViewers/GLTextureDecoder.cs
@@ -217,7 +217,7 @@ public class GLTextureDecoder : IHardwareTextureDecoder, IDisposable
         GL.Disable(EnableCap.DepthTest);
 
         var textureType = GetTextureTypeDefine(inputTexture.Target);
-        var shader = RendererContext.ShaderLoader.LoadShader("vrf.texture_decode", (textureType, 1));
+        var shader = RendererContext.ShaderLoader.LoadShader("texture_decode", (textureType, 1));
 
         shader.Use();
 

--- a/GUI/Types/GLViewers/GLTextureViewer.cs
+++ b/GUI/Types/GLViewers/GLTextureViewer.cs
@@ -1162,7 +1162,7 @@ namespace GUI.Types.GLViewers
                 return;
             }
 
-            shader = RendererContext.ShaderLoader.LoadShader("vrf.texture_decode", (textureType, 1));
+            shader = RendererContext.ShaderLoader.LoadShader("texture_decode", (textureType, 1));
         }
 
         private void UploadTexture(bool forceSoftwareDecode)

--- a/GUI/Types/GLViewers/ShaderHotReload.cs
+++ b/GUI/Types/GLViewers/ShaderHotReload.cs
@@ -11,13 +11,35 @@ namespace GUI.Types.GLViewers;
 
 internal class ShaderHotReload : IDisposable
 {
-    private FileSystemWatcher? ShaderWatcher = new()
+    // The built-in shader folder, plus every directory mounted through ShaderRegistry
+    private List<FileSystemWatcher>? ShaderWatchers = CreateWatchers();
+
+    private static List<FileSystemWatcher> CreateWatchers()
     {
-        Path = ShaderParser.GetShaderDiskPath(string.Empty),
-        NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
-        IncludeSubdirectories = true,
-        EnableRaisingEvents = true,
-    };
+        var watchers = new List<FileSystemWatcher>(1 + ShaderRegistry.Directories.Length);
+        var paths = new List<string>(watchers.Capacity);
+        paths.AddRange(ShaderRegistry.Directories);
+
+        // Only present when this assembly was built from the shader source files, rather than using the embedded copies
+        if (ShaderParser.ShaderSourceDirectory != null)
+        {
+            paths.Add(ShaderParser.ShaderSourceDirectory);
+        }
+
+        foreach (var path in paths)
+        {
+            watchers.Add(new FileSystemWatcher
+            {
+                Path = path,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+                IncludeSubdirectories = true,
+                EnableRaisingEvents = true,
+                Filters = { "*.slang" },
+            });
+        }
+
+        return watchers;
+    }
 
     private readonly TaskDialogPage errorReloadingPage = new()
     {
@@ -43,30 +65,35 @@ internal class ShaderHotReload : IDisposable
     {
         ViewerControl = viewerControl;
         ShaderLoader = shaderLoader;
-
-        ShaderWatcher.Filters.Add("*.slang");
     }
 
     public void SetSynchronizingObject(ISynchronizeInvoke synchronizingObject)
     {
-        Debug.Assert(ShaderWatcher is not null);
+        Debug.Assert(ShaderWatchers is not null);
 
-        ShaderWatcher.SynchronizingObject = synchronizingObject;
+        foreach (var watcher in ShaderWatchers)
+        {
+            watcher.SynchronizingObject = synchronizingObject;
 
-        ShaderWatcher.Changed += Hotload;
-        ShaderWatcher.Created += Hotload;
-        ShaderWatcher.Renamed += Hotload;
+            watcher.Changed += Hotload;
+            watcher.Created += Hotload;
+            watcher.Renamed += Hotload;
+        }
     }
 
     public void Dispose()
     {
-        if (ShaderWatcher != null)
+        if (ShaderWatchers != null)
         {
-            ShaderWatcher.Changed -= Hotload;
-            ShaderWatcher.Created -= Hotload;
-            ShaderWatcher.Renamed -= Hotload;
-            ShaderWatcher.Dispose();
-            ShaderWatcher = null;
+            foreach (var watcher in ShaderWatchers)
+            {
+                watcher.Changed -= Hotload;
+                watcher.Created -= Hotload;
+                watcher.Renamed -= Hotload;
+                watcher.Dispose();
+            }
+
+            ShaderWatchers = null;
 
             reloadSemaphore.Dispose();
         }

--- a/Renderer/ParticleRenderer/Renderers/RenderCables.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderCables.cs
@@ -15,7 +15,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderCables">C_OP_RenderCables</seealso>
     internal class RenderCables : ParticleFunctionRenderer
     {
-        private const string ShaderName = "vrf.particle_cable";
+        private const string ShaderName = "particle_cable";
 
         private Shader shader;
         private readonly Scene scene;

--- a/Renderer/ParticleRenderer/Renderers/RenderSprites.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderSprites.cs
@@ -15,7 +15,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderSprites">C_OP_RenderSprites</seealso>
     internal class RenderSprites : ParticleFunctionRenderer
     {
-        private const string ShaderName = "vrf.particle_sprite";
+        private const string ShaderName = "particle_sprite";
         // position 3, colour 4, uv 2, next-frame uv 2, frame blend 1
         private const int VertexSize = 12 + ((MaxTextureLayers - 1) * 4);
 

--- a/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
@@ -16,7 +16,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderTrails">C_OP_RenderTrails</seealso>
     internal class RenderTrails : ParticleFunctionRenderer
     {
-        private const string ShaderName = "vrf.particle_trail";
+        private const string ShaderName = "particle_trail";
         private const int VertexSize = 9;
 
         // The shared quad index buffer covers 65532 indices, six per quad

--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -273,13 +273,13 @@ public class Renderer
         BarnLightShadowBuffer.SetShadowDepthSamplerState(true);
         Textures.Add(new(ReservedTextureSlots.BarnLightShadowDepth, "g_tBarnLightShadowDepth", BarnLightShadowBuffer.Depth));
 
-        depthOnlyShaders[(int)DepthOnlyProgram.Static] = Scene.RendererContext.ShaderLoader.LoadShader("vrf.depth_only");
-        //depthOnlyShaders[(int)DepthOnlyProgram.StaticAlphaTest] = GuiContext.ShaderLoader.LoadShader("vrf.depth_only", ("F_ALPHA_TEST", 1));
-        depthOnlyShaders[(int)DepthOnlyProgram.Animated] = Scene.RendererContext.ShaderLoader.LoadShader("vrf.depth_only", ("D_ANIMATED", 1));
-        depthOnlyShaders[(int)DepthOnlyProgram.AnimatedEightBones] = Scene.RendererContext.ShaderLoader.LoadShader("vrf.depth_only", ("D_ANIMATED", 1), ("D_EIGHT_BONE_BLENDING", 1));
+        depthOnlyShaders[(int)DepthOnlyProgram.Static] = Scene.RendererContext.ShaderLoader.LoadShader("depth_only");
+        //depthOnlyShaders[(int)DepthOnlyProgram.StaticAlphaTest] = GuiContext.ShaderLoader.LoadShader("depth_only", ("F_ALPHA_TEST", 1));
+        depthOnlyShaders[(int)DepthOnlyProgram.Animated] = Scene.RendererContext.ShaderLoader.LoadShader("depth_only", ("D_ANIMATED", 1));
+        depthOnlyShaders[(int)DepthOnlyProgram.AnimatedEightBones] = Scene.RendererContext.ShaderLoader.LoadShader("depth_only", ("D_ANIMATED", 1), ("D_EIGHT_BONE_BLENDING", 1));
 
-        histogramShaders[0] = Scene.RendererContext.ShaderLoader.LoadShader("vrf.histogram");
-        histogramShaders[1] = Scene.RendererContext.ShaderLoader.LoadShader("vrf.histogram", ("D_HISTOGRAM_MODE", 1));
+        histogramShaders[0] = Scene.RendererContext.ShaderLoader.LoadShader("histogram");
+        histogramShaders[1] = Scene.RendererContext.ShaderLoader.LoadShader("histogram", ("D_HISTOGRAM_MODE", 1));
 
         histogramBuffers[0] = StorageBuffer.Allocate<uint>(ReservedBufferSlots.Histogram, 256, BufferUsageHint.DynamicDraw);
         histogramBuffers[1] = StorageBuffer.Allocate<uint>(ReservedBufferSlots.AverageLuminance, 4, BufferUsageHint.DynamicRead);

--- a/Renderer/Renderer.csproj
+++ b/Renderer/Renderer.csproj
@@ -31,6 +31,10 @@
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <AssemblyMetadata Include="ShaderSourceDirectory" Value="$(MSBuildProjectDirectory)\Shaders" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="NLayer" Version="2.0.1" />

--- a/Renderer/Renderer/InfiniteGrid.cs
+++ b/Renderer/Renderer/InfiniteGrid.cs
@@ -24,7 +24,7 @@ namespace ValveResourceFormat.Renderer
                 -1f, -1f,
             };
 
-            shader = scene.RendererContext.ShaderLoader.LoadShader("vrf.grid");
+            shader = scene.RendererContext.ShaderLoader.LoadShader("grid");
 
             // Create VAO
             GL.CreateVertexArrays(1, out vao);

--- a/Renderer/Renderer/LightBinner.cs
+++ b/Renderer/Renderer/LightBinner.cs
@@ -62,8 +62,8 @@ public sealed class LightBinner(Scene scene) : IDisposable
     /// <summary>Loads the two compute shaders. Call once the GL context exists.</summary>
     public void LoadShaders()
     {
-        TileCullBitsShader = scene.RendererContext.ShaderLoader.LoadShader("vrf.compute_tile_cullbits");
-        DepthBinCullBitsShader = scene.RendererContext.ShaderLoader.LoadShader("vrf.compute_depthbin_cullbits");
+        TileCullBitsShader = scene.RendererContext.ShaderLoader.LoadShader("compute_tile_cullbits");
+        DepthBinCullBitsShader = scene.RendererContext.ShaderLoader.LoadShader("compute_depthbin_cullbits");
     }
 
     /// <summary>

--- a/Renderer/Renderer/LightTilesOverlay.cs
+++ b/Renderer/Renderer/LightTilesOverlay.cs
@@ -68,7 +68,7 @@ public class LightTilesOverlay(RendererContext rendererContext)
             return;
         }
 
-        shader ??= rendererContext.ShaderLoader.LoadShader("vrf.light_tiles_overlay");
+        shader ??= rendererContext.ShaderLoader.LoadShader("light_tiles_overlay");
 
         Debug.Assert(shader != null);
 

--- a/Renderer/Renderer/LineBuffer.cs
+++ b/Renderer/Renderer/LineBuffer.cs
@@ -21,7 +21,7 @@ namespace ValveResourceFormat.Renderer
         /// <summary>Creates the GL objects and binds the default shader layout.</summary>
         public LineBuffer(RendererContext rendererContext, string label)
         {
-            Shader = rendererContext.ShaderLoader.LoadShader("vrf.default");
+            Shader = rendererContext.ShaderLoader.LoadShader("default");
 
             GL.CreateBuffers(1, out vboHandle);
 

--- a/Renderer/Renderer/Materials/MaterialLoader.cs
+++ b/Renderer/Renderer/Materials/MaterialLoader.cs
@@ -492,7 +492,7 @@ namespace ValveResourceFormat.Renderer.Materials
 
         private RenderMaterial GetErrorMaterial()
         {
-            var errorMat = new RenderMaterial(RendererContext.ShaderLoader.LoadShader("vrf.error"));
+            var errorMat = new RenderMaterial(RendererContext.ShaderLoader.LoadShader("error"));
             OwnedMaterials.Add(errorMat);
             return errorMat;
         }

--- a/Renderer/Renderer/Materials/RenderMaterial.cs
+++ b/Renderer/Renderer/Materials/RenderMaterial.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Microsoft.Extensions.Logging;
 using OpenTK.Graphics.OpenGL;
 using ValveResourceFormat.CompiledShader;
@@ -198,13 +199,13 @@ namespace ValveResourceFormat.Renderer.Materials
                 }
             }
 
-            if (material.ShaderName == "sky.vfx")
+            if (ShaderName == "sky.vfx")
             {
                 ShaderCollection? shader = null;
 
                 try
                 {
-                    shader = rendererContext.FileLoader.LoadShader(material.ShaderName);
+                    shader = rendererContext.FileLoader.LoadShader(ShaderName);
                 }
                 catch (UnexpectedMagicException e)
                 {
@@ -236,7 +237,7 @@ namespace ValveResourceFormat.Renderer.Materials
             }
 
             SetRenderState();
-            Shader = rendererContext.ShaderLoader.LoadShader(material.ShaderName, combinedShaderParameters, blocking: false);
+            Shader = rendererContext.ShaderLoader.LoadShader(ShaderName, combinedShaderParameters, blocking: false);
             ResetRenderState();
 
             SortId = GetSortId();
@@ -245,7 +246,7 @@ namespace ValveResourceFormat.Renderer.Materials
         /// <summary>Initializes a new instance of the <see cref="RenderMaterial"/> class wrapping an existing shader with an empty material.</summary>
         /// <param name="shader">The shader to use for rendering.</param>
         [SetsRequiredMembers]
-        public RenderMaterial(Shader shader) : this(new Material { Resource = null!, ShaderName = shader.Name })
+        public RenderMaterial(Shader shader) : this(new Material { Resource = null!, ShaderName = shader.Name }, normalizeShaderName: false)
         {
             Shader = shader;
             SortId = GetSortId();
@@ -264,9 +265,11 @@ namespace ValveResourceFormat.Renderer.Materials
             "csgo_effects.vfx",
         ];
 
-        RenderMaterial(Material material)
+        // Renderer shaders are wrapped by their own name, only material shader names are normalized
+        RenderMaterial(Material material, bool normalizeShaderName = true)
         {
             Material = material;
+            ShaderName = normalizeShaderName ? NormalizeShaderName(material.ShaderName) : material.ShaderName;
 
             IntParams.EnsureCapacity(material.IntParams.Count);
             FloatParams.EnsureCapacity(material.FloatParams.Count);
@@ -290,6 +293,15 @@ namespace ValveResourceFormat.Renderer.Materials
             LoadRenderState();
         }
 
+        /// <summary>Gets the shader name of the material, normalized to the <c>.vfx</c> extension the renderer resolves shaders by.</summary>
+        public string ShaderName { get; }
+
+        // Some games name their shaders .shader or .shader_c instead of .vfx
+        private static string NormalizeShaderName(string shaderName)
+        {
+            return string.Concat(Path.GetFileNameWithoutExtension(shaderName.AsSpan()), ShaderLoader.VfxExtension);
+        }
+
         /// <summary>
         /// Load or reload render state from material data.
         /// </summary>
@@ -301,7 +313,7 @@ namespace ValveResourceFormat.Renderer.Materials
             isRenderBackfaces = IntParams.GetValueOrDefault("F_RENDER_BACKFACES") == 1;
             disableDepthTest = IntParams.GetValueOrDefault("F_DISABLE_Z_BUFFERING") == 1;
 
-            if (material.ShaderName == "csgo_water_fancy.vfx")
+            if (ShaderName == "csgo_water_fancy.vfx")
             {
                 blendMode = BlendMode.Translucent;
                 DoNotCastShadows = true;
@@ -316,7 +328,7 @@ namespace ValveResourceFormat.Renderer.Materials
             hasDepthBias = IntParams.GetValueOrDefault("F_DEPTHBIAS") == 1 || IntParams.GetValueOrDefault("F_DEPTH_BIAS") == 1;
             IsOverlay = IntParams.GetValueOrDefault("F_OVERLAY") == 1;
 
-            if (material.ShaderName == "csgo_decalmodulate.vfx")
+            if (ShaderName == "csgo_decalmodulate.vfx")
             {
                 blendMode = BlendMode.Mod2x;
                 return;
@@ -328,7 +340,7 @@ namespace ValveResourceFormat.Renderer.Materials
             }
 
             if (IntParams.GetValueOrDefault("F_TRANSLUCENT") == 1
-            || TranslucentShaders.AsSpan().Contains(material.ShaderName)
+            || TranslucentShaders.AsSpan().Contains(ShaderName)
             || material.IntAttributes.ContainsKey("mapbuilder.water"))
             {
                 blendMode = BlendMode.Translucent;
@@ -340,19 +352,19 @@ namespace ValveResourceFormat.Renderer.Materials
             }
 
             // :MaterialIsOverlay
-            if (IsTranslucent && hasDepthBias && material.ShaderName is "csgo_vertexlitgeneric.vfx" or "csgo_complex.vfx")
+            if (IsTranslucent && hasDepthBias && ShaderName is "csgo_vertexlitgeneric.vfx" or "csgo_complex.vfx")
             {
                 IsOverlay = true;
             }
 
             var blendModeParam = 0;
-            if (material.ShaderName.EndsWith("static_overlay.vfx", StringComparison.Ordinal) || material.ShaderName is "citadel_overlay.vfx")
+            if (ShaderName.EndsWith("static_overlay.vfx", StringComparison.Ordinal) || ShaderName is "citadel_overlay.vfx")
             {
                 IsOverlay = true;
                 blendModeParam = (int)IntParams.GetValueOrDefault("F_BLEND_MODE");
             }
 
-            if (material.ShaderName == "csgo_unlitgeneric.vfx")
+            if (ShaderName == "csgo_unlitgeneric.vfx")
             {
                 blendModeParam = (int)IntParams.GetValueOrDefault("F_BLEND_MODE");
             }
@@ -454,7 +466,7 @@ namespace ValveResourceFormat.Renderer.Materials
             {
                 EvalDeadlockColorMatrices(shader, buffer);
             }
-            else if (Material.ShaderName.EndsWith("static_overlay.vfx", StringComparison.Ordinal))
+            else if (ShaderName.EndsWith("static_overlay.vfx", StringComparison.Ordinal))
             {
                 EvalStaticOverlayColorAdjust(shader, buffer);
             }

--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -222,7 +222,7 @@ namespace ValveResourceFormat.Renderer
                             uniforms.LPVIrradianceTexture = shader.GetUniformLocation("g_tLPV_Irradiance");
                         }
 
-                        if (shader.Name == "vrf.picking")
+                        if (shader.Name == "picking")
                         {
                             uniforms.MeshId = shader.GetUniformLocation("meshId");
                             uniforms.ShaderId = shader.GetUniformLocation("shaderId");

--- a/Renderer/Renderer/MorphComposite.cs
+++ b/Renderer/Renderer/MorphComposite.cs
@@ -48,7 +48,7 @@ namespace ValveResourceFormat.Renderer
         {
             ArgumentNullException.ThrowIfNull(morph.TextureResource);
             morphAtlas = renderContext.MaterialLoader.LoadTexture(morph.TextureResource);
-            shader = renderContext.ShaderLoader.LoadShader("vrf.morph_composite");
+            shader = renderContext.ShaderLoader.LoadShader("morph_composite");
 
             var width = morph.Data.GetInt32Property("m_nWidth");
             var height = morph.Data.GetInt32Property("m_nHeight");

--- a/Renderer/Renderer/OcclusionDebugRenderer.cs
+++ b/Renderer/Renderer/OcclusionDebugRenderer.cs
@@ -33,8 +33,8 @@ namespace ValveResourceFormat.Renderer
             this.scene = scene;
             renderContext = rendererContext;
 
-            shader = rendererContext.ShaderLoader.LoadShader("vrf.occlusion_debug");
-            finalizeShader = rendererContext.ShaderLoader.LoadShader("vrf.occlusion_debug_finalize");
+            shader = rendererContext.ShaderLoader.LoadShader("occlusion_debug");
+            finalizeShader = rendererContext.ShaderLoader.LoadShader("occlusion_debug_finalize");
         }
 
         /// <summary>Allocates (if needed) and clears the GPU buffer that receives occluded bounds from the culling shader.</summary>

--- a/Renderer/Renderer/PickingTexture.cs
+++ b/Renderer/Renderer/PickingTexture.cs
@@ -87,8 +87,8 @@ public class PickingTexture : Framebuffer
     public PickingTexture(RendererContext rendererContext, EventHandler<PickingResponse> onPicked) : base(nameof(PickingTexture))
     {
         RendererContext = rendererContext;
-        Shader = rendererContext.ShaderLoader.LoadShader("vrf.picking");
-        DebugShader = rendererContext.ShaderLoader.LoadShader("vrf.picking", ("F_DEBUG_PICKER", 1));
+        Shader = rendererContext.ShaderLoader.LoadShader("picking");
+        DebugShader = rendererContext.ShaderLoader.LoadShader("picking", ("F_DEBUG_PICKER", 1));
         OnPicked += onPicked;
 
         ColorFormat = new(PixelInternalFormat.Rgba32ui, PixelFormat.RgbaInteger, PixelType.UnsignedInt);

--- a/Renderer/Renderer/PostProcess/BloomRenderer.cs
+++ b/Renderer/Renderer/PostProcess/BloomRenderer.cs
@@ -42,12 +42,12 @@ public class BloomRenderer
     /// <summary>Loads bloom shaders and allocates ping-pong and accumulation framebuffers.</summary>
     public void Load()
     {
-        firstDownsampleBloomThreshold = RendererContext.ShaderLoader.LoadShader("vrf.downsample_bloomthreshold");
-        downsample = RendererContext.ShaderLoader.LoadShader("vrf.gaussian_bloom_blur");
-        horizontalBlur = RendererContext.ShaderLoader.LoadShader("vrf.gaussian_bloom_blur", ("D_BLUR_PASS", 1), ("D_BLUR_PASS_HORIZONTAL", 1));
-        verticalBlur = RendererContext.ShaderLoader.LoadShader("vrf.gaussian_bloom_blur", ("D_BLUR_PASS", 1), ("D_BLUR_PASS_HORIZONTAL", 0));
-        upsample = RendererContext.ShaderLoader.LoadShader("vrf.gaussian_bloom_blur", ("D_BLUR_PASS", 2));
-        firstUpsample = RendererContext.ShaderLoader.LoadShader("vrf.gaussian_bloom_blur", ("D_BLUR_PASS", 3));
+        firstDownsampleBloomThreshold = RendererContext.ShaderLoader.LoadShader("downsample_bloomthreshold");
+        downsample = RendererContext.ShaderLoader.LoadShader("gaussian_bloom_blur");
+        horizontalBlur = RendererContext.ShaderLoader.LoadShader("gaussian_bloom_blur", ("D_BLUR_PASS", 1), ("D_BLUR_PASS_HORIZONTAL", 1));
+        verticalBlur = RendererContext.ShaderLoader.LoadShader("gaussian_bloom_blur", ("D_BLUR_PASS", 1), ("D_BLUR_PASS_HORIZONTAL", 0));
+        upsample = RendererContext.ShaderLoader.LoadShader("gaussian_bloom_blur", ("D_BLUR_PASS", 2));
+        firstUpsample = RendererContext.ShaderLoader.LoadShader("gaussian_bloom_blur", ("D_BLUR_PASS", 3));
 
         Ping = CreateFramebuffer("BloomPing");
         Pong = CreateFramebuffer("BloomPong");

--- a/Renderer/Renderer/PostProcess/DOFRenderer.cs
+++ b/Renderer/Renderer/PostProcess/DOFRenderer.cs
@@ -64,7 +64,7 @@ public class DOFRenderer
     /// it on first use and whenever <see cref="MsaaSamples"/> selects a different variant.
     /// </summary>
     public Shader MsaaResolveDof
-        => msaaResolveDof ??= RendererContext.ShaderLoader.LoadShader("vrf.msaa_resolve", ("D_DOF", 1), ("D_MSAA_SAMPLES", MsaaSamples));
+        => msaaResolveDof ??= RendererContext.ShaderLoader.LoadShader("msaa_resolve", ("D_DOF", 1), ("D_MSAA_SAMPLES", MsaaSamples));
 
     private readonly RendererContext RendererContext;
 
@@ -108,7 +108,7 @@ public class DOFRenderer
     {
         if (DOF == null)
         {
-            DOF = RendererContext.ShaderLoader.LoadShader("vrf.dof2");
+            DOF = RendererContext.ShaderLoader.LoadShader("dof2");
             BlurredResult = Framebuffer.Prepare("Depth Of Field", 2, 2, 0, PostProcessRenderer.DefaultColorFormat, null);
             BlurredResult.Initialize();
         }

--- a/Renderer/Renderer/PostProcess/OutlineRenderer.cs
+++ b/Renderer/Renderer/PostProcess/OutlineRenderer.cs
@@ -13,7 +13,7 @@ public class OutlineRenderer(RendererContext rendererContext)
     /// <summary>Loads the outline edge detection shader.</summary>
     public void Load()
     {
-        outlineEdge = rendererContext.ShaderLoader.LoadShader("vrf.outline_post");
+        outlineEdge = rendererContext.ShaderLoader.LoadShader("outline_post");
     }
 
     /// <summary>

--- a/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
+++ b/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
@@ -68,10 +68,10 @@ namespace ValveResourceFormat.Renderer.PostProcess
         public void Load(int msaaSamples)
         {
             var msaa = (byte)msaaSamples;
-            shaderMsaaResolve = RendererContext.ShaderLoader.LoadShader("vrf.msaa_resolve", ("D_MSAA_SAMPLES", msaa));
-            shaderDepthResolve = RendererContext.ShaderLoader.LoadShader("vrf.depth_resolve", ("D_MSAA_SAMPLES", msaa));
-            shaderPostProcess = RendererContext.ShaderLoader.LoadShader("vrf.post_processing", ("D_BLOOM", 0));
-            shaderPostProcessBloom = RendererContext.ShaderLoader.LoadShader("vrf.post_processing", ("D_BLOOM", 1));
+            shaderMsaaResolve = RendererContext.ShaderLoader.LoadShader("msaa_resolve", ("D_MSAA_SAMPLES", msaa));
+            shaderDepthResolve = RendererContext.ShaderLoader.LoadShader("depth_resolve", ("D_MSAA_SAMPLES", msaa));
+            shaderPostProcess = RendererContext.ShaderLoader.LoadShader("post_processing", ("D_BLOOM", 0));
+            shaderPostProcessBloom = RendererContext.ShaderLoader.LoadShader("post_processing", ("D_BLOOM", 1));
 
             DOF.MsaaSamples = msaa;
             Bloom.Load();

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -216,11 +216,11 @@ namespace ValveResourceFormat.Renderer
 
             UpdateBuffers();
 
-            OutlineShader = RendererContext.ShaderLoader.LoadShader("vrf.outline");
-            FrustumCullShader = RendererContext.ShaderLoader.LoadShader("vrf.frustum_cull");
-            CompactionShader = RendererContext.ShaderLoader.LoadShader("vrf.compact_indirect_draws");
-            DepthPyramidShader = RendererContext.ShaderLoader.LoadShader("vrf.depth_pyramid");
-            DepthPyramidNpotShader = RendererContext.ShaderLoader.LoadShader("vrf.depth_pyramid", ("D_NPOT_DOWNSAMPLE", 1));
+            OutlineShader = RendererContext.ShaderLoader.LoadShader("outline");
+            FrustumCullShader = RendererContext.ShaderLoader.LoadShader("frustum_cull");
+            CompactionShader = RendererContext.ShaderLoader.LoadShader("compact_indirect_draws");
+            DepthPyramidShader = RendererContext.ShaderLoader.LoadShader("depth_pyramid");
+            DepthPyramidNpotShader = RendererContext.ShaderLoader.LoadShader("depth_pyramid", ("D_NPOT_DOWNSAMPLE", 1));
             LightBinner.LoadShaders();
 
             EnableIndirectDraws = LightingInfo.LightingData.IsSkybox == 0u;

--- a/Renderer/Renderer/SceneEnvironment/SceneBackground.cs
+++ b/Renderer/Renderer/SceneEnvironment/SceneBackground.cs
@@ -11,7 +11,7 @@ namespace ValveResourceFormat.Renderer.SceneEnvironment
         /// </summary>
         /// <param name="scene">The scene this background belongs to.</param>
         public SceneBackground(Scene scene)
-            : base(new RenderMaterial(scene.RendererContext.ShaderLoader.LoadShader("vrf.background")))
+            : base(new RenderMaterial(scene.RendererContext.ShaderLoader.LoadShader("background")))
         {
         }
 

--- a/Renderer/Renderer/SceneNodes/CS2BombDamageSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/CS2BombDamageSceneNode.cs
@@ -79,7 +79,7 @@ public class CS2BombDamageSceneNode : SceneNode
     /// <param name="bombsiteLabel">Display label for the bombsite ("A", "B", or a per-site index when unresolved).</param>
     public CS2BombDamageSceneNode(Scene scene, BombDamage bombDamageData, int bombsiteIndex, RenderTexture renderTexture, string bombsiteLabel) : base(scene)
     {
-        var shader = Scene.RendererContext.ShaderLoader.LoadShader("vrf.cs2_baked_bomb_damage");
+        var shader = Scene.RendererContext.ShaderLoader.LoadShader("cs2_baked_bomb_damage");
         meshName = $"{bombDamageData.Resource.FileName}:site{bombsiteIndex}";
 
         material = new RenderMaterial(shader);

--- a/Renderer/Renderer/SceneNodes/ShapeSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ShapeSceneNode.cs
@@ -47,7 +47,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
 
         private ShapeSceneNode(Scene scene) : base(scene)
         {
-            shader = Scene.RendererContext.ShaderLoader.LoadShader("vrf.basic_shape");
+            shader = Scene.RendererContext.ShaderLoader.LoadShader("basic_shape");
         }
 
         internal ShapeSceneNode(Scene scene, List<SimpleVertexNormal> verts, List<int> inds) : this(scene)

--- a/Renderer/Renderer/SceneNodes/VisibilitySceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/VisibilitySceneNode.cs
@@ -21,7 +21,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
         /// </summary>
         public VisibilitySceneNode(Scene scene, VoxelVisibility voxelVisibility) : base(scene)
         {
-            shader = Scene.RendererContext.ShaderLoader.LoadShader("vrf.default");
+            shader = Scene.RendererContext.ShaderLoader.LoadShader("default");
 
             var vertices = new List<SimpleVertex>();
             var ranges = new List<ClusterDrawRange>();

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -126,9 +126,9 @@ namespace ValveResourceFormat.Renderer.Shaders
             Default = new RenderMaterial(this);
             MaterialLoader = rendererContext.MaterialLoader;
 
-            IgnoreMaterialData = Name is "vrf.picking"
-                                      or "vrf.outline"
-                                      or "vrf.depth_only";
+            IgnoreMaterialData = Name is "picking"
+                                      or "outline"
+                                      or "depth_only";
         }
 
         /// <summary>Ensures the shader program has been linked and its uniforms and attributes have been cached.</summary>

--- a/Renderer/Renderer/Shaders/ShaderLoader.cs
+++ b/Renderer/Renderer/Shaders/ShaderLoader.cs
@@ -193,6 +193,19 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
+        /// <summary>
+        /// Drops all preprocessed shader sources and rediscovers the available shader files. Called when the
+        /// <see cref="ShaderRegistry"/> changes; shader programs that have already been compiled are not affected.
+        /// </summary>
+        internal static void InvalidateParsedShaders()
+        {
+            using var _ = ParserLock.EnterScope();
+
+            ParsedCache.Clear();
+            Parser.ClearBuilder();
+            Parser.RefreshAvailableShaders();
+        }
+
         private static ParsedShaderData GetOrParseShader(string shaderFileName)
         {
             using var _ = ParserLock.EnterScope();
@@ -483,8 +496,24 @@ namespace ValveResourceFormat.Renderer.Shaders
         public const string ShaderFileExtension = ".vert.slang";
         const string VrfInternalShaderPrefix = "vrf.";
 
+        /// <summary>
+        /// Maps a Source 2 shader name to the renderer shader file that draws it. Mappings registered in
+        /// <see cref="ShaderRegistry"/> take priority over the built-in ones.
+        /// </summary>
+        /// <param name="shaderName">The Source 2 shader name (e.g. <c>shader.vfx</c>).</param>
+        /// <returns>The renderer shader name without stage or extension (e.g. <c>complex</c>).</returns>
+        public static string GetShaderFileByName(string shaderName)
+        {
+            if (ShaderRegistry.Mappings.TryGetValue(shaderName, out var customShaderFile))
+            {
+                return customShaderFile;
+            }
+
+            return GetBuiltinShaderFileByName(shaderName);
+        }
+
         // Map Valve's shader names to shader files VRF has
-        private static string GetShaderFileByName(string shaderName) => shaderName switch
+        private static string GetBuiltinShaderFileByName(string shaderName) => shaderName switch
         {
             "sky.vfx" => "sky",
             "tools_sprite.vfx" => "sprite",
@@ -597,6 +626,9 @@ namespace ValveResourceFormat.Renderer.Shaders
         {
             Parser.ClearBuilder();
 
+            // Picks up shader files that were created after startup, including ones in mounted directories
+            Parser.RefreshAvailableShaders();
+
             if (name != null && ShaderParser.ExtensionToProgramType.Keys.Any(ext => name.EndsWith($".{ext}.slang", StringComparison.Ordinal)))
             {
                 // If a named shader changed (not an include), then we can only reload this shader
@@ -632,7 +664,8 @@ namespace ValveResourceFormat.Renderer.Shaders
         {
             using var renderContext = new RendererContext(new ValveResourceFormat.IO.GameFileLoader(null, null), logger);
             var loader = renderContext.ShaderLoader;
-            var folder = ShaderParser.GetShaderDiskPath(string.Empty);
+            var folder = ShaderParser.ShaderSourceDirectory
+                ?? throw new DirectoryNotFoundException("Shader validation requires the shader source files, but this build only has the embedded copies.");
 
             var vertShaders = Directory.GetFiles(folder, "*.vert.slang");
             var compShaders = Directory.GetFiles(folder, "*.comp.slang");

--- a/Renderer/Renderer/Shaders/ShaderLoader.cs
+++ b/Renderer/Renderer/Shaders/ShaderLoader.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.IO.Hashing;
 using System.Linq;
@@ -145,7 +145,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         }
 
         /// <summary>Loads or retrieves a cached shader compiled with the specified static combos.</summary>
-        /// <param name="shaderName">The Source 2 shader name (e.g. <c>complex.vfx</c>).</param>
+        /// <param name="shaderName">The Source 2 shader name (e.g. <c>complex.vfx</c>), or a renderer shader file name that must exist (e.g. <c>grid</c>). See <see cref="GetShaderFileByName"/>.</param>
         /// <param name="combos">Static combo name/value pairs to activate.</param>
         public Shader LoadShader(string shaderName, params (string ComboName, byte ComboValue)[] combos)
         {
@@ -154,7 +154,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         }
 
         /// <summary>Loads or retrieves a cached shader compiled with the given argument dictionary.</summary>
-        /// <param name="shaderName">The Source 2 shader name (e.g. <c>complex.vfx</c>).</param>
+        /// <param name="shaderName">The Source 2 shader name (e.g. <c>complex.vfx</c>), or a renderer shader file name that must exist (e.g. <c>grid</c>). See <see cref="GetShaderFileByName"/>.</param>
         /// <param name="arguments">Static combo parameter overrides, or <see langword="null"/> for defaults.</param>
         /// <param name="blocking">When <see langword="true"/>, waits for linking to complete before returning.</param>
         public Shader LoadShader(string shaderName, IReadOnlyDictionary<string, byte>? arguments = null, bool blocking = true)
@@ -254,7 +254,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             {
                 var sources = parsedData.Sources;
 
-                if (shaderName == "vrf.depth_only" && arguments.Count == 0)
+                if (shaderName == "depth_only" && arguments.Count == 0)
                 {
                     sources = new(sources);
                     sources.Remove(ShaderProgramType.Fragment);
@@ -348,7 +348,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
-        private static void CompileShaderObjects(int[] shaderObjects, string[] shaderSources, string shaderFile, ReadOnlySpan<char> originalShaderName, IReadOnlyDictionary<string, byte> arguments, ParsedShaderData parsedData)
+        private static void CompileShaderObjects(int[] shaderObjects, string[] shaderSources, string shaderFile, string originalShaderName, IReadOnlyDictionary<string, byte> arguments, ParsedShaderData parsedData)
         {
             var header = new StringBuilder();
             header.Append(ShaderParser.ExpectedShaderVersion);
@@ -363,7 +363,10 @@ namespace ValveResourceFormat.Renderer.Shaders
                 header.Append('\n');
             }
 
-            var variantName = $"GameVfx_{Path.GetFileNameWithoutExtension(originalShaderName)}";
+            // Only Valve shader names activate a shader variant, renderer shader files are loaded as themselves
+            var variantName = IsVfxShaderName(originalShaderName)
+                ? $"GameVfx_{Path.GetFileNameWithoutExtension(originalShaderName)}"
+                : null;
 
             // Add all defines (with argument overrides or defaults)
             foreach (var (defineName, defaultValue) in parsedData.Defines)
@@ -494,13 +497,18 @@ namespace ValveResourceFormat.Renderer.Shaders
 
         /// <summary>The file extension used to identify vertex shader entry points (<c>.vert.slang</c>).</summary>
         public const string ShaderFileExtension = ".vert.slang";
+        // No longer used by the renderer itself, kept so that names that were required before still resolve
         const string VrfInternalShaderPrefix = "vrf.";
 
         /// <summary>
-        /// Maps a Source 2 shader name to the renderer shader file that draws it. Mappings registered in
+        /// Resolves a shader name to the renderer shader file that draws it. Mappings registered in
         /// <see cref="ShaderRegistry"/> take priority over the built-in ones.
         /// </summary>
-        /// <param name="shaderName">The Source 2 shader name (e.g. <c>shader.vfx</c>).</param>
+        /// <param name="shaderName">
+        /// A Source 2 shader name ending in <c>.vfx</c>, which is mapped to the renderer shader that best matches it and
+        /// falls back to <c>complex</c> when it is unknown. Any other name is the renderer shader file to load directly,
+        /// and must exist.
+        /// </param>
         /// <returns>The renderer shader name without stage or extension (e.g. <c>complex</c>).</returns>
         public static string GetShaderFileByName(string shaderName)
         {
@@ -509,7 +517,24 @@ namespace ValveResourceFormat.Renderer.Shaders
                 return customShaderFile;
             }
 
+            if (!IsVfxShaderName(shaderName))
+            {
+                // Not a Valve shader name, so it names a renderer shader file directly.
+                // Unknown names are not silently drawn with 'complex', loading them throws instead.
+                return shaderName.StartsWith(VrfInternalShaderPrefix, StringComparison.Ordinal)
+                    ? shaderName[VrfInternalShaderPrefix.Length..]
+                    : shaderName;
+            }
+
             return GetBuiltinShaderFileByName(shaderName);
+        }
+
+        /// <summary>The file extension of Source 2 shader names (<c>.vfx</c>).</summary>
+        public const string VfxExtension = ".vfx";
+
+        private static bool IsVfxShaderName(string shaderName)
+        {
+            return shaderName.EndsWith(VfxExtension, StringComparison.Ordinal);
         }
 
         // Map Valve's shader names to shader files VRF has
@@ -531,7 +556,6 @@ namespace ValveResourceFormat.Renderer.Shaders
             "pbr.vfx" => "pbr",
             "citadel_overlay.vfx" => "citadel_overlay",
 
-            _ when shaderName.StartsWith(VrfInternalShaderPrefix, StringComparison.Ordinal) => shaderName[VrfInternalShaderPrefix.Length..],
             _ => "complex",
         };
 
@@ -682,28 +706,27 @@ namespace ValveResourceFormat.Renderer.Shaders
             foreach (var shader in allShaders)
             {
                 var shaderName = ShaderNameFromPath(shader);
-                var vrfFileName = string.Concat(VrfInternalShaderPrefix, shaderName);
 
                 if (IsCI)
                 {
                     Console.WriteLine($"::group::Shader {shaderName}");
                 }
 
-                progressReporter.Report($"Compiling {vrfFileName}");
+                progressReporter.Report($"Compiling {shaderName}");
 
                 if (shaderName == "texture_decode")
                 {
-                    loader.LoadShader(vrfFileName, new Dictionary<string, byte>
+                    loader.LoadShader(shaderName, new Dictionary<string, byte>
                     {
                         ["S_TYPE_TEXTURE2D"] = 1,
                     });
                     continue;
                 }
 
-                loader.LoadShader(vrfFileName);
+                loader.LoadShader(shaderName);
 
                 // Test all defines one by one
-                var parsed = GetOrParseShader(GetShaderFileByName(vrfFileName));
+                var parsed = GetOrParseShader(GetShaderFileByName(shaderName));
                 var defines = parsed.Defines.Where(static x => !x.Key.StartsWith("GameVfx_", StringComparison.Ordinal)).ToDictionary();
                 var variants = parsed.Defines.Keys.Where(static x => x.StartsWith("GameVfx_", StringComparison.Ordinal));
                 var sourceLines = parsed.SourceFileLines;
@@ -715,9 +738,9 @@ namespace ValveResourceFormat.Renderer.Shaders
 
                     for (var value = 1; value <= maxValue; value++)
                     {
-                        progressReporter.Report($"Compiling {vrfFileName} with {define}={value}");
+                        progressReporter.Report($"Compiling {shaderName} with {define}={value}");
 
-                        loader.LoadShader(vrfFileName, new Dictionary<string, byte>
+                        loader.LoadShader(shaderName, new Dictionary<string, byte>
                         {
                             [define] = (byte)value,
                         });

--- a/Renderer/Renderer/Shaders/ShaderLoader.cs
+++ b/Renderer/Renderer/Shaders/ShaderLoader.cs
@@ -517,6 +517,7 @@ namespace ValveResourceFormat.Renderer.Shaders
                 return customShaderFile;
             }
 
+            // TODO: Consider naming renderer shaders with a .slang extension, so that they read as explicitly as .vfx names do
             if (!IsVfxShaderName(shaderName))
             {
                 // Not a Valve shader name, so it names a renderer shader file directly.

--- a/Renderer/Renderer/Shaders/ShaderLoader.cs
+++ b/Renderer/Renderer/Shaders/ShaderLoader.cs
@@ -333,7 +333,17 @@ namespace ValveResourceFormat.Renderer.Shaders
                 }
 
                 var argsDescription = GetArgumentDescription(SortAndFilterArguments(parsedData.Defines, arguments));
-                RendererContext.Logger.LogInformation("Shader '{ShaderName}' as '{ShaderFileName}'{ArgsDescription} compiled{CompiledStatus} successfully (program={Program})", shaderName, shaderFileName, argsDescription, blocking ? " and linked" : string.Empty, shader.Program);
+                var compiledStatus = blocking ? " and linked" : string.Empty;
+
+                // Only Valve shader names are resolved to a different file, so naming both would be noise
+                if (IsVfxShaderName(shaderName))
+                {
+                    RendererContext.Logger.LogInformation("Shader '{ShaderName}' as '{ShaderFileName}'{ArgsDescription} compiled{CompiledStatus} successfully (program={Program})", shaderName, shaderFileName, argsDescription, compiledStatus, shader.Program);
+                }
+                else
+                {
+                    RendererContext.Logger.LogInformation("Shader '{ShaderName}'{ArgsDescription} compiled{CompiledStatus} successfully (program={Program})", shaderName, argsDescription, compiledStatus, shader.Program);
+                }
 
                 return shader;
             }

--- a/Renderer/Renderer/Shaders/ShaderParser.cs
+++ b/Renderer/Renderer/Shaders/ShaderParser.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using static ValveResourceFormat.Renderer.Shaders.ShaderLoader;
@@ -320,11 +321,17 @@ namespace ValveResourceFormat.Renderer.Shaders
             return ExtensionToProgramType.GetValueOrDefault(ext, ShaderProgramType.Max);
         }
 
-        /// <summary>Gets the map from shader base names to a bool array indicating which pipeline stages (vertex, fragment, compute) exist on disk or in the assembly manifest.</summary>
-        public Dictionary<string, bool[]> AvailableShaders { get; }
+        /// <summary>Gets the map from shader base names to a bool array indicating which pipeline stages (vertex, fragment, compute) exist in a mounted shader directory, on disk, or in the assembly manifest.</summary>
+        public Dictionary<string, bool[]> AvailableShaders { get; private set; }
 
         /// <summary>Initializes a new instance of the <see cref="ShaderParser"/> class and discovers all available shader files.</summary>
         public ShaderParser()
+        {
+            AvailableShaders = GetAvailableShaders();
+        }
+
+        /// <summary>Rediscovers the available shader files, picking up changes to <see cref="ShaderRegistry"/>.</summary>
+        internal void RefreshAvailableShaders()
         {
             AvailableShaders = GetAvailableShaders();
         }
@@ -349,47 +356,105 @@ namespace ValveResourceFormat.Renderer.Shaders
                 stages[(int)shaderType] = true;
             }
 
-#if DEBUG
-            var dirInfo = new DirectoryInfo(ShaderRootDirectory);
-            var files = dirInfo.GetFiles($"*{SlangExtension}", SearchOption.TopDirectoryOnly);
+            foreach (var file in ShaderRegistry.EnumerateShaderFiles($"*{SlangExtension}"))
+            {
+                var fileName = Path.GetFileName(file);
 
-            foreach (var file in files)
-            {
-                var shaderName = ShaderNameFromPath(file.FullName);
-                var shaderType = GetTypeFromFileName(file.Name);
-                LogShaderStage(shaderName, shaderType);
+                if (fileName.Length <= ShaderFileExtension.Length)
+                {
+                    continue;
+                }
+
+                LogShaderStage(ShaderNameFromPath(file), GetTypeFromFileName(fileName));
             }
-#else
-            var resources = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceNames()
-                .Where(static r => r.StartsWith(ShaderDirectory, StringComparison.Ordinal))
-                .Where(static r => r.EndsWith(SlangExtension, StringComparison.Ordinal));
-            foreach (var resource in resources)
+
+            if (ShaderSourceDirectory != null)
             {
-                var shaderName = resource[ShaderDirectory.Length..^ShaderFileExtension.Length];
-                var shaderType = GetTypeFromFileName(resource);
-                LogShaderStage(shaderName, shaderType);
+                var dirInfo = new DirectoryInfo(ShaderSourceDirectory);
+                var files = dirInfo.GetFiles($"*{SlangExtension}", SearchOption.TopDirectoryOnly);
+
+                foreach (var file in files)
+                {
+                    var shaderName = ShaderNameFromPath(file.FullName);
+                    var shaderType = GetTypeFromFileName(file.Name);
+                    LogShaderStage(shaderName, shaderType);
+                }
             }
-#endif
+            else
+            {
+                var resources = Assembly.GetExecutingAssembly().GetManifestResourceNames()
+                    .Where(static r => r.StartsWith(ShaderDirectory, StringComparison.Ordinal))
+                    .Where(static r => r.EndsWith(SlangExtension, StringComparison.Ordinal));
+                foreach (var resource in resources)
+                {
+                    var shaderName = resource[ShaderDirectory.Length..^ShaderFileExtension.Length];
+                    var shaderType = GetTypeFromFileName(resource);
+                    LogShaderStage(shaderName, shaderType);
+                }
+            }
+
             return availableShaders;
         }
 
-#if !DEBUG
+        /// <summary>
+        /// Opens a shader source file, preferring the directories mounted through <see cref="ShaderRegistry"/> over the
+        /// shaders shipped with the renderer.
+        /// </summary>
+        /// <param name="name">Root relative shader file name using forward slashes (e.g. <c>common/lighting.slang</c>).</param>
         private static Stream GetShaderStream(string name)
         {
+            return ShaderRegistry.TryOpenShaderFile(name) ?? GetBuiltinShaderStream(name);
+        }
+
+        private const string ShaderSourceDirectoryMetadataKey = "ShaderSourceDirectory";
+
+        /// <summary>
+        /// Gets the folder holding the shaders shipped with the renderer as loose files on disk, or <see langword="null"/>
+        /// when only the copies embedded in this assembly are available.
+        /// </summary>
+        /// <remarks>
+        /// Debug builds record the absolute path of the shader folder at compile time so that shader files can be edited
+        /// and hot reloaded without rebuilding. It is not recorded in release builds, and points at a folder that does not
+        /// exist when the assembly is used on another machine, in which case the embedded shaders are used instead.
+        /// </remarks>
+        public static string? ShaderSourceDirectory { get; } = FindShaderSourceDirectory();
+
+        private static string? FindShaderSourceDirectory()
+        {
+            foreach (var metadata in typeof(ShaderParser).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>())
+            {
+                if (metadata.Key == ShaderSourceDirectoryMetadataKey
+                && !string.IsNullOrEmpty(metadata.Value)
+                && Directory.Exists(metadata.Value))
+                {
+                    return metadata.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static Stream GetBuiltinShaderStream(string name)
+        {
+            if (ShaderSourceDirectory != null)
+            {
+                var path = Path.Combine(ShaderSourceDirectory, name);
+
+                if (File.Exists(path))
+                {
+                    return OpenShaderFile(path);
+                }
+            }
+
             var resourceName = $"{ShaderDirectory}{name.Replace('/', '.')}";
-            var stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
-            ArgumentNullException.ThrowIfNull(stream);
+            var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName)
+                ?? throw new FileNotFoundException($"Shader file '{name}' was not found on disk or among the embedded shaders.", name);
+
             return stream;
         }
-#else
-        // Path to the folder where the ValveResourceFormat.slnx is on disk (parent of the GUI folder)
-        private static readonly string SolutionRootDirector = GetSolutionRootDirectory();
-        private static readonly string ShaderRootDirectory = Path.Combine(SolutionRootDirector, ShaderDirectory.Replace('.', Path.DirectorySeparatorChar));
 
-        private static FileStream GetShaderStream(string name)
+        private static FileStream OpenShaderFile(string path)
         {
-            var path = GetShaderDiskPath(name);
-
             try
             {
                 return File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -405,35 +470,5 @@ namespace ValveResourceFormat.Renderer.Shaders
                 return File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             }
         }
-
-        /// <summary>Returns the absolute path to a shader file on disk (debug builds only).</summary>
-        /// <param name="name">Relative shader file name (e.g. <c>complex.vert.slang</c>).</param>
-        public static string GetShaderDiskPath(string name)
-        {
-            return Path.Combine(ShaderRootDirectory, name);
-        }
-
-        private static string GetSolutionRootDirectory()
-        {
-            var root = AppContext.BaseDirectory;
-            var failsafe = 10;
-            var fileName = string.Empty;
-
-            do
-            {
-                root = Path.GetDirectoryName(root);
-
-                if (root == null || failsafe-- == 0)
-                {
-                    throw new DirectoryNotFoundException("Failed to find the project root folder for the shaders, are you debugging in some unconventional setup?");
-                }
-
-                fileName = Path.Join(root, "ValveResourceFormat.slnx");
-            }
-            while (!File.Exists(fileName));
-
-            return root;
-        }
-#endif
     }
 }

--- a/Renderer/Renderer/Shaders/ShaderRegistry.cs
+++ b/Renderer/Renderer/Shaders/ShaderRegistry.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace ValveResourceFormat.Renderer.Shaders
+{
+    /// <summary>
+    /// Registry of user provided shader directories and shader name mappings.
+    ///
+    /// <para>
+    /// Directories added here are mounted in front of the shaders shipped with the renderer, similar to how search paths
+    /// work in <see cref="ValveResourceFormat.IO.GameFileLoader"/>. Any file placed in a mounted directory overrides the
+    /// built-in file with the same relative path, which applies to shader entry points (<c>complex.vert.slang</c>) as well
+    /// as anything pulled in with <c>#include</c> (<c>common/lighting.slang</c>).
+    /// </para>
+    ///
+    /// <para>
+    /// Mappings translate a Source 2 shader name (<c>shader.vfx</c>) to the renderer shader file that will be used to draw
+    /// it, taking priority over the built-in mapping table.
+    /// </para>
+    ///
+    /// <para>
+    /// Configure this before creating a <see cref="RendererContext"/>. Changing the registry drops the parsed shader cache,
+    /// but shader programs that have already been compiled by an existing loader keep running the old code.
+    /// </para>
+    /// </summary>
+    public static class ShaderRegistry
+    {
+        private static readonly Lock RegistryLock = new();
+        private static ImmutableArray<string> directories = [];
+        private static ImmutableDictionary<string, string> mappings = ImmutableDictionary.Create<string, string>(StringComparer.Ordinal);
+
+        /// <summary>Gets the mounted shader directories, highest priority first.</summary>
+        public static ImmutableArray<string> Directories => directories;
+
+        /// <summary>Gets the registered shader name mappings, keyed by the Source 2 shader name (e.g. <c>shader.vfx</c>).</summary>
+        public static ImmutableDictionary<string, string> Mappings => mappings;
+
+        /// <summary>
+        /// Mounts a directory containing shader files. The most recently added directory has the highest priority, and all
+        /// mounted directories take priority over the shaders shipped with the renderer.
+        /// </summary>
+        /// <param name="path">Path to the directory that mirrors the layout of the built-in <c>Renderer/Shaders</c> folder.</param>
+        /// <returns><see langword="true"/> if the directory was added, <see langword="false"/> if it was already mounted.</returns>
+        /// <exception cref="DirectoryNotFoundException">The directory does not exist.</exception>
+        public static bool AddShaderDirectory(string path)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
+            var fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+
+            if (!Directory.Exists(fullPath))
+            {
+                throw new DirectoryNotFoundException($"Shader directory '{fullPath}' does not exist.");
+            }
+
+            using (RegistryLock.EnterScope())
+            {
+                if (directories.Any(dir => string.Equals(dir, fullPath, StringComparison.Ordinal)))
+                {
+                    return false;
+                }
+
+                directories = directories.Insert(0, fullPath);
+            }
+
+            ShaderLoader.InvalidateParsedShaders();
+            return true;
+        }
+
+        /// <summary>
+        /// Maps a Source 2 shader name to the renderer shader file used to draw it. Overrides the built-in mapping when the
+        /// same name is already known to the renderer.
+        /// </summary>
+        /// <param name="shaderName">The Source 2 shader name, including the extension (e.g. <c>shader.vfx</c>).</param>
+        /// <param name="shaderFileName">The renderer shader name without stage or extension (e.g. <c>my_shader</c> for <c>my_shader.vert.slang</c>).</param>
+        public static void AddShaderMapping(string shaderName, string shaderFileName)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(shaderName);
+            ArgumentException.ThrowIfNullOrEmpty(shaderFileName);
+
+            using (RegistryLock.EnterScope())
+            {
+                mappings = mappings.SetItem(shaderName, shaderFileName);
+            }
+
+            ShaderLoader.InvalidateParsedShaders();
+        }
+
+        /// <summary>Removes all mounted directories and registered mappings.</summary>
+        public static void Reset()
+        {
+            using (RegistryLock.EnterScope())
+            {
+                directories = [];
+                mappings = mappings.Clear();
+            }
+
+            ShaderLoader.InvalidateParsedShaders();
+        }
+
+        /// <summary>
+        /// Opens a shader file from the mounted directories, or returns <see langword="null"/> when no mounted directory
+        /// provides it and the built-in shader should be used instead.
+        /// </summary>
+        /// <param name="name">Root relative shader file name using forward slashes (e.g. <c>common/lighting.slang</c>).</param>
+        internal static Stream? TryOpenShaderFile(string name)
+        {
+            var mounted = directories;
+
+            if (mounted.IsEmpty)
+            {
+                return null;
+            }
+
+            var relativePath = name.Replace('/', Path.DirectorySeparatorChar);
+
+            foreach (var directory in mounted)
+            {
+                var path = Path.Combine(directory, relativePath);
+
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                return File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            }
+
+            return null;
+        }
+
+        /// <summary>Enumerates the shader entry point files in the mounted directories.</summary>
+        /// <param name="searchPattern">The file search pattern to match against file names.</param>
+        internal static IEnumerable<string> EnumerateShaderFiles(string searchPattern)
+        {
+            foreach (var directory in directories)
+            {
+                if (!Directory.Exists(directory))
+                {
+                    continue;
+                }
+
+                foreach (var file in Directory.EnumerateFiles(directory, searchPattern, SearchOption.TopDirectoryOnly))
+                {
+                    yield return file;
+                }
+            }
+        }
+    }
+}

--- a/Renderer/Renderer/TextRenderer.cs
+++ b/Renderer/Renderer/TextRenderer.cs
@@ -240,7 +240,7 @@ namespace ValveResourceFormat.Renderer
             using var fontStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Renderer.Resources.jetbrains_mono_msdf.png");
             using var bitmap = SKBitmap.Decode(fontStream);
 
-            shader = RendererContext.ShaderLoader.LoadShader("vrf.font_msdf");
+            shader = RendererContext.ShaderLoader.LoadShader("font_msdf");
 
             fontTexture = new RenderTexture(TextureTarget.Texture2D, (int)AtlasSize, (int)AtlasSize, 1, 1);
             fontTexture.SetWrapMode(TextureWrapMode.ClampToEdge);

--- a/Tests/Renderer/ShaderRegistryTest.cs
+++ b/Tests/Renderer/ShaderRegistryTest.cs
@@ -117,6 +117,20 @@ namespace Tests.Renderer
         }
 
         [Test]
+        public void OnlyVfxShaderNamesFallBackToComplex()
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ShaderLoader.GetShaderFileByName("mygame_glass.vfx"), Is.EqualTo("complex"));
+                Assert.That(ShaderLoader.GetShaderFileByName("sky.vfx"), Is.EqualTo("sky"));
+
+                // Renderer shader files are loaded as themselves, and throw when they do not exist
+                Assert.That(ShaderLoader.GetShaderFileByName("mygame_glass"), Is.EqualTo("mygame_glass"));
+                Assert.That(ShaderLoader.GetShaderFileByName("vrf.grid"), Is.EqualTo("grid"));
+            }
+        }
+
+        [Test]
         public void ShaderMappingsOverrideBuiltinOnes()
         {
             Assert.That(ShaderLoader.GetShaderFileByName("mygame_glass.vfx"), Is.EqualTo("complex"));

--- a/Tests/Renderer/ShaderRegistryTest.cs
+++ b/Tests/Renderer/ShaderRegistryTest.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using ValveResourceFormat.Renderer.Shaders;
+
+namespace Tests.Renderer
+{
+    public class ShaderRegistryTest
+    {
+        private string customShaderDirectory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            customShaderDirectory = Path.Combine(Path.GetTempPath(), "VrfCustomShaders_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(customShaderDirectory, "common"));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ShaderRegistry.Reset();
+            Directory.Delete(customShaderDirectory, recursive: true);
+        }
+
+        private void WriteShader(string relativePath, string source)
+        {
+            File.WriteAllText(Path.Combine(customShaderDirectory, relativePath.Replace('/', Path.DirectorySeparatorChar)), source);
+        }
+
+        private static string Preprocess(string shaderFile, ShaderLoader.ParsedShaderData? parsedData = null)
+        {
+            return new ShaderParser().PreprocessShader(shaderFile, parsedData ?? new ShaderLoader.ParsedShaderData());
+        }
+
+        [Test]
+        public void CustomShaderResolvesItsOwnInclude()
+        {
+            WriteShader("custom_test.vert.slang", """
+                #version 460
+                #include "common/custom_include.slang"
+                void main() { CustomHelper(); }
+                """);
+
+            WriteShader("common/custom_include.slang", """
+                #version 460
+                void CustomHelper() {}
+                """);
+
+            ShaderRegistry.AddShaderDirectory(customShaderDirectory);
+
+            var parsedData = new ShaderLoader.ParsedShaderData();
+            var source = Preprocess("custom_test.vert.slang", parsedData);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(new ShaderParser().AvailableShaders, Contains.Key("custom_test"));
+                Assert.That(source, Does.Contain("void CustomHelper() {}"));
+                Assert.That(source, Does.Contain("void main() { CustomHelper(); }"));
+                Assert.That(parsedData.SourceFiles, Does.Contain("common/custom_include.slang"));
+            }
+        }
+
+        [Test]
+        public void MountedIncludeOverridesBuiltinOne()
+        {
+            Assert.That(Preprocess("complex.vert.slang"), Does.Not.Contain("CustomUtilsMarker"));
+
+            // complex.vert.slang includes common/utils.slang
+            WriteShader("common/utils.slang", """
+                #version 460
+                void CustomUtilsMarker() {}
+                """);
+
+            ShaderRegistry.AddShaderDirectory(customShaderDirectory);
+
+            Assert.That(Preprocess("complex.vert.slang"), Does.Contain("void CustomUtilsMarker() {}"));
+        }
+
+        [Test]
+        public void LastAddedShaderDirectoryHasPriority()
+        {
+            var secondDirectory = customShaderDirectory + "_second";
+            Directory.CreateDirectory(secondDirectory);
+
+            try
+            {
+                WriteShader("complex.vert.slang", "#version 460\nvoid main() { First(); }");
+                File.WriteAllText(Path.Combine(secondDirectory, "complex.vert.slang"), "#version 460\nvoid main() { Second(); }");
+
+                ShaderRegistry.AddShaderDirectory(customShaderDirectory);
+                ShaderRegistry.AddShaderDirectory(secondDirectory);
+
+                Assert.That(Preprocess("complex.vert.slang"), Does.Contain("void main() { Second(); }"));
+            }
+            finally
+            {
+                Directory.Delete(secondDirectory, recursive: true);
+            }
+        }
+
+        [Test]
+        public void ShaderMappingsOverrideBuiltinOnes()
+        {
+            Assert.That(ShaderLoader.GetShaderFileByName("mygame_glass.vfx"), Is.EqualTo("complex"));
+
+            ShaderRegistry.AddShaderMapping("mygame_glass.vfx", "mygame_glass");
+            ShaderRegistry.AddShaderMapping("sky.vfx", "mygame_sky");
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ShaderLoader.GetShaderFileByName("mygame_glass.vfx"), Is.EqualTo("mygame_glass"));
+                Assert.That(ShaderLoader.GetShaderFileByName("sky.vfx"), Is.EqualTo("mygame_sky"));
+            }
+        }
+    }
+}

--- a/Tests/Renderer/ShaderRegistryTest.cs
+++ b/Tests/Renderer/ShaderRegistryTest.cs
@@ -100,6 +100,23 @@ namespace Tests.Renderer
         }
 
         [Test]
+        public void PreprocessedSourceCanBePatched()
+        {
+            // Shaders can also be customized by patching the preprocessed source instead of overriding whole files.
+            // Note the result cannot be written back out as a shader file, as it is already fully inlined.
+            var parsedData = new ShaderLoader.ParsedShaderData();
+            var patched = Preprocess("complex.vert.slang", parsedData)
+                .Replace("void main()", "void PatchedMain()", StringComparison.Ordinal);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(patched, Does.Contain("void PatchedMain()"));
+                Assert.That(patched, Does.Not.Contain("void main()"));
+                Assert.That(parsedData.Sources, Is.Empty, "Sources are only filled in by ShaderLoader when it compiles a shader");
+            }
+        }
+
+        [Test]
         public void ShaderMappingsOverrideBuiltinOnes()
         {
             Assert.That(ShaderLoader.GetShaderFileByName("mygame_glass.vfx"), Is.EqualTo("complex"));


### PR DESCRIPTION
Library users can load their own shader code. Hot reload works naturally, so they get a similar experience as developing for s2v.

The files should have `.slang` extension. Start with `#version 460`. Internal includes can be referenced.

`LoadShader("unknown_shader")` no longer remaps to "complex". `LoadShader("unknown_shader.vfx")` does.