### PR TITLE
Fix fragment transforms after aggregate LoD filtering

### DIFF
--- a/Renderer/Renderer/SceneAggregate.cs
+++ b/Renderer/Renderer/SceneAggregate.cs
@@ -213,6 +213,9 @@ namespace ValveResourceFormat.Renderer
                 var tintColor = fragmentData.GetSubCollection("m_vTintColor").ToVector3();
                 var flags = fragmentData.GetEnumValue<ObjectTypeFlags>("m_objectFlags", normalize: true);
                 var lodGroupMask = fragmentData.GetUInt32Property("m_nLODGroupMask");
+                var fragmentTransform = fragmentData.GetBooleanProperty("m_bHasTransform") == true
+                    ? fragmentTransforms[transformIndex++]
+                    : null;
 
                 var isHighestDetailMesh = lodGroupMask == 0 || (lodGroupMask & lowestLodBit) != 0;
                 if (!isHighestDetailMesh)
@@ -230,10 +233,10 @@ namespace ValveResourceFormat.Renderer
                     Flags = flags,
                 };
 
-                if (fragmentData.GetBooleanProperty("m_bHasTransform") == true)
+                if (fragmentTransform != null)
                 {
                     CanDrawIndirect = false; // skip indirect draw path for instanced draws
-                    fragment.Transform *= fragmentTransforms[transformIndex++].ToMatrix4x4();
+                    fragment.Transform *= fragmentTransform.ToMatrix4x4();
                 }
 
                 yield return fragment;


### PR DESCRIPTION
## Description
Aggregate transforms are stored in a positional order but filtering fragments before their transform causes shift in the subsequent fragments

## Reproduction

`de_train`
- `agg_prop_gk01_gas_meters_01_tint_medium_1`
- `agg_prop_train_railcar_base_details_01_2`

Before: 265/270 and 5/7 retained fragments misplaced, with max displacement about 3300 units
After: 270/270 and 7/7 match the unfiltered positional baseline


`de_nuke`
Aggregate #338 filters 46 transformed fragments, but no retained transformed fragments follow them so no visible effect

## Note
The current CLI CI failure on `master` is addressed by #1287