### PR TITLE
Match the game weight normalization in exposure smoothing

### DIFF
--- a/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
+++ b/Renderer/Renderer/PostProcess/PostProcessRenderer.cs
@@ -417,7 +417,7 @@ namespace ValveResourceFormat.Renderer.PostProcess
                     weightedSum += weight * ExposureHistory[i];
                 }
 
-                clampedScalar = MathF.Min(MathF.Max(weightedSum / weightTotal, min), max);
+                clampedScalar = MathF.Min(MathF.Max(weightedSum * (1.0f / weightTotal), min), max);
             }
 
             if (!float.IsFinite(clampedScalar))


### PR DESCRIPTION
## Description
The exposure history smoothing divides the weighted sum by the accumulated
weight total. The game folds the same weight total (5.0000005 in float — the
scalar sum of the ten weights does not land on exactly 5.0) but then multiplies
by its reciprocal instead of dividing. Doing the same makes the smoothed
exposure scalar match the game's at this step

## Reproduction
Weighted sum 5.0 with a full ten-sample history:
Before: 5.0 / 5.0000005 = 0.99999988
After: 5.0 × (1 / 5.0000005) = 0.99999994, the game's value

## Note
One-ULP-class change but makes the code follow the engine path bit exact