### PR TITLE
Refactor CI workflow and release packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ permissions:
 
 on:
   push:
+    branches:
+    - master
+    tags:
+    - '*'
     paths-ignore:
     - '.github/*_TEMPLATE/**'
     - 'docs/**'
@@ -18,7 +22,16 @@ on:
     - '*.md'
   workflow_dispatch:
   schedule:
-  - cron: "0 10 1 * *"
+  - cron: "37 10 * * 2"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' && github.ref != 'refs/heads/master' }}
+
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+  SKIP_ANALYSIS: -p:RunAnalyzersDuringBuild=false
+  PUBLISH_ARGS: -p:PublishReadyToRun=${{ github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
 jobs:
   build:
@@ -28,19 +41,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-latest]
+        include:
+        - os: ubuntu-latest
+          coverage: --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
 
     runs-on: ${{ matrix.os }}
-
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-      CI_SKIP_ANALYSIS: true
 
     steps:
     - uses: actions/checkout@v7
     - uses: ./.github/actions/setup-dotnet-cache
 
     - name: Run tests
-      run: dotnet test --project ./Tests/Tests.csproj --configuration Release --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --minimum-expected-tests 400
+      run: dotnet test --project ./Tests/Tests.csproj --configuration Release --minimum-expected-tests 400 ${{ env.SKIP_ANALYSIS }} ${{ matrix.coverage }}
 
 #    - name: Check formatting
 #      if: matrix.os == 'ubuntu-latest'
@@ -48,55 +60,43 @@ jobs:
 
     - name: Pack nupkg
       if: matrix.os == 'ubuntu-latest'
-      run: dotnet pack --configuration Release ValveResourceFormat/ValveResourceFormat.csproj
+      run: dotnet pack --configuration Release ${{ env.SKIP_ANALYSIS }} ValveResourceFormat/ValveResourceFormat.csproj
 
     - name: Pack renderer nupkg
       if: matrix.os == 'ubuntu-latest'
-      run: dotnet pack --configuration Release Renderer/Renderer.csproj
-
-    - name: Publish GUI
-      if: matrix.os == 'windows-latest'
-      run: dotnet publish --configuration Release --self-contained --runtime win-x64 GUI/GUI.csproj
+      run: dotnet pack --configuration Release ${{ env.SKIP_ANALYSIS }} Renderer/Renderer.csproj
 
     - name: Publish CLI (Windows x64)
       if: matrix.os == 'windows-latest'
-      run: dotnet publish --configuration Release --self-contained --runtime win-x64 CLI/CLI.csproj
+      run: dotnet publish --configuration Release --self-contained --runtime win-x64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Publish CLI (Windows arm64)
       if: matrix.os == 'windows-11-arm'
-      run: dotnet publish --configuration Release --self-contained --runtime win-arm64 CLI/CLI.csproj
+      run: dotnet publish --configuration Release --self-contained --runtime win-arm64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Publish CLI (Linux x64)
       if: matrix.os == 'ubuntu-latest'
-      run: dotnet publish --configuration Release --self-contained --runtime linux-x64 CLI/CLI.csproj
+      run: dotnet publish --configuration Release --self-contained --runtime linux-x64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Publish CLI (Linux arm)
-      if: matrix.os == 'ubuntu-latest'
-      run: dotnet publish --configuration Release --self-contained --runtime linux-arm CLI/CLI.csproj
+      if: matrix.os == 'ubuntu-24.04-arm'
+      run: dotnet publish --configuration Release --self-contained --runtime linux-arm ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Publish CLI (Linux arm64)
       if: matrix.os == 'ubuntu-24.04-arm'
-      run: dotnet publish --configuration Release --self-contained --runtime linux-arm64 CLI/CLI.csproj
+      run: dotnet publish --configuration Release --self-contained --runtime linux-arm64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Publish CLI (macOS x64)
       if: matrix.os == 'macos-latest'
-      run: dotnet publish --configuration Release --self-contained --runtime osx-x64 CLI/CLI.csproj
+      run: dotnet publish --configuration Release --self-contained --runtime osx-x64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Publish CLI (macOS arm64)
       if: matrix.os == 'macos-latest'
-      run: dotnet publish --configuration Release --self-contained --runtime osx-arm64 CLI/CLI.csproj
+      run: dotnet publish --configuration Release --self-contained --runtime osx-arm64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} CLI/CLI.csproj
 
     - name: Build misc projects
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-24.04-arm'
       run: dotnet build Misc/MiscVrfProjects.slnx
-
-    - name: Upload GUI
-      uses: actions/upload-artifact@v7
-      if: matrix.os == 'windows-latest'
-      with:
-        #archive: false # https://github.com/oprypin/nightly.link/issues/88
-        name: Source2Viewer
-        path: 'GUI/bin/Release/win-x64/publish/*.exe'
 
     - name: Upload nupkg
       uses: actions/upload-artifact@v7
@@ -141,7 +141,7 @@ jobs:
 
     - name: Upload CLI (Linux arm)
       uses: actions/upload-artifact@v7
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-24.04-arm'
       with:
         name: cli-linux-arm
         path: |
@@ -177,19 +177,35 @@ jobs:
 
     - name: Upload test coverage
       uses: codecov/codecov-action@v7
-      if: github.ref == 'refs/heads/master'
+      if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./TestResults/coverage.cobertura.xml
         fail_ci_if_error: true
         verbose: true
 
+  publish-gui:
+    name: Publish GUI
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v7
+    - uses: ./.github/actions/setup-dotnet-cache
+
+    - name: Publish GUI
+      run: dotnet publish --configuration Release --self-contained --runtime win-x64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} GUI/GUI.csproj
+
+    - name: Upload GUI
+      uses: actions/upload-artifact@v7
+      with:
+        #archive: false # https://github.com/oprypin/nightly.link/issues/88
+        name: Source2Viewer
+        path: 'GUI/bin/Release/win-x64/publish/*.exe'
+        compression-level: 0
+
   analyze:
     name: Analyze (Release)
     runs-on: windows-latest
-
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
     steps:
     - uses: actions/checkout@v7
@@ -201,7 +217,7 @@ jobs:
   release:
     name: Create release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build, analyze]
+    needs: [build, analyze, publish-gui]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,18 +184,18 @@ jobs:
         fail_ci_if_error: true
         verbose: true
 
-  publish-gui:
-    name: Publish GUI
+  source2viewer-rel:
+    name: Source2Viewer (win-x64)
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v7
     - uses: ./.github/actions/setup-dotnet-cache
 
-    - name: Publish GUI
+    - name: Publish
       run: dotnet publish --configuration Release --self-contained --runtime win-x64 ${{ env.SKIP_ANALYSIS }} ${{ env.PUBLISH_ARGS }} GUI/GUI.csproj
 
-    - name: Upload GUI
+    - name: Upload
       uses: actions/upload-artifact@v7
       with:
         #archive: false # https://github.com/oprypin/nightly.link/issues/88
@@ -217,7 +217,7 @@ jobs:
   release:
     name: Create release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build, analyze, publish-gui]
+    needs: [build, analyze, source2viewer-rel]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,14 +204,14 @@ jobs:
         compression-level: 0
 
   analyze:
-    name: Analyze (Release)
+    name: Run all analyzers
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v7
     - uses: ./.github/actions/setup-dotnet-cache
 
-    - name: Run analyzers
+    - name: Build
       run: dotnet build --configuration Release ValveResourceFormat.slnx
 
   release:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,10 +45,6 @@
     <NoWarn>$(NoWarn);CA2000</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Release' AND '$(CI_SKIP_ANALYSIS)' == 'true'">
-    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-  </PropertyGroup>
-
   <ItemGroup>
     <Using Include="System" />
     <Using Include="System.Numerics" />


### PR DESCRIPTION
Tightens GitHub Actions execution by limiting push triggers to master/tags, adding concurrency cancellation for non-release refs, and moving common build flags to workflow env variables. The build matrix now only generates coverage on ubuntu-latest, routes Linux arm publishing and misc builds to the ARM runner. GUI publishing was split into its own job and added as a release dependency so tagged releases consistently include the GUI artifact.