### PR TITLE
Fix reference grid translucency

### DIFF
--- a/GUI/Types/GLViewers/GLSceneViewer.cs
+++ b/GUI/Types/GLViewers/GLSceneViewer.cs
@@ -647,6 +647,7 @@ namespace GUI.Types.GLViewers
             }
 
             Renderer.ForceResolveSceneDepth = ShowBaseGrid;
+            Renderer.BaseGrid = ShowBaseGrid ? baseGrid : null;
 
             var quadOverdrawThisFrame = false;
 
@@ -717,8 +718,6 @@ namespace GUI.Types.GLViewers
 
                 if (ShowBaseGrid && baseGrid != null)
                 {
-                    baseGrid.Render();
-
                     DrawWorldSpaceText("+X", 10f, Vector3.UnitX * 120f, Color32.Red, renderContext);
                     DrawWorldSpaceText("-X", 10f, -Vector3.UnitX * 120f, Color32.Red, renderContext);
                     DrawWorldSpaceText("+Y", 10f, Vector3.UnitY * 120f, Color32.Green, renderContext);

--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -102,6 +102,11 @@ public class Renderer
     public SceneBackground? BaseBackground { get; protected set; }
 
     /// <summary>
+    /// Optional reference grid drawn after the opaque passes so translucent geometry composites over it.
+    /// </summary>
+    public InfiniteGrid? BaseGrid { get; set; }
+
+    /// <summary>
     /// GPU uniform buffer containing per-view constants such as view-projection matrices.
     /// </summary>
     public UniformBuffer<ViewConstants>? ViewBuffer { get; set; }
@@ -714,6 +719,12 @@ public class Renderer
 
             renderContext.ReplacementShader?.SetUniform1("isSkybox", 0u);
             DepthRange.Scene.Apply();
+        }
+
+        if (isStandardPass && BaseGrid != null)
+        {
+            using var _ = new GLDebugGroup("Base Grid Render");
+            BaseGrid.Render();
         }
 
         using (new GLDebugGroup("Main Scene Translucent Render"))

--- a/Renderer/Renderer/InfiniteGrid.cs
+++ b/Renderer/Renderer/InfiniteGrid.cs
@@ -49,12 +49,14 @@ namespace ValveResourceFormat.Renderer
         {
             GL.Enable(EnableCap.Blend);
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            GL.DepthMask(false);
 
             shader.Use();
             GL.BindVertexArray(vao);
 
             GL.DrawArrays(PrimitiveType.Triangles, 0, 6);
 
+            GL.DepthMask(true);
             GL.Disable(EnableCap.Blend);
         }
     }


### PR DESCRIPTION
Grid draws bugged over translucent stuff, especially noticeable for particles. Depth mask change due to Z-fighting of Grid on particles aswell.

Old:
<img height="500" alt="bugged" src="https://github.com/user-attachments/assets/744bc83b-ce20-444a-906b-7b3051443965" />
New:
<img height="500" alt="correct" src="https://github.com/user-attachments/assets/fddc1448-732b-4b04-bac1-a716ee684fd0" />
