### PR TITLE
Fix VPK cube array texture decompilation

### DIFF
--- a/CLI/Decompiler.cs
+++ b/CLI/Decompiler.cs
@@ -1380,6 +1380,17 @@ namespace CLI
                             {
                                 outputFile = Path.ChangeExtension(outputFile, extension);
                             }
+
+                            if (RecursiveSearchArchives)
+                            {
+                                outputFile = Path.Combine(parentPath, outputFile);
+                            }
+
+                            outputFile = GetOutputPath(outputFile, useOutputAsDirectory);
+
+                            // Dump before disposing resource because texture subfiles are generated lazily.
+                            DumpContentFile(outputFile, contentFile, singleFileOutput: !useOutputAsDirectory);
+                            continue;
                         }
 
                         if (RecursiveSearchArchives)


### PR DESCRIPTION
Cube-array textures decompilation throws a `NullReferenceException` in `Texture.GenerateBitmap` causing EXR images to be not extracted despite the CLI exit code 0

```bash
  Source2Viewer-CLI \
    -i /path/to/csgo/maps/de_dust2.vpk \
    -o output \
    -d \
    -f maps/de_dust2/cubemaps/env_cubemap_array.vtex_c
```

Before: NullReferenceException, 0 files written.
After: 43 EXR files written.

This restores the behavior fixed in #632 after the VCS-path restructuring in #965