### PR TITLE
Fix Indirect Lighting in SteamVR and Robot Repair

### DIFF
--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -324,7 +324,11 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
 
     // Environment Maps
 #if defined(IBL) && (IBL == 1)
-    vec3 environment = GetEnvironment(mat);
+    #if (S_LIGHTMAP_VERSION_MINOR == 0)
+        vec3 environment = SrgbGammaToLinear(GetEnvironment(mat));
+    #else
+        vec3 environment = GetEnvironment(mat);
+    #endif
 
     lighting.SpecularIndirect = environment
         * GetEnvMapNormalization(mat.IsometricRoughness, mat.AmbientNormal, lighting.DiffuseIndirect);


### PR DESCRIPTION
Fixes indirect lighting in Robot Repair and SteamVR using linear color instead of srgb for the envmaps.

Before:
<img width="1696" height="898" alt="image" src="https://github.com/user-attachments/assets/0c440942-e267-49f1-8302-15c71c9d5c29" />

After:
<img width="1696" height="898" alt="image" src="https://github.com/user-attachments/assets/eb06a0d2-2296-474c-8a44-15f2632d747a" />
