### PR TITLE
Match the engine log luminance range in the histogram

### DIFF
--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -906,10 +906,8 @@ public class Renderer
 
         static void Dispatch(Shader shader, RenderTexture texture, int x, int y)
         {
-            var minLuminance = 0.005f / 256.0f;
-            var maxLuminance = 8f; //65_204f;
-            var logMin = MathF.Log2(minLuminance);
-            var logRange = MathF.Log2(maxLuminance) - logMin;
+            var logMin = -8f;
+            var logRange = 13f;
 
             shader.Use();
             shader.SetTexture(0, "inputImage", texture);


### PR DESCRIPTION
## Description
The game builds the exposure histogram over the luminance window [2^-8, 2^5] (log2 min −8, range 13)
The renderer derives its minimum from `0.005 / 256` (−15.64, range 18.64), so bin indices and the decoded average luminance sit in different places than the game's across the whole range

## Reproduction
Captured a live CS2 frame: the histogram build dispatch maps
luminance into its log2 range with the constants −8.0 and 1/13, and the reduce
dispatch decodes the average as `exp2(averageBin / 255 * 13 − 8)`

Before: bin at 180
After: bin 108, and the decode matches the game's expression

## Sanity check 
For a uniform mid-gray 0.18 frame: (log2(0.18) + 8) / 13 × 255 = 108.4, so the game bins it at 108

## Note
Also resolves the `0.005f / 256.0f` vs shader-floor mismatch: with these
anchors the shader's own 0.005 floor lands in bin 6