### PR TITLE
Match the game luma weights in GetLuma

### DIFF
--- a/Renderer/Shaders/common/utils.slang
+++ b/Renderer/Shaders/common/utils.slang
@@ -98,9 +98,8 @@ float length_squared(vec4 vector)
 const vec3 gamma = vec3(2.4);
 const vec3 invGamma = vec3(1.0 / gamma);
 
-// The game weighs luminance with these values, not standard Rec.709
 float GetLuma(vec3 Color) {
-	return dot( Color, vec3(0.2125, 0.7154, 0.0721) );
+	return dot( Color, vec3(0.2125, 0.7154, 0.0721) ); // BT.709-1, same as Valve
 }
 
 float LevelsAdjust(float component, vec3 L_BlackWhiteGamma)

--- a/Renderer/Shaders/common/utils.slang
+++ b/Renderer/Shaders/common/utils.slang
@@ -99,7 +99,7 @@ const vec3 gamma = vec3(2.4);
 const vec3 invGamma = vec3(1.0 / gamma);
 
 float GetLuma(vec3 Color) {
-	return dot( Color, vec3(0.2126, 0.7152, 0.0722) );
+	return dot( Color, vec3(0.2125, 0.7154, 0.0721) );
 }
 
 float LevelsAdjust(float component, vec3 L_BlackWhiteGamma)

--- a/Renderer/Shaders/common/utils.slang
+++ b/Renderer/Shaders/common/utils.slang
@@ -98,6 +98,7 @@ float length_squared(vec4 vector)
 const vec3 gamma = vec3(2.4);
 const vec3 invGamma = vec3(1.0 / gamma);
 
+// The game weighs luminance with these values, not standard Rec.709
 float GetLuma(vec3 Color) {
 	return dot( Color, vec3(0.2125, 0.7154, 0.0721) );
 }

--- a/Renderer/Shaders/particle_sprite.frag.slang
+++ b/Renderer/Shaders/particle_sprite.frag.slang
@@ -74,7 +74,6 @@ uniform float uLayerBlend[MAX_TEXTURE_LAYERS];
 #define SPRITECARD_TEXTURE_1D_COLOR_LOOKUP 2
 uniform int uLayerEffectMode[MAX_TEXTURE_LAYERS];
 
-// The mask modes use Rec.601 weights, while the LUMINANCE blend below uses GetLuma.
 const vec3 LUMA_601 = vec3(0.299, 0.587, 0.114);
 
 // A constant table from the reference, indexed by mask mode: .x premultiplies the ramp's source colour by

--- a/Renderer/Shaders/particle_sprite.frag.slang
+++ b/Renderer/Shaders/particle_sprite.frag.slang
@@ -74,7 +74,7 @@ uniform float uLayerBlend[MAX_TEXTURE_LAYERS];
 #define SPRITECARD_TEXTURE_1D_COLOR_LOOKUP 2
 uniform int uLayerEffectMode[MAX_TEXTURE_LAYERS];
 
-// The mask modes use Rec.601 weights, while the LUMINANCE blend below uses Rec.709 (GetLuma).
+// The mask modes use Rec.601 weights, while the LUMINANCE blend below uses GetLuma.
 const vec3 LUMA_601 = vec3(0.299, 0.587, 0.114);
 
 // A constant table from the reference, indexed by mask mode: .x premultiplies the ramp's source colour by


### PR DESCRIPTION
## Description
The game weighs luminance with (0.2125, 0.7154, 0.0721) rather than the Rec.709 constants in [`GetLuma`](https://github.com/ValveResourceFormat/ValveResourceFormat/blob/0bce1e2/Renderer/Shaders/common/utils.slang#L101-L103)

SDK2013 HDR shaders use the same vector
([sample4x4log_ps2x.fxc](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/materialsystem/stdshaders/sample4x4log_ps2x.fxc)),

In CS2 every shipped shader family behind a GetLuma caller (environment, water, character, spritecard, post process, histogram) carries it while the Rec.709 vector does not appear in any shipped CS2 shader

## Note
Affecting all GetLuma callers is intentional per the above. The Rec.601 weights for spritecard mask modes match the game and are unchanged. All 2346 shader variants validate