### PR TITLE
Fix exposure adaptation snapping when deltaTime is 0

### DIFF
--- a/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
+++ b/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
@@ -452,10 +452,12 @@ namespace ValveResourceFormat.Renderer.PostProcess
                 adaptRate = -adaptRate;
             }
 
+            // Decide the clamp direction before the deltaTime multiply: a zero-length frame must hold, not snap
+            var adaptingUpward = adaptRate >= 0.0;
             adaptRate *= deltaTime;
 
             var newScalar = MathF.Pow(2, logCurrent + adaptRate);
-            newScalar = adaptRate >= 0.0
+            newScalar = adaptingUpward
                 ? MathF.Min(newScalar, TargetExposure)
                 : MathF.Max(newScalar, TargetExposure);
 

--- a/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
+++ b/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
@@ -452,7 +452,7 @@ namespace ValveResourceFormat.Renderer.PostProcess
                 adaptRate = -adaptRate;
             }
 
-            // Decide the clamp direction before the deltaTime multiply: a zero-length frame must hold, not snap
+            // Decide the clamp direction before the deltaTime multiply
             var adaptingUpward = adaptRate >= 0.0;
             adaptRate *= deltaTime;
 


### PR DESCRIPTION
## Description
`AutoAdjustExposure` decides the overshoot clamp with `adaptRate >= 0.0` after `adaptRate *= deltaTime`

On a zero-length frame a downward rate becomes `-0.0`, which passes `>= 0.0` so the clamp takes `Min(current, target)` and snaps the exposure to the target instantly; the upward case correctly holds
This captures the direction before the multiply, so both directions hold

## Reproduction
CurrentExposure 4.0, target 1.0, deltaTime 0:
Before: exposure snaps to 1.0 in one frame
After: exposure holds 4.0 — symmetric with the upward case (1.0 toward target 4.0), which holds at 1.0 both before and after