### PR TITLE
Fix CLI resource disposal analysis

### DIFF
--- a/CLI/Decompiler.cs
+++ b/CLI/Decompiler.cs
@@ -1292,9 +1292,6 @@ namespace CLI
                 var rawFileData = ArrayPool<byte>.Shared.Rent(totalLength);
                 ContentFile? contentFile = null;
 
-                // Must outlive DumpContentFile because content subfiles can be generated lazily from the resource.
-                Resource? resource = null;
-
                 try
                 {
                     package.ReadEntry(file, rawFileData);
@@ -1325,6 +1322,8 @@ namespace CLI
 
                     if (OutputFile != null)
                     {
+                        // Must outlive DumpContentFile because content subfiles can be generated lazily from the resource.
+                        using var resource = new Resource();
                         string outputFile;
                         // VCS files require multiple files to be decompiled together
                         if (isVcsFile)
@@ -1348,10 +1347,7 @@ namespace CLI
                         }
                         else
                         {
-                            resource = new Resource
-                            {
-                                FileName = filePath,
-                            };
+                            resource.FileName = filePath;
                             resource.Read(memory);
 
                             if (GltfExportFormat != null && GltfModelExporter.CanExport(resource))
@@ -1402,7 +1398,6 @@ namespace CLI
                 finally
                 {
                     contentFile?.Dispose();
-                    resource?.Dispose();
                     ArrayPool<byte>.Shared.Return(rawFileData);
                 }
             }


### PR DESCRIPTION
  ## Description

  Move the `Resource` into a `using` scope that still spans `DumpContentFile`, making disposal
  explicit while preserving lazy subfile generation and preventing CA2000 error during publish

  ## Reproduction

  ```bash
  dotnet publish \
    --configuration Release \
    --self-contained \
    --runtime linux-x64 \
    CLI/CLI.csproj
  ```

  Before: publish fails with CA2000 in CLI/Decompiler.cs.
  After: publish succeeds and cube-array extraction still writes 43 EXR files.
