### PR TITLE
Apply world lightmap UV scale on export

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -27,8 +27,9 @@ public partial class GltfModelExporter
     private readonly record struct ExportedMaterial(string Name, Vector4 Tint);
     private readonly record struct ExportedMaterialData(Material Material, bool IsOverlay);
     private readonly Dictionary<ExportedMaterial, ExportedMaterialData> ExportedMaterials = [];
+    private readonly Dictionary<(Accessor Accessor, Vector2 Scale), Accessor> ScaledLightmapUvAccessors = [];
 
-    private Mesh CreateGltfMesh(string meshName, VMesh vmesh, VBIB vbib, ModelRoot exportedModel, int[]? boneRemapTable, string? skinMaterialPath, Vector4 tintColor)
+    private Mesh CreateGltfMesh(string meshName, VMesh vmesh, VBIB vbib, ModelRoot exportedModel, int[]? boneRemapTable, string? skinMaterialPath, Vector4 tintColor, Vector2? lightmapUvScale)
     {
         ProgressReporter?.Report($"Creating mesh: {meshName}");
 
@@ -46,7 +47,7 @@ public partial class GltfModelExporter
         {
             foreach (var drawCall in sceneObject.GetArray("m_drawCalls"))
             {
-                var primitive = CreateMeshFromDrawCall(drawCall, mesh, vbib, vertexBufferAccessors, exportedModel, skinMaterialPath, tintColor);
+                var primitive = CreateMeshFromDrawCall(drawCall, mesh, vbib, vertexBufferAccessors, exportedModel, skinMaterialPath, tintColor, lightmapUvScale);
 
                 if (vmesh.MorphData != null)
                 {
@@ -309,7 +310,8 @@ public partial class GltfModelExporter
     }
 
     private MeshPrimitive CreateMeshFromDrawCall(KVObject drawCall, Mesh mesh, VBIB vbib, Dictionary<string,
-        Accessor>[] vertexBufferAccessors, ModelRoot exportedModel, string? skinMaterialPath, Vector4 parentTintColor)
+        Accessor>[] vertexBufferAccessors, ModelRoot exportedModel, string? skinMaterialPath, Vector4 parentTintColor,
+        Vector2? lightmapUvScale)
     {
         CancellationToken.ThrowIfCancellationRequested();
 
@@ -347,7 +349,19 @@ public partial class GltfModelExporter
                     key = attributeKey;
                 }
 
-                primitive.SetVertexAccessor(key, accessor);
+                var vertexAccessor = accessor;
+                // Lightmap UVs may be locally named TEXCOORD_0, so scale after primitive remapping.
+                if (key == "TEXCOORD_1" && lightmapUvScale is { } scale)
+                {
+                    var scaledAccessorKey = (accessor, scale);
+                    if (!ScaledLightmapUvAccessors.TryGetValue(scaledAccessorKey, out vertexAccessor))
+                    {
+                        vertexAccessor = ApplyLightmapUvScale(exportedModel, accessor, scale);
+                        ScaledLightmapUvAccessors.Add(scaledAccessorKey, vertexAccessor);
+                    }
+                }
+
+                primitive.SetVertexAccessor(key, vertexAccessor);
 
                 DebugValidateGLTF();
             }
@@ -441,7 +455,7 @@ public partial class GltfModelExporter
     }
 
     // Copied from ValveResourceFormat.Renderer.SceneAggregate.CreateFragments
-    private bool AggregateCreateFragments(ModelRoot exportedModel, Scene scene, VModel model, KVObject aggregateSceneObject, string name)
+    private bool AggregateCreateFragments(ModelRoot exportedModel, Scene scene, VModel model, KVObject aggregateSceneObject, string name, Vector2? lightmapUvScale)
     {
         var embeddedMeshes = model.GetEmbeddedMeshesAndLoD().ToList();
         VMesh vmesh;
@@ -531,7 +545,7 @@ public partial class GltfModelExporter
             var mesh = exportedModel.CreateMesh(meshName);
             mesh.Extras = new JsonObject();
 
-            CreateMeshFromDrawCall(drawCall, mesh, vbib, vertexBufferAccessors, exportedModel, skinMaterialPath: null, tintColor);
+            CreateMeshFromDrawCall(drawCall, mesh, vbib, vertexBufferAccessors, exportedModel, skinMaterialPath: null, tintColor, lightmapUvScale);
 
             var newNode = scene.CreateNode(name).WithMesh(mesh);
             // The conversion is baked into the geometry (CreateVertexBufferAccessors), so the placement
@@ -604,6 +618,12 @@ public partial class GltfModelExporter
         }
 
         return indices;
+    }
+
+    private static Accessor ApplyLightmapUvScale(ModelRoot exportedModel, Accessor accessor, Vector2 scale)
+    {
+        var scaledUvs = accessor.AsVector2Array().Select(uv => uv * scale).ToArray();
+        return CreateAccessor(exportedModel, scaledUvs);
     }
 
     private static Accessor CreateAccessor(ModelRoot exportedModel, Vector2[] vectors)

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -92,7 +92,7 @@ namespace ValveResourceFormat.IO
 
         private string DstDir = string.Empty;
         private CancellationToken CancellationToken;
-        private readonly Dictionary<string, Mesh> ExportedMeshes = [];
+        private readonly Dictionary<(string Name, Vector2? LightmapUvScale), Mesh> ExportedMeshes = [];
         private readonly List<(PhysAggregateData Phys, string? Classname, Matrix4x4 Transform)> PhysicsToExport = [];
         private bool IsExporting;
 
@@ -167,6 +167,7 @@ namespace ValveResourceFormat.IO
             {
                 matchedAnimationFilter.Clear();
                 ExportedMeshes.Clear();
+                ScaledLightmapUvAccessors.Clear();
                 PhysicsToExport.Clear();
                 TextureExportingTasks.Clear();
                 ExportedTextures.Clear();
@@ -307,6 +308,7 @@ namespace ValveResourceFormat.IO
         private void ExportToFile(string resourceName, string? fileName, VWorld world)
         {
             var exportedModel = CreateModelRoot(resourceName, out var scene);
+            var lightmapUvScale = GetLightmapUvScale(world);
 
             // First the WorldNodes
             foreach (var worldNodeName in world.GetWorldNodeNames())
@@ -323,7 +325,7 @@ namespace ValveResourceFormat.IO
                 }
 
                 var worldNode = (VWorldNode)worldResource.DataBlock!;
-                LoadWorldNodeModels(exportedModel, scene, worldNode);
+                LoadWorldNodeModels(exportedModel, scene, worldNode, lightmapUvScale);
             }
 
             // Then the Entities
@@ -525,7 +527,18 @@ namespace ValveResourceFormat.IO
             WriteModelFile(exportedModel, fileName);
         }
 
-        private void LoadWorldNodeModels(ModelRoot exportedModel, Scene scene, VWorldNode worldNode)
+        private static Vector2? GetLightmapUvScale(VWorld world)
+        {
+            var worldLightingInfo = world.GetWorldLightingInfo();
+            if (worldLightingInfo == null || worldLightingInfo.GetInt32Property("m_nLightmapVersionNumber") != 8)
+            {
+                return null;
+            }
+
+            return worldLightingInfo.GetSubCollection("m_vLightmapUvScale")?.ToVector2();
+        }
+
+        private void LoadWorldNodeModels(ModelRoot exportedModel, Scene scene, VWorldNode worldNode, Vector2? lightmapUvScale = null)
         {
             foreach (var sceneObject in worldNode.SceneObjects)
             {
@@ -551,7 +564,7 @@ namespace ValveResourceFormat.IO
                     tintColor = Vector4.One;
                 }
 
-                LoadModel(exportedModel, scene, model, name, matrix, tintColor);
+                LoadModel(exportedModel, scene, model, name, matrix, tintColor, lightmapUvScale: lightmapUvScale);
             }
 
             foreach (var sceneObject in worldNode.AggregateSceneObjects)
@@ -570,9 +583,9 @@ namespace ValveResourceFormat.IO
                     var name = Path.GetFileNameWithoutExtension(renderableModel);
                     var model = (VModel)modelResource.DataBlock!;
 
-                    if (!AggregateCreateFragments(exportedModel, scene, model, sceneObject, name))
+                    if (!AggregateCreateFragments(exportedModel, scene, model, sceneObject, name, lightmapUvScale))
                     {
-                        LoadModel(exportedModel, scene, model, name, Matrix4x4.Identity, Vector4.One);
+                        LoadModel(exportedModel, scene, model, name, Matrix4x4.Identity, Vector4.One, lightmapUvScale: lightmapUvScale);
                     }
                 }
             }
@@ -669,7 +682,8 @@ namespace ValveResourceFormat.IO
         }
 
         private void LoadModel(ModelRoot exportedModel, Scene scene, VModel model, string name,
-            Matrix4x4 transform, Vector4 tintColor, string? skinName = null, EntityLump.Entity? entity = null)
+            Matrix4x4 transform, Vector4 tintColor, string? skinName = null, EntityLump.Entity? entity = null,
+            Vector2? lightmapUvScale = null)
         {
 #if DEBUG
             ProgressReporter?.Report($"Loading model {name}");
@@ -744,7 +758,7 @@ namespace ValveResourceFormat.IO
                 }
 
                 var boneRemapTable = model.GetRemapTable(m.MeshIndex);
-                var node = AddMeshNode(exportedModel, scene, meshName, tintColor, m.Mesh, m.Mesh.VBIB, joints, out var meshNode, boneRemapTable, skinMaterialPath, entity);
+                var node = AddMeshNode(exportedModel, scene, meshName, tintColor, m.Mesh, m.Mesh.VBIB, joints, out var meshNode, boneRemapTable, skinMaterialPath, entity, lightmapUvScale);
                 if (node != null)
                 {
                     node.WorldMatrix = nodeTransform;
@@ -821,7 +835,7 @@ namespace ValveResourceFormat.IO
 
         private Node? AddMeshNode(ModelRoot exportedModel, Scene scene, string name, Vector4 tintColor,
             VMesh mesh, Blocks.VBIB vbib, Node[]? joints, out Node? meshNode, int[]? boneRemapTable = null,
-            string? skinMaterialPath = null, EntityLump.Entity? entity = null)
+            string? skinMaterialPath = null, EntityLump.Entity? entity = null, Vector2? lightmapUvScale = null)
         {
             meshNode = null;
 
@@ -832,15 +846,16 @@ namespace ValveResourceFormat.IO
 
             var newNode = scene.CreateNode(name);
             meshNode = newNode;
-            if (ExportedMeshes.TryGetValue(name, out var exportedMesh))
+            var exportedMeshKey = (name, lightmapUvScale);
+            if (ExportedMeshes.TryGetValue(exportedMeshKey, out var exportedMesh))
             {
                 // Make a new node that uses the existing mesh
                 newNode.Mesh = exportedMesh;
                 return newNode;
             }
 
-            exportedMesh = CreateGltfMesh(name, mesh, vbib, exportedModel, boneRemapTable, skinMaterialPath, tintColor);
-            ExportedMeshes.Add(name, exportedMesh);
+            exportedMesh = CreateGltfMesh(name, mesh, vbib, exportedModel, boneRemapTable, skinMaterialPath, tintColor, lightmapUvScale);
+            ExportedMeshes.Add(exportedMeshKey, exportedMesh);
 
             if (entity != null && ExportExtras)
             {


### PR DESCRIPTION
## Description
The glTF exporter doesn't apply `m_vLightmapUvScale` to the lightmap UVs while the renderer applies it in the runtime

Fixes #977


## Reproduction

  ```sh
  Source2Viewer-CLI \
    -i "/path/to/Deadlock/game/citadel/maps/dl_hideout.vpk" \
    -o "exported/" \
    -d \
    -f "maps/dl_hideout.vmap_c" \
    --gltf_export_format gltf
  ```

Deadlock `dl_hideout` (`m_vLightmapUvScale = 1.333313`)

Before: The world lightmap scale is not applied to exported lightmap UVs
After: 
- 449 non-zero world `TEXCOORD_1` channels match the original UVs multiplied by the world scale (maximum error 0)
- 5 entity channels remain unchanged

CS2 `de_dust2` (`m_vLightmapUvScale = 1.14284`)

Before: The world lightmap scale is not applied to exported lightmap UVs
After: 
- 2,585 non-zero world `TEXCOORD_1` (max error 0)
- 19,461 other vertex and index accessor comparisons remain byte-identical