### PR TITLE
fix: docs interpreting text as italic

### DIFF
--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -382,7 +382,7 @@ namespace ValveResourceFormat.Renderer
         /// <summary>
         /// Finds the first scene node whose entity name matches with the given pattern.
         /// </summary>
-        /// <param name="pattern">Targetname to match against, may contain wildcards: '*' and '?' (e.g. <c>door_*</c>).</param>
+        /// <param name="pattern">Targetname to match against, may contain wildcards: `*` and `?` (e.g. <c>door_*</c>).</param>
         /// <returns>The matching <see cref="SceneNode"/>, or <see langword="null"/> if not found.</returns>
         public SceneNode? FindNodeByTargetName(string pattern)
         {

--- a/Renderer/Renderer/World/WorldLoader.cs
+++ b/Renderer/Renderer/World/WorldLoader.cs
@@ -1836,7 +1836,7 @@ namespace ValveResourceFormat.Renderer.World
         /// <summary>
         /// Finds the first entity which matches its name with the given pattern.
         /// </summary>
-        /// <param name="pattern">Targetname to match against, may contain wildcards: '*' and '?' (e.g. <c>door_*</c>).</param>
+        /// <param name="pattern">Targetname to match against, may contain wildcards: `*` and `?` (e.g. <c>door_*</c>).</param>
         /// <returns>The matching <see cref="Entity"/>, or <see langword="null"/> if not found.</returns>
         public Entity? FindEntityByTargetName(string pattern)
         {

--- a/ValveResourceFormat/Resource/ResourceTypes/EntityLump.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/EntityLump.cs
@@ -605,7 +605,7 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>
         /// Compares an entity targetname against a target string that may contain wildcards.
         /// </summary>
-        /// <param name="pattern">Targetname to match against, may contain wildcards: '*' and '?' (e.g. <c>door_*</c>).</param>
+        /// <param name="pattern">Targetname to match against, may contain wildcards: `*` and `?` (e.g. <c>door_*</c>).</param>
         /// <param name="targetName">Entity targetname.</param>
         /// <returns>Whether the targetname matches.</returns>
         public static bool EntityNameMatches(string pattern, string targetName)


### PR DESCRIPTION
docs interpreted `'*' and '?' (e.g. <code>door_*</code>` as italic between the two stars