### PR TITLE
Shader feature additions

### DIFF
--- a/Renderer/Renderer/VertexAttributeLocations.cs
+++ b/Renderer/Renderer/VertexAttributeLocations.cs
@@ -70,8 +70,8 @@ namespace ValveResourceFormat.Renderer
         [VertexAttributeName("vTEXCOORD1", Semantic = "TEXCOORD", SemanticIndex = 1)]
         TexCoord1,
 
-        /// <summary>Layer blend weights.</summary>
-        [VertexAttributeName("vTEXCOORD2", Semantic = "TEXCOORD", SemanticIndex = 2)]
+        /// <summary>Layer blend weights, or per vertex subsurface curvature on skin.</summary>
+        [VertexAttributeName("vTEXCOORD2", "flSSSCurvature", Semantic = "TEXCOORD", SemanticIndex = 2)]
         TexCoord2,
 
         /// <summary>Layer parameters, or foliage sway parameters.</summary>

--- a/Renderer/Shaders/common/environment.slang
+++ b/Renderer/Shaders/common/environment.slang
@@ -135,7 +135,17 @@ struct EnvBRDF_t
     vec3 MultiScatter;  // FmsEms, lit by the irradiance rather than the cube map
 };
 
-EnvBRDF_t EnvBRDF(vec3 specColor, float perceptualRoughness, vec3 N, vec3 V)
+// The NDF takes NoH and the visibility takes (NoL, NoV); the ambient case fixes NoL at 1.
+// csgo_character's pixel shader evaluates pow(1 - NoH*NoH, 0.5/alpha) over the half vector and
+// leaves the Neubelt denominator as (1 + NoV) - NoV, which is that substitution written out.
+float EnvBRDFCloth(float perceptualRoughness, vec3 N, vec3 V)
+{
+    float NoV = dot(N, V);
+    float NoH = dot(normalize(N + V), N);
+    return D_Charlie(pow2(perceptualRoughness), NoH) * V_Neubelt(1.0, NoV) * CLOTH_ENERGY_SCALE;
+}
+
+EnvBRDF_t EnvBRDF(vec3 specColor, float perceptualRoughness, vec3 N, vec3 V, float clothMask)
 {
     float NdotV = ClampToPositive(dot(N, V));
     vec4 lut = SampleBrdfLut(perceptualRoughness, NdotV, BRDF_LUT_GGX);
@@ -143,19 +153,26 @@ EnvBRDF_t EnvBRDF(vec3 specColor, float perceptualRoughness, vec3 N, vec3 V)
     EnvBRDF_t brdf;
     brdf.SingleScatter = mix(vec3(lut.x), vec3(lut.y), specColor);
 
+    if (F_CLOTH_SHADING == 1)
+    {
+        // Cloth replaces the split sum lobe before the multiple scattering term feeds off it, and
+        // takes the specular colour the same way the GGX lobe does.
+        brdf.SingleScatter = mix(brdf.SingleScatter, specColor * EnvBRDFCloth(perceptualRoughness, N, V), clothMask);
+    }
+
     // What a single bounce misses, fed back through the average Fresnel of a Schlick lobe.
     float energyMissing = 1.0 - lut.y;
     vec3 averageFresnel = specColor + (vec3(1.0) - specColor) * (1.0 / 21.0);
 
     brdf.MultiScatter = ((brdf.SingleScatter * averageFresnel) / (vec3(1.0) - averageFresnel * energyMissing)) * energyMissing;
-    return brdf;
-}
 
-float EnvBRDFCloth(float perceptualRoughness, vec3 N, vec3 V)
-{
-    float NoV = dot(N, V);
-    float NoH = dot(normalize(N + V), N);
-    return D_Charlie(pow2(perceptualRoughness), NoV) * V_Neubelt(NoH, NoH);
+    if (F_CLOTH_SHADING == 1)
+    {
+        // Cloth takes no multiple scattering.
+        brdf.MultiScatter *= 1.0 - clothMask;
+    }
+
+    return brdf;
 }
 
 // In CS2, anisotropic cubemaps are default enabled with aniso gloss
@@ -195,13 +212,9 @@ vec3 GetEnvironmentNoBRDF(MaterialProperties_t mat, float reflectionCorrectionAm
         mat.IsometricRoughness = 0.0;
     }
 
+    // No cloth remap here: csgo_character's cloth mask never reaches the roughness or the env map
+    // LOD, only the BRDF lobes.
     float perceptualRoughness = saturate(mat.IsometricRoughness);
-
-    
-    if (F_CLOTH_SHADING == 1)
-    {
-        perceptualRoughness = mix(perceptualRoughness, sqrt(perceptualRoughness), mat.ClothMask);
-    }
 
     // Reflection Vector
     vec3 R = normalize(reflect(-mat.ViewDir, reflectionNormal));
@@ -323,12 +336,7 @@ vec3 GetEnvironment(MaterialProperties_t mat, float reflectionCorrectionAmount)
         return envMap;
     }
 
-    vec3 brdf = EnvBRDF(mat.SpecularColor, mat.IsometricRoughness, mat.AmbientNormal, mat.ViewDir).SingleScatter;
-    if (F_CLOTH_SHADING == 1)
-    {
-        vec3 clothBrdf = vec3(EnvBRDFCloth(mat.IsometricRoughness, mat.AmbientNormal, mat.ViewDir));
-        brdf = mix(brdf, clothBrdf, mat.ClothMask);
-    }
+    vec3 brdf = EnvBRDF(mat.SpecularColor, mat.IsometricRoughness, mat.AmbientNormal, mat.ViewDir, mat.ClothMask).SingleScatter;
 
     return brdf * envMap;
 }

--- a/Renderer/Shaders/common/environment.slang
+++ b/Renderer/Shaders/common/environment.slang
@@ -135,9 +135,6 @@ struct EnvBRDF_t
     vec3 MultiScatter;  // FmsEms, lit by the irradiance rather than the cube map
 };
 
-// The NDF takes NoH and the visibility takes (NoL, NoV); the ambient case fixes NoL at 1.
-// csgo_character's pixel shader evaluates pow(1 - NoH*NoH, 0.5/alpha) over the half vector and
-// leaves the Neubelt denominator as (1 + NoV) - NoV, which is that substitution written out.
 float EnvBRDFCloth(float perceptualRoughness, vec3 N, vec3 V)
 {
     float NoV = dot(N, V);
@@ -155,8 +152,6 @@ EnvBRDF_t EnvBRDF(vec3 specColor, float perceptualRoughness, vec3 N, vec3 V, flo
 
     if (F_CLOTH_SHADING == 1)
     {
-        // Cloth replaces the split sum lobe before the multiple scattering term feeds off it, and
-        // takes the specular colour the same way the GGX lobe does.
         brdf.SingleScatter = mix(brdf.SingleScatter, specColor * EnvBRDFCloth(perceptualRoughness, N, V), clothMask);
     }
 
@@ -168,7 +163,6 @@ EnvBRDF_t EnvBRDF(vec3 specColor, float perceptualRoughness, vec3 N, vec3 V, flo
 
     if (F_CLOTH_SHADING == 1)
     {
-        // Cloth takes no multiple scattering.
         brdf.MultiScatter *= 1.0 - clothMask;
     }
 
@@ -212,8 +206,6 @@ vec3 GetEnvironmentNoBRDF(MaterialProperties_t mat, float reflectionCorrectionAm
         mat.IsometricRoughness = 0.0;
     }
 
-    // No cloth remap here: csgo_character's cloth mask never reaches the roughness or the env map
-    // LOD, only the BRDF lobes.
     float perceptualRoughness = saturate(mat.IsometricRoughness);
 
     // Reflection Vector

--- a/Renderer/Shaders/common/environment.slang
+++ b/Renderer/Shaders/common/environment.slang
@@ -170,7 +170,7 @@ EnvBRDF_t EnvBRDF(vec3 specColor, float perceptualRoughness, vec3 N, vec3 V, flo
 }
 
 // In CS2, anisotropic cubemaps are default enabled with aniso gloss
-#if (defined(ANISO_ROUGHNESS) && ((F_SPECULAR_CUBE_MAP_ANISOTROPIC_WARP == 1) || (GameVfx_vr_complex == 0)))
+#if (defined(ANISO_ROUGHNESS) && ((F_SPECULAR_CUBE_MAP_ANISOTROPIC_WARP == 1) || !anisoCubemapWarpOptional))
     vec3 CalculateAnisoCubemapWarpVector(MaterialProperties_t mat)
     {
         // is this like part of the material struct in the og code? it's calculated at the start
@@ -194,7 +194,7 @@ vec3 GetCorrectedSampleCoords(vec3 R, mat4x3 envMapWorldToLocal, vec3 envMapLoca
 
 vec3 GetEnvironmentNoBRDF(MaterialProperties_t mat, float reflectionCorrectionAmount)
 {
-    #if (defined(ANISO_ROUGHNESS) && ((F_SPECULAR_CUBE_MAP_ANISOTROPIC_WARP == 1) || (GameVfx_vr_complex == 0)))
+    #if (defined(ANISO_ROUGHNESS) && ((F_SPECULAR_CUBE_MAP_ANISOTROPIC_WARP == 1) || !anisoCubemapWarpOptional))
         vec3 reflectionNormal = CalculateAnisoCubemapWarpVector(mat);
     #else
         vec3 reflectionNormal = mat.AmbientNormal;

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -273,7 +273,7 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, Mate
         // overhead and pushed up where it grazes, which spreads an otherwise flat lightmap texel
         // across the normal map. Curvature is how fast the geometric normal turns per world unit,
         // so the tipping fades out over anything visibly curved and leaves silhouettes alone.
-        float flCurvature = length(fwidth(mat.GeometricNormal)) / length(fwidth(mat.PositionWS));
+        float flCurvature = GetCurvature(mat.GeometricNormal, mat.PositionWS);
         float flFlatness = smoothstep(0.1, 0.01, flCurvature) * 0.8;
         float flZScale = mix(1.0, mix(0.1, 2.0, saturate((1.0 - cosTheta) * 1.5)), flFlatness);
 

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -253,10 +253,12 @@ void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialPrope
 uniform float g_flDirectionalLightmapStrength = 1.0;
 uniform float g_flDirectionalLightmapMinZ = 0.05;
 
-const float colorSpaceMul = 254.0 / 255.0;
+// Read out of csgo_character's pixel shader. Deliberately not 254/255, which is the value the
+// expression here used to be written as.
+const float colorSpaceMul = 0.996190845966339111328125;
 
 // I don't actually understand much of this, but it's Valve's code.
-vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3 normalMap)
+vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, MaterialProperties_t mat)
 {
     if (UseLightmapDirectionality)
     {
@@ -267,12 +269,20 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3
         float sinTheta = dot(vTangentSpaceXY, vTangentSpaceXY);
         float cosTheta = sqrt(1.0 - sinTheta);
 
-        vec3 vTangentSpaceLightVector = normalize(vec3(vTangentSpaceXY, cosTheta));
+        // Flat surfaces get the light vector tipped: Z is pulled down where the light already sits
+        // overhead and pushed up where it grazes, which spreads an otherwise flat lightmap texel
+        // across the normal map. Curvature is how fast the geometric normal turns per world unit,
+        // so the tipping fades out over anything visibly curved and leaves silhouettes alone.
+        float flCurvature = length(fwidth(mat.GeometricNormal)) / length(fwidth(mat.PositionWS));
+        float flFlatness = smoothstep(0.1, 0.01, flCurvature) * 0.8;
+        float flZScale = mix(1.0, mix(0.1, 2.0, saturate((1.0 - cosTheta) * 1.5)), flFlatness);
+
+        vec3 vTangentSpaceLightVector = normalize(vec3(vTangentSpaceXY, cosTheta * flZScale));
 
         float flDirectionality = mix(0.0, irradianceDirection.z, g_flDirectionalLightmapStrength);
         vec3 vNonDirectionalLightmap = irradianceColor * saturate(flDirectionality);
 
-        float NoL = ClampToPositive(dot(vTangentSpaceLightVector, normalMap));
+        float NoL = ClampToPositive(dot(vTangentSpaceLightVector, mat.NormalMap));
         float LightmapZ = max(vTangentSpaceLightVector.z, g_flDirectionalLightmapMinZ);
 
         irradianceColor = (NoL * (irradianceColor - vNonDirectionalLightmap) / LightmapZ) + vNonDirectionalLightmap;
@@ -301,7 +311,7 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
             vec4 vAHDData = texture(g_tDirectionalIrradiance, mat.LightmapUv);
         #endif
 
-        lighting.DiffuseIndirect = ComputeLightmapShading(irradiance, vAHDData, mat.NormalMap);
+        lighting.DiffuseIndirect = ComputeLightmapShading(irradiance, vAHDData, mat);
 
         lighting.SpecularOcclusion = vAHDData.a;
     }
@@ -336,10 +346,18 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
         mat.Roughness = oldRoughness;
     #endif
 
-    EnvBRDF_t envBrdf = EnvBRDF(mat.SpecularColor, mat.IsometricRoughness, mat.AmbientNormal, mat.ViewDir);
+    EnvBRDF_t envBrdf = EnvBRDF(mat.SpecularColor, mat.IsometricRoughness, mat.AmbientNormal, mat.ViewDir, mat.ClothMask);
 
     lighting.SpecularIndirect += envBrdf.MultiScatter * lighting.DiffuseIndirect;
-    lighting.DiffuseIndirect *= ClampToPositive(vec3(1.0) - (envBrdf.SingleScatter + envBrdf.MultiScatter));
+
+    vec3 diffuseEnergy = ClampToPositive(vec3(1.0) - (envBrdf.SingleScatter + envBrdf.MultiScatter));
+
+    if (F_CLOTH_SHADING == 1)
+    {
+        diffuseEnergy = mix(diffuseEnergy, vec3(1.0), mat.ClothMask);
+    }
+
+    lighting.DiffuseIndirect *= diffuseEnergy;
 #endif
 }
 
@@ -383,6 +401,9 @@ LightingTerms_t CalculateLighting(inout MaterialProperties_t mat)
     #endif
 
     CalculateDirectLighting(lighting, mat);
+
+    lighting.SpecularDirect *= GetSpecularEnergyCompensation(mat);
+
     CalculateIndirectLighting(lighting, mat);
 
     return lighting;

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -253,24 +253,23 @@ void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialPrope
 uniform float g_flDirectionalLightmapStrength = 1.0;
 uniform float g_flDirectionalLightmapMinZ = 0.05;
 
-const float colorSpaceMul = 254 / 255;
+const float colorSpaceMul = 254.0 / 255.0;
 
 // I don't actually understand much of this, but it's Valve's code.
 vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3 normalMap)
 {
     if (UseLightmapDirectionality)
     {
-        vec3 vTangentSpaceLightVector = vec3(0.0);
+        vec2 vTangentSpaceXY = UnpackFromColor(irradianceDirection.xy);
 
-        vTangentSpaceLightVector.xy = UnpackFromColor(irradianceDirection.xy);
+        vTangentSpaceXY *= (colorSpaceMul / max(colorSpaceMul, length(vTangentSpaceXY)));
 
-        float sinTheta = dot(vTangentSpaceLightVector.xy, vTangentSpaceLightVector.xy);
+        float sinTheta = dot(vTangentSpaceXY, vTangentSpaceXY);
         float cosTheta = sqrt(1.0 - sinTheta);
 
-        vTangentSpaceLightVector *= (colorSpaceMul / max(colorSpaceMul, length(vTangentSpaceLightVector.xy)));
-        vTangentSpaceLightVector.z = cosTheta;
+        vec3 vTangentSpaceLightVector = normalize(vec3(vTangentSpaceXY, cosTheta));
 
-        float flDirectionality = mix(0, irradianceDirection.z, g_flDirectionalLightmapStrength);
+        float flDirectionality = mix(0.0, irradianceDirection.z, g_flDirectionalLightmapStrength);
         vec3 vNonDirectionalLightmap = irradianceColor * saturate(flDirectionality);
 
         float NoL = ClampToPositive(dot(vTangentSpaceLightVector, normalMap));

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -253,7 +253,8 @@ void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialPrope
 uniform float g_flDirectionalLightmapStrength = 1.0;
 uniform float g_flDirectionalLightmapMinZ = 0.05;
 
-const float colorSpaceMul = 0.996190845966339111328125;
+const float LIGHTMAP_DIRECTION_MIN_Z = 0.0872; // sin(5 degrees)
+const float LIGHTMAP_DIRECTION_MAX_XY = sqrt(1.0 - LIGHTMAP_DIRECTION_MIN_Z * LIGHTMAP_DIRECTION_MIN_Z);
 
 // I don't actually understand much of this, but it's Valve's code.
 vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, MaterialProperties_t mat)
@@ -262,7 +263,7 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, Mate
     {
         vec2 vTangentSpaceXY = UnpackFromColor(irradianceDirection.xy);
 
-        vTangentSpaceXY *= (colorSpaceMul / max(colorSpaceMul, length(vTangentSpaceXY)));
+        vTangentSpaceXY *= (LIGHTMAP_DIRECTION_MAX_XY / max(LIGHTMAP_DIRECTION_MAX_XY, length(vTangentSpaceXY)));
 
         float sinTheta = dot(vTangentSpaceXY, vTangentSpaceXY);
         float cosTheta = sqrt(1.0 - sinTheta);

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -253,8 +253,6 @@ void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialPrope
 uniform float g_flDirectionalLightmapStrength = 1.0;
 uniform float g_flDirectionalLightmapMinZ = 0.05;
 
-// Read out of csgo_character's pixel shader. Deliberately not 254/255, which is the value the
-// expression here used to be written as.
 const float colorSpaceMul = 0.996190845966339111328125;
 
 // I don't actually understand much of this, but it's Valve's code.
@@ -269,10 +267,6 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, Mate
         float sinTheta = dot(vTangentSpaceXY, vTangentSpaceXY);
         float cosTheta = sqrt(1.0 - sinTheta);
 
-        // Flat surfaces get the light vector tipped: Z is pulled down where the light already sits
-        // overhead and pushed up where it grazes, which spreads an otherwise flat lightmap texel
-        // across the normal map. Curvature is how fast the geometric normal turns per world unit,
-        // so the tipping fades out over anything visibly curved and leaves silhouettes alone.
         float flCurvature = GetCurvature(mat.GeometricNormal, mat.PositionWS);
         float flFlatness = smoothstep(0.1, 0.01, flCurvature) * 0.8;
         float flZScale = mix(1.0, mix(0.1, 2.0, saturate((1.0 - cosTheta) * 1.5)), flFlatness);

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -103,6 +103,14 @@ vec3 GetRetroReflectiveNormal(float retroReflectivity, vec3 L, vec3 V, vec3 N, v
 }
 
 uniform int F_CLOTH_SHADING; // csgo_character, csgo_complex, csgo_customglove, csgo_textile_layer, vr_complex
+uniform int F_SUBSURFACE_SCATTERING; // csgo_character, vr_skin
+
+// Preintegrated skin. Indexed by NdotL across and curvature down, storing a signed correction to the
+// diffuse term rather than the term itself. Authored per material (TextureDiffuseFalloff, suffix
+// "diffusewarp"), not engine supplied - CS2 ships one for skin and others for fleece and cake icing.
+uniform sampler2D g_tDiffuseFalloff; // SrgbRead(true)
+uniform vec3 g_vNormalSoftness = vec3(0.0);
+uniform float g_flCurvatureScale = 1.0;
 
 // BRDF. Layer 1 is the GGX split sum, layer 2 the sheen directional albedo; layer 0 is unused.
 uniform sampler2DArray g_tBRDFLookup; // reserved
@@ -233,14 +241,57 @@ vec3 GetSpecularEnergyCompensation(MaterialProperties_t mat)
     return vCompensation;
 }
 
+// Preintegrated skin, evaluated per light. Light that enters the surface and leaves somewhere else is
+// approximated two ways at once: the shading normal is softened per channel, so red - which scatters
+// furthest - is lit by the flattest normal, and the falloff table adds back the light that wraps past
+// the terminator. Both the scatter amount and the table's NdotL axis are read against the soft
+// normal, not the shading normal.
+vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffuseLight)
+{
+    // Onto the table's V axis. Both constants are read straight out of csgo_character; they work out
+    // to a curvature range of roughly [0.025, 2.54], and are not a half texel inset of the 512 tall
+    // table, so do not "correct" them to one.
+    float flCurvature = (GetCurvature(mat.GeometricNormal, mat.PositionWS) * g_flCurvatureScale) * 0.3976777493953704833984375 - 0.0101010091602802276611328125;
+
+    // The soft end of the blend is the same normal map with its bitangent term negated, so raising
+    // softness flattens the normal along the bitangent rather than fading toward the geometric
+    // normal. That is what csgo_character blends toward - it builds the vector from the one
+    // g_tNormal sample twice, differing only in the sign of tangent space Y.
+    vec3 vSoftNormal = normalize(mat.Tangent * mat.NormalMap.x - mat.Bitangent * mat.NormalMap.y + mat.GeometricNormal * mat.NormalMap.z);
+
+    float flSoftNoL = dot(vSoftNormal, lightVector);
+
+    // Facing away from the light the shading normal is given up entirely, which is what rounds off
+    // the terminator; facing into it, each channel keeps whatever softness the material asked for.
+    vec3 vScatter = saturate(vec3(1.0) - vec3(flSoftNoL));
+    vScatter *= vScatter;
+
+    vec3 vChannelNoL;
+
+    for (int i = 0; i < 3; i++)
+    {
+        vec3 vChannelNormal = normalize(mix(mat.Normal, vSoftNormal, mix(g_vNormalSoftness[i], 1.0, vScatter[i])));
+        vChannelNoL[i] = saturate(dot(vChannelNormal, lightVector));
+    }
+
+    vec3 vFalloff = textureLod(g_tDiffuseFalloff, vec2(flSoftNoL * 0.5 + 0.5, flCurvature), 0.0).rgb * 0.5 - 0.25;
+
+    return mix(diffuseLight, saturate(vChannelNoL + vFalloff), mat.SSSMask);
+}
+
 // Calculate PBR shading for a light
 void CalculateShading(inout LightingTerms_t lighting, vec3 lightVector, vec3 lightColor, MaterialProperties_t mat)
 {
 #if defined(S_DIFFUSE_WRAP)
     vec3 diffuseLight = diffuseWrapped(mat.Normal, lightVector);
 #else
-    float diffuseLight = ClampToPositive(dot(mat.Normal, lightVector));
+    vec3 diffuseLight = vec3(ClampToPositive(dot(mat.Normal, lightVector)));
 #endif
+
+    if (F_SUBSURFACE_SCATTERING == 1)
+    {
+        diffuseLight = GetSubsurfaceDiffuse(mat, lightVector, diffuseLight);
+    }
 
     float sheenAlbedoScaling = GetSheenAlbedoScaling(mat, lightVector);
     diffuseLight *= sheenAlbedoScaling;

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -105,9 +105,6 @@ vec3 GetRetroReflectiveNormal(float retroReflectivity, vec3 L, vec3 V, vec3 N, v
 uniform int F_CLOTH_SHADING; // csgo_character, csgo_complex, csgo_customglove, csgo_textile_layer, vr_complex
 uniform int F_SUBSURFACE_SCATTERING; // csgo_character, vr_skin
 
-// Preintegrated skin. Indexed by NdotL across and curvature down, storing a signed correction to the
-// diffuse term rather than the term itself. Authored per material (TextureDiffuseFalloff, suffix
-// "diffusewarp"), not engine supplied - CS2 ships one for skin and others for fleece and cake icing.
 uniform sampler2D g_tDiffuseFalloff; // SrgbRead(true)
 uniform vec3 g_vNormalSoftness = vec3(0.0);
 uniform float g_flCurvatureScale = 1.0;
@@ -129,23 +126,16 @@ vec4 SampleBrdfLut(float roughness, float NdotV, float layer)
 float D_Charlie(float roughness, float NoH)
 {
     float invRough = 1.0 / roughness;
-    // csgo_character leaves the base unclamped. The 2^-7 floor is kept: it stops the pow running at
-    // exactly zero with an exponent that reaches into the thousands as roughness approaches its own
-    // minimum, and only moves the result where the lobe has already fallen to nothing.
     return (invRough + 2.0) * pow(max(1.0 - pow2(NoH), 0.0078125), invRough * 0.5) / TAU;
 }
 
 // Clamped to 1 (Filament, Deadlock). Unclamped it runs away to ~65000
-// where NoL and NoV both approach zero. csgo_character instead biases NoV by +0.001; this guard is
-// kept because it bounds the same blow-up without pushing NoV off its true value.
+// where NoL and NoV both approach zero.
 float V_Neubelt(float NoL, float NoV)
 {
     return saturate(1.0 / max(4.0 * (NoL + NoV - NoL * NoV), 0.00001532));
 }
 
-// csgo_character folds D_Charlie * V_Neubelt down to a single 1/8. D_Charlie's 1/TAU and
-// V_Neubelt's 1/4 above come to 1/(8*PI) against that, so the cloth lobe scales by PI to land on
-// Valve's constant. The sheen lobe keeps Filament's normalisation and is not scaled.
 #define CLOTH_ENERGY_SCALE PI
 
 // Still pass normal due to some effects modifying normal per light
@@ -181,8 +171,6 @@ vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat, f
     {
         float ClothNDF = D_Charlie(roughness, NoH);
         float ClothVis = V_Neubelt(NoL, NoV);
-        // NoL twice on purpose: the cloth lobe carries one inside the blend and the shared multiply
-        // below applies another. Both of csgo_character's light loops emit it that way.
         ndfVis = mix(ndfVis, ClothNDF * ClothVis * CLOTH_ENERGY_SCALE * NoL, mat.ClothMask);
     }
 
@@ -222,10 +210,6 @@ float GetSheenAlbedoScaling(MaterialProperties_t mat, vec3 lightVector)
     return ClampToPositive(1.0 - sheenMax * directionalAlbedo);
 }
 
-// What a single GGX bounce loses to multiple scattering, put back on the direct specular. Estimated
-// from roughness and NoV rather than read out of the table, so it costs nothing to evaluate; it runs
-// once over the accumulated direct specular rather than per light. Cloth has no GGX lobe to
-// compensate, so the mask takes it back to 1.
 vec3 GetSpecularEnergyCompensation(MaterialProperties_t mat)
 {
     float flRoughnessSum = mat.Roughness.x + mat.Roughness.y;
@@ -241,28 +225,14 @@ vec3 GetSpecularEnergyCompensation(MaterialProperties_t mat)
     return vCompensation;
 }
 
-// Preintegrated skin, evaluated per light. Light that enters the surface and leaves somewhere else is
-// approximated two ways at once: the shading normal is softened per channel, so red - which scatters
-// furthest - is lit by the flattest normal, and the falloff table adds back the light that wraps past
-// the terminator. Both the scatter amount and the table's NdotL axis are read against the soft
-// normal, not the shading normal.
 vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffuseLight)
 {
-    // Onto the table's V axis. Both constants are read straight out of csgo_character; they work out
-    // to a curvature range of roughly [0.025, 2.54], and are not a half texel inset of the 512 tall
-    // table, so do not "correct" them to one.
     float flCurvature = (GetCurvature(mat.GeometricNormal, mat.PositionWS) * g_flCurvatureScale) * 0.3976777493953704833984375 - 0.0101010091602802276611328125;
 
-    // The soft end of the blend is the same normal map with its bitangent term negated, so raising
-    // softness flattens the normal along the bitangent rather than fading toward the geometric
-    // normal. That is what csgo_character blends toward - it builds the vector from the one
-    // g_tNormal sample twice, differing only in the sign of tangent space Y.
     vec3 vSoftNormal = normalize(mat.Tangent * mat.NormalMap.x - mat.Bitangent * mat.NormalMap.y + mat.GeometricNormal * mat.NormalMap.z);
 
     float flSoftNoL = dot(vSoftNormal, lightVector);
 
-    // Facing away from the light the shading normal is given up entirely, which is what rounds off
-    // the terminator; facing into it, each channel keeps whatever softness the material asked for.
     vec3 vScatter = saturate(vec3(1.0) - vec3(flSoftNoL));
     vScatter *= vScatter;
 

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -121,15 +121,24 @@ vec4 SampleBrdfLut(float roughness, float NdotV, float layer)
 float D_Charlie(float roughness, float NoH)
 {
     float invRough = 1.0 / roughness;
+    // csgo_character leaves the base unclamped. The 2^-7 floor is kept: it stops the pow running at
+    // exactly zero with an exponent that reaches into the thousands as roughness approaches its own
+    // minimum, and only moves the result where the lobe has already fallen to nothing.
     return (invRough + 2.0) * pow(max(1.0 - pow2(NoH), 0.0078125), invRough * 0.5) / TAU;
 }
 
 // Clamped to 1 (Filament, Deadlock). Unclamped it runs away to ~65000
-// where NoL and NoV both approach zero.
+// where NoL and NoV both approach zero. csgo_character instead biases NoV by +0.001; this guard is
+// kept because it bounds the same blow-up without pushing NoV off its true value.
 float V_Neubelt(float NoL, float NoV)
 {
     return saturate(1.0 / max(4.0 * (NoL + NoV - NoL * NoV), 0.00001532));
 }
+
+// csgo_character folds D_Charlie * V_Neubelt down to a single 1/8. D_Charlie's 1/TAU and
+// V_Neubelt's 1/4 above come to 1/(8*PI) against that, so the cloth lobe scales by PI to land on
+// Valve's constant. The sheen lobe keeps Filament's normalisation and is not scaled.
+#define CLOTH_ENERGY_SCALE PI
 
 // Still pass normal due to some effects modifying normal per light
 vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat, float sheenAlbedoScaling)
@@ -164,7 +173,9 @@ vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat, f
     {
         float ClothNDF = D_Charlie(roughness, NoH);
         float ClothVis = V_Neubelt(NoL, NoV);
-        ndfVis = mix(ndfVis, ClothNDF * ClothVis, mat.ClothMask);
+        // NoL twice on purpose: the cloth lobe carries one inside the blend and the shared multiply
+        // below applies another. Both of csgo_character's light loops emit it that way.
+        ndfVis = mix(ndfVis, ClothNDF * ClothVis * CLOTH_ENERGY_SCALE * NoL, mat.ClothMask);
     }
 
     // Sheen is a second lobe over the top, with its own colour and roughness, rather than a
@@ -201,6 +212,25 @@ float GetSheenAlbedoScaling(MaterialProperties_t mat, vec3 lightVector)
 
     float sheenMax = max(mat.SheenColor.x, max(mat.SheenColor.y, mat.SheenColor.z));
     return ClampToPositive(1.0 - sheenMax * directionalAlbedo);
+}
+
+// What a single GGX bounce loses to multiple scattering, put back on the direct specular. Estimated
+// from roughness and NoV rather than read out of the table, so it costs nothing to evaluate; it runs
+// once over the accumulated direct specular rather than per light. Cloth has no GGX lobe to
+// compensate, so the mask takes it back to 1.
+vec3 GetSpecularEnergyCompensation(MaterialProperties_t mat)
+{
+    float flRoughnessSum = mat.Roughness.x + mat.Roughness.y;
+    float flBoost = 0.125 * pow2(pow2(flRoughnessSum)) * saturate(dot(mat.AmbientNormal, mat.ViewDir));
+
+    vec3 vCompensation = vec3(1.0) + mat.SpecularColor * flBoost;
+
+    if (F_CLOTH_SHADING == 1)
+    {
+        vCompensation = mix(vCompensation, vec3(1.0), mat.ClothMask);
+    }
+
+    return vCompensation;
 }
 
 // Calculate PBR shading for a light

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -7,6 +7,7 @@
 #include "utils.slang"
 #include "texturing.slang"
 #include "lighting_common.slang"
+#include "shadowmapping.slang"
 
 // DIFFUSE LIGHTING
 
@@ -104,7 +105,7 @@ vec3 GetRetroReflectiveNormal(float retroReflectivity, vec3 L, vec3 V, vec3 N, v
 
 uniform int F_CLOTH_SHADING; // csgo_character, csgo_complex, csgo_customglove, csgo_textile_layer, vr_complex
 
-#if (GameVfx_vr_skin != 0)
+#if (secondSpecularLobe)
     uniform float g_flSecondSpecularLobeGlossiness = 0.423;
     uniform float g_flSecondSpecularLobeRatio = 0.021;
 #endif
@@ -112,7 +113,7 @@ uniform int F_CLOTH_SHADING; // csgo_character, csgo_complex, csgo_customglove, 
     uniform sampler2D g_tDiffuseFalloff; // SrgbRead(true)
     uniform float g_flCurvatureScale = 1.0;
 
-    #if (GameVfx_vr_skin != 0)
+    #if (subsurfaceSkin)
         uniform vec3 g_vAmbientNormalSoftness = vec3(0.0);
         #define NORMAL_SOFTNESS g_vAmbientNormalSoftness
     #else
@@ -179,7 +180,7 @@ vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat, f
 	vec3 F = F_Schlick(VoH, mat.SpecularColor);
     float ndfVis = NDF * Vis;
 
-#if (GameVfx_vr_skin != 0)
+#if (secondSpecularLobe)
     float flSecondPerceptualRoughness = mat.IsometricRoughness * g_flSecondSpecularLobeGlossiness;
     float flSecondRoughness = max(pow2(flSecondPerceptualRoughness), MIN_GGX_ALPHA);
     float flSecondNdfVis = D_GGX(NoH, flSecondRoughness) * G_SchlickSmithGGX(NoL, NoV, flSecondPerceptualRoughness);
@@ -246,11 +247,11 @@ vec3 GetSpecularEnergyCompensation(MaterialProperties_t mat)
 }
 
 #if (subsurface)
-const float SSS_CURVATURE_RADIUS_MAX = 39.37; // 1m
-const float SSS_CURVATURE_RADIUS_MIN = 0.3937; // 1cm
+const float SSS_CURVATURE_RADIUS_MIN_METRES = 0.01;
+const float SSS_CURVATURE_RADIUS_MAX_METRES = 1.0;
 
-const float SSS_CURVATURE_MIN = 1.0 / SSS_CURVATURE_RADIUS_MAX;
-const float SSS_CURVATURE_MAX = 1.0 / SSS_CURVATURE_RADIUS_MIN;
+const float SSS_CURVATURE_MIN = INCH_TO_M / SSS_CURVATURE_RADIUS_MAX_METRES;
+const float SSS_CURVATURE_MAX = INCH_TO_M / SSS_CURVATURE_RADIUS_MIN_METRES;
 
 vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffuseLight)
 {
@@ -262,7 +263,7 @@ vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffu
 
     flCurvature = RemapValClamped(flCurvature, SSS_CURVATURE_MIN, SSS_CURVATURE_MAX, 0.0, 1.0);
 
-    #if (GameVfx_vr_skin != 0)
+    #if (subsurfaceSkin)
         vec3 vSoftNormal = mat.SoftNormal;
     #else
         vec3 vSoftNormal = normalize(mat.Tangent * mat.NormalMap.x - mat.Bitangent * mat.NormalMap.y + mat.GeometricNormal * mat.NormalMap.z);
@@ -311,6 +312,13 @@ void CalculateShading(inout LightingTerms_t lighting, vec3 lightVector, vec3 lig
     #if (F_TRANSMISSIVE_BACKFACE_NDOTL == 1)
         float transmissiveLight = ClampToPositive(-dot(mat.Normal, lightVector)); // Light passing through the back face
         lighting.TransmissiveDirect += transmissiveLight * lightColor * mat.TransmissiveColor;
+    #endif
+
+    #if (subsurfaceSkin)
+        float flTransmissionWrap = saturate(0.5 - 0.5 * dot(mat.GeometricNormal, lightVector));
+        float flTransmissionDepth = CalculateSunShadowThickness(mat.PositionWS) * g_flTransmissionFalloff;
+
+        lighting.TransmissiveDirect += exp(-pow2(flTransmissionDepth)) * flTransmissionWrap * lightColor * mat.TransmissiveColor;
     #endif
 }
 

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -103,11 +103,18 @@ vec3 GetRetroReflectiveNormal(float retroReflectivity, vec3 L, vec3 V, vec3 N, v
 }
 
 uniform int F_CLOTH_SHADING; // csgo_character, csgo_complex, csgo_customglove, csgo_textile_layer, vr_complex
-uniform int F_SUBSURFACE_SCATTERING; // csgo_character, vr_skin
+#if (subsurface)
+    uniform sampler2D g_tDiffuseFalloff; // SrgbRead(true)
+    uniform float g_flCurvatureScale = 1.0;
 
-uniform sampler2D g_tDiffuseFalloff; // SrgbRead(true)
-uniform vec3 g_vNormalSoftness = vec3(0.0);
-uniform float g_flCurvatureScale = 1.0;
+    #if (GameVfx_vr_skin != 0)
+        uniform vec3 g_vAmbientNormalSoftness = vec3(0.0);
+        #define NORMAL_SOFTNESS g_vAmbientNormalSoftness
+    #else
+        uniform vec3 g_vNormalSoftness = vec3(0.0);
+        #define NORMAL_SOFTNESS g_vNormalSoftness
+    #endif
+#endif
 
 // BRDF. Layer 1 is the GGX split sum, layer 2 the sheen directional albedo; layer 0 is unused.
 uniform sampler2DArray g_tBRDFLookup; // reserved
@@ -225,9 +232,22 @@ vec3 GetSpecularEnergyCompensation(MaterialProperties_t mat)
     return vCompensation;
 }
 
+#if (subsurface)
+const float SSS_CURVATURE_RADIUS_MAX = 39.37; // 1m
+const float SSS_CURVATURE_RADIUS_MIN = 0.3937; // 1cm
+
+const float SSS_CURVATURE_MIN = 1.0 / SSS_CURVATURE_RADIUS_MAX;
+const float SSS_CURVATURE_MAX = 1.0 / SSS_CURVATURE_RADIUS_MIN;
+
 vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffuseLight)
 {
-    float flCurvature = (GetCurvature(mat.GeometricNormal, mat.PositionWS) * g_flCurvatureScale) * 0.3976777493953704833984375 - 0.0101010091602802276611328125;
+    #if (F_USE_PER_VERTEX_CURVATURE == 1)
+        float flCurvature = vCurvatureOut * g_flCurvatureScale;
+    #else
+        float flCurvature = GetCurvature(mat.GeometricNormal, mat.PositionWS) * g_flCurvatureScale;
+    #endif
+
+    flCurvature = RemapValClamped(flCurvature, SSS_CURVATURE_MIN, SSS_CURVATURE_MAX, 0.0, 1.0);
 
     vec3 vSoftNormal = normalize(mat.Tangent * mat.NormalMap.x - mat.Bitangent * mat.NormalMap.y + mat.GeometricNormal * mat.NormalMap.z);
 
@@ -240,7 +260,7 @@ vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffu
 
     for (int i = 0; i < 3; i++)
     {
-        vec3 vChannelNormal = normalize(mix(mat.Normal, vSoftNormal, mix(g_vNormalSoftness[i], 1.0, vScatter[i])));
+        vec3 vChannelNormal = normalize(mix(mat.Normal, vSoftNormal, mix(NORMAL_SOFTNESS[i], 1.0, vScatter[i])));
         vChannelNoL[i] = saturate(dot(vChannelNormal, lightVector));
     }
 
@@ -248,6 +268,7 @@ vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffu
 
     return mix(diffuseLight, saturate(vChannelNoL + vFalloff), mat.SSSMask);
 }
+#endif
 
 // Calculate PBR shading for a light
 void CalculateShading(inout LightingTerms_t lighting, vec3 lightVector, vec3 lightColor, MaterialProperties_t mat)
@@ -258,10 +279,9 @@ void CalculateShading(inout LightingTerms_t lighting, vec3 lightVector, vec3 lig
     vec3 diffuseLight = vec3(ClampToPositive(dot(mat.Normal, lightVector)));
 #endif
 
-    if (F_SUBSURFACE_SCATTERING == 1)
-    {
+    #if (subsurface)
         diffuseLight = GetSubsurfaceDiffuse(mat, lightVector, diffuseLight);
-    }
+    #endif
 
     float sheenAlbedoScaling = GetSheenAlbedoScaling(mat, lightVector);
     diffuseLight *= sheenAlbedoScaling;

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -103,6 +103,11 @@ vec3 GetRetroReflectiveNormal(float retroReflectivity, vec3 L, vec3 V, vec3 N, v
 }
 
 uniform int F_CLOTH_SHADING; // csgo_character, csgo_complex, csgo_customglove, csgo_textile_layer, vr_complex
+
+#if (GameVfx_vr_skin != 0)
+    uniform float g_flSecondSpecularLobeGlossiness = 0.423;
+    uniform float g_flSecondSpecularLobeRatio = 0.021;
+#endif
 #if (subsurface)
     uniform sampler2D g_tDiffuseFalloff; // SrgbRead(true)
     uniform float g_flCurvatureScale = 1.0;
@@ -154,7 +159,7 @@ vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat, f
 
     if (F_RETRO_REFLECTIVE == 1)
     {
-        normal = GetRetroReflectiveNormal(mat.ExtraParams.r, lightVector, mat.ViewDir, normal, halfVector);
+        normal = GetRetroReflectiveNormal(mat.RetroReflectivity, lightVector, mat.ViewDir, normal, halfVector);
     }
 
 	float NoH = saturate(dot(normal, halfVector));
@@ -173,6 +178,14 @@ vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat, f
 #endif
 	vec3 F = F_Schlick(VoH, mat.SpecularColor);
     float ndfVis = NDF * Vis;
+
+#if (GameVfx_vr_skin != 0)
+    float flSecondPerceptualRoughness = mat.IsometricRoughness * g_flSecondSpecularLobeGlossiness;
+    float flSecondRoughness = max(pow2(flSecondPerceptualRoughness), MIN_GGX_ALPHA);
+    float flSecondNdfVis = D_GGX(NoH, flSecondRoughness) * G_SchlickSmithGGX(NoL, NoV, flSecondPerceptualRoughness);
+
+    ndfVis = mix(ndfVis, flSecondNdfVis, g_flSecondSpecularLobeRatio);
+#endif
 
     if (F_CLOTH_SHADING == 1)
     {
@@ -249,7 +262,11 @@ vec3 GetSubsurfaceDiffuse(MaterialProperties_t mat, vec3 lightVector, vec3 diffu
 
     flCurvature = RemapValClamped(flCurvature, SSS_CURVATURE_MIN, SSS_CURVATURE_MAX, 0.0, 1.0);
 
-    vec3 vSoftNormal = normalize(mat.Tangent * mat.NormalMap.x - mat.Bitangent * mat.NormalMap.y + mat.GeometricNormal * mat.NormalMap.z);
+    #if (GameVfx_vr_skin != 0)
+        vec3 vSoftNormal = mat.SoftNormal;
+    #else
+        vec3 vSoftNormal = normalize(mat.Tangent * mat.NormalMap.x - mat.Bitangent * mat.NormalMap.y + mat.GeometricNormal * mat.NormalMap.z);
+    #endif
 
     float flSoftNoL = dot(vSoftNormal, lightVector);
 

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -11,7 +11,7 @@
 
 // DIFFUSE LIGHTING
 
-#if (F_DIFFUSE_WRAP == 1) || (GameVfx_vr_xen_foliage != 0)
+#if (diffuseWrap)
 // idea: what if we included individual features in tiny files per feature. they would all be used in #includes
 #define S_DIFFUSE_WRAP
 

--- a/Renderer/Shaders/common/shadowmapping.slang
+++ b/Renderer/Shaders/common/shadowmapping.slang
@@ -68,4 +68,28 @@ float CalculateSunShadowMapVisibility(vec3 vPosition)
     return 1.0;
 }
 
+// Should be a NoCmp depth read; the comparison sampler only answers "is the occluder nearer than this?".
+float CalculateSunShadowThickness(vec3 vPosition)
+{
+    vec4 projCoordsW = g_matWorldToShadow[0] * vec4(vPosition, 1.0);
+    vec3 projCoords = projCoordsW.xyz / projCoordsW.w;
+
+    vec2 shadowCoords = clamp(projCoords.xy * 0.5 + 0.5, vec2(-1), vec2(2));
+    float currentDepth = saturate(projCoords.z) + g_flSunShadowBias;
+
+    const int nThicknessSteps = 4;
+    const float flThicknessStep = 0.002;
+
+    float flThickness = 0.0;
+
+    for (int i = 1; i <= nThicknessSteps; ++i)
+    {
+        float flReference = currentDepth - flThicknessStep * float(i);
+        flThickness += textureGrad(g_tShadowDepthBufferDepth,
+            vec4(shadowCoords, 0.0, flReference), vec2(0.0), vec2(0.0));
+    }
+
+    return flThickness / float(nThicknessSteps);
+}
+
 #endif

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -46,6 +46,7 @@ struct MaterialProperties_t
     float Metalness;
     vec3 Normal;
     vec3 NormalMap;
+    vec3 SoftNormal;
     vec2 Roughness;
     float IsometricRoughness;
     vec2 RoughnessTex;
@@ -53,9 +54,12 @@ struct MaterialProperties_t
     float Height;
     vec3 DiffuseAO; // vec3 because Diffuse AO can be tinted
     float SpecularAO;
-    vec4 ExtraParams;
-    float ClothMask;
+    float RetroReflectivity;
     float SSSMask;
+    float MouthMask;
+    float WaterEdgeBlend;
+    float WaterColumnDepth;
+    float ClothMask;
 
     // Sheen lobe, layered over the specular. Zero roughness disables it.
     vec3 SheenColor;
@@ -94,6 +98,7 @@ void InitProperties(out MaterialProperties_t mat, vec3 GeometricNormal, vec3 Pos
     mat.Metalness = 0.0;
     mat.Normal = vec3(0.0);
     mat.NormalMap = vec3(0, 0, 1);
+    mat.SoftNormal = vec3(0, 0, 1);
 
     mat.Roughness = vec2(0.0);
     mat.IsometricRoughness = 0.0;
@@ -103,9 +108,12 @@ void InitProperties(out MaterialProperties_t mat, vec3 GeometricNormal, vec3 Pos
     mat.DiffuseAO = vec3(1.0);
     mat.SpecularAO = 1.0;
     // r = retro reflectivity, g = misc, b = misc, a = misc/rimmask?
-    mat.ExtraParams = vec4(0.0);
-    mat.ClothMask = 0.0;
+    mat.RetroReflectivity = 0.0;
     mat.SSSMask = 0.0;
+    mat.MouthMask = 0.0;
+    mat.WaterEdgeBlend = 0.0;
+    mat.WaterColumnDepth = 0.0;
+    mat.ClothMask = 0.0;
     mat.SheenColor = vec3(0.0);
     mat.SheenRoughness = 0.0;
 
@@ -450,7 +458,7 @@ bool HandleMaterialRenderModes(inout vec4 outputColor, MaterialProperties_t mat)
             outputColor.rgb = mat.Height.xxx;
             return true;
         case renderMode_ExtraParams:
-            outputColor.rgb = mat.ExtraParams.rgb;
+            outputColor.rgb = vec3(max(mat.RetroReflectivity, mat.WaterEdgeBlend), mat.WaterColumnDepth, mat.SSSMask);
             return true;
         default:
             return false;

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -9,13 +9,12 @@
 #include "utils.slang"
 #include "fullbright.slang"
 
-#if defined(NEED_CURVATURE) && (F_USE_PER_VERTEX_CURVATURE == 0)
-    // Expensive, only used in skin shaders
-    float GetCurvature(vec3 vNormal, vec3 vPositionWS)
-    {
-        return length(fwidth(vNormal)) / length(fwidth(vPositionWS));
-    }
-#endif
+// How fast the geometric normal turns per world unit. Two derivatives, so not free, but it is what
+// both the skin falloff and the lightmap directionality tip key off, and neither can be hoisted.
+float GetCurvature(vec3 vNormal, vec3 vPositionWS)
+{
+    return length(fwidth(vNormal)) / length(fwidth(vPositionWS));
+}
 
 // Geometric roughness. Essentially just Specular Anti-Aliasing
 float CalculateGeometricRoughnessFactor(vec3 geometricNormal)

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -179,9 +179,6 @@ vec3 calculateIridescence(float hueAngle, float intensity)
     }
 }
 
-#if (GameVfx_vr_skin != 0) || (GameVfx_vr_xen_foliage != 0)
-#define DIFFUSE_AO_COLOR_BLEED
-#endif
 
 #if defined(DIFFUSE_AO_COLOR_BLEED)
 
@@ -278,10 +275,9 @@ vec3 calculateWorldNormal(vec3 normalMap, vec3 normal, vec3 tangent, vec3 bitang
 
 #if (F_DETAIL_TEXTURE > 0)
 
-// Xen foliage detail textures always have both color and normal
-#define DETAIL_COLOR_MOD2X (F_DETAIL_TEXTURE == 1) && (GameVfx_vr_xen_foliage == 0)
-#define DETAIL_COLOR_OVERLAY ((F_DETAIL_TEXTURE == 2) || (F_DETAIL_TEXTURE == 4)) || (GameVfx_vr_xen_foliage != 0)
-#define DETAIL_NORMALS ((F_DETAIL_TEXTURE == 3) || (F_DETAIL_TEXTURE == 4)) || (GameVfx_vr_xen_foliage != 0)
+#define DETAIL_COLOR_MOD2X (F_DETAIL_TEXTURE == 1) && !detailAlwaysColorAndNormal
+#define DETAIL_COLOR_OVERLAY ((F_DETAIL_TEXTURE == 2) || (F_DETAIL_TEXTURE == 4)) || detailAlwaysColorAndNormal
+#define DETAIL_NORMALS ((F_DETAIL_TEXTURE == 3) || (F_DETAIL_TEXTURE == 4)) || detailAlwaysColorAndNormal
 
 uniform float g_flDetailBlendFactor = 1.0;
 uniform float g_flDetailBlendToFull = 0.0;
@@ -363,7 +359,7 @@ void applyDetailTexture(inout vec3 Albedo, inout vec3 NormalMap, vec2 detailMask
 #endif
 
 // Cloth Sheen
-#if (GameVfx_csgo_character != 0)
+#if (clothSheen)
 
     uniform float g_flSheenScale = 0.667;
     uniform vec3 g_flSheenTintColor = vec3(1.0);  // SrgbRead(true)

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -9,8 +9,6 @@
 #include "utils.slang"
 #include "fullbright.slang"
 
-// How fast the geometric normal turns per world unit. Two derivatives, so not free, but it is what
-// both the skin falloff and the lightmap directionality tip key off, and neither can be hoisted.
 float GetCurvature(vec3 vNormal, vec3 vPositionWS)
 {
     return length(fwidth(vNormal)) / length(fwidth(vPositionWS));

--- a/Renderer/Shaders/common/utils.slang
+++ b/Renderer/Shaders/common/utils.slang
@@ -7,6 +7,7 @@
 // tau = PI*2
 #define TAU 6.2831853071795864769252867665590
 
+#define INCH_TO_M 0.0254
 
 // clamp(value, 0.0, 1.0)
 float saturate(float val) {

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -154,6 +154,7 @@ uniform sampler2D g_tTintMask;
     uniform sampler2D g_tCombinedMasks;
     uniform vec3 g_vTransmissionColor = vec3(0.74902, 0.231373, 0.011765); // SrgbRead(true)
     uniform float g_flMouthInteriorBrightnessScale = 1.0;
+    uniform float g_flTransmissionFalloff = 1.8;
     uniform float g_flDiffuseNormalBlur = 0.5;
 #endif
 
@@ -162,6 +163,8 @@ uniform sampler2D g_tTintMask;
 #define _colorAlphaMetalness ((defined(simple_vfx_common) || defined(complex_vfx_common)) && (F_METALNESS_TEXTURE == 1))
 #define _colorAlphaAO ((GameVfx_vr_simple != 0) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 0)) || (defined(simple_blend_common) && (F_ENABLE_AMBIENT_OCCLUSION == 1))
 #define subsurface ((F_SUBSURFACE_SCATTERING == 1) || (GameVfx_vr_skin != 0))
+#define subsurfaceSkin (GameVfx_vr_skin != 0)
+#define secondSpecularLobe (GameVfx_vr_skin != 0)
 #define _metalnessTexture (defined(complex_vfx_common) && (F_METALNESS_TEXTURE == 1) && ((F_ALPHA_TEST == 1) || (F_TRANSLUCENT == 1))) || (GameVfx_csgo_weapon != 0) || (GameVfx_csgo_character != 0) || (GameVfx_csgo_vertexlitgeneric != 0)
 #define _ambientOcclusionTexture (((GameVfx_vr_simple != 0) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 1)) || defined(complex_vfx_common) || (GameVfx_csgo_foliage != 0) || (GameVfx_csgo_weapon != 0) || (GameVfx_csgo_character != 0) || defined(csgo_generic_vfx_common) || (GameVfx_csgo_simple_3layer_parallax != 0))
 
@@ -418,7 +421,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
         // r=MouthMask, g=AO, b=selfillum/tint mask, a=SSS/opacity
         vec4 combinedMasks = texture(g_tCombinedMasks, texCoord);
 
-        mat.MouthMask = combinedMasks.x; // Mouth Mask
+        mat.MouthMask = combinedMasks.x;
         mat.AmbientOcclusion = combinedMasks.y;
 
         #if (F_SELF_ILLUM == 1)

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -81,7 +81,7 @@ uniform int F_DECAL_BLEND_MODE; // csgo_character, csgo_complex, csgo_vertexlitg
 #define F_TRANSMISSIVE_BACKFACE_NDOTL 0 // csgo_complex, csgo_foliage, csgo_simple_3layer_parallax, vr_complex
 uniform int F_NO_SPECULAR_AT_FULL_ROUGHNESS; // csgo_lightmappedgeneric, pbr
 // SKIN
-//#define F_SUBSURFACE_SCATTERING 0 // todo: same preintegrated method as vr_skin in HLA; csgo_character
+// F_SUBSURFACE_SCATTERING is a uniform int in pbr.slang, not a define - do not declare it here.
 //#define F_USE_FACE_OCCLUSION_TEXTURE 0 // todo: weird; vr_skin, vr_xen_foliage
 //#define F_USE_PER_VERTEX_CURVATURE 0 // todo; vr_skin, vr_skin_blended
 //#define F_SSS_MASK 0 // todo; vr_skin
@@ -102,6 +102,7 @@ uniform sampler2D g_tBlueNoise; // reserved
 uniform sampler2D g_tColor; // SrgbRead(true) Sampler(UserConfig)
 uniform sampler2D g_tNormal; // Sampler(UserConfig)
 uniform sampler2D g_tTintMask;
+uniform sampler2D g_tSssMask;
 
 #if defined(foliage_vfx_common)
     in vec4 vFoliageParamsOut;
@@ -428,9 +429,10 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
     #endif
 
 #if (GameVfx_csgo_character != 0)
-    #if (F_SUBSURFACE_SCATTERING == 1)
-        //mat.SSSMask = texture(g_tSSSMask, texCoord).g;
-    #endif
+    if (F_SUBSURFACE_SCATTERING == 1)
+    {
+        mat.SSSMask = texture(g_tSssMask, texCoord).g;
+    }
 #endif
 #endif
 

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -81,8 +81,9 @@ uniform int F_DECAL_BLEND_MODE; // csgo_character, csgo_complex, csgo_vertexlitg
 #define F_TRANSMISSIVE_BACKFACE_NDOTL 0 // csgo_complex, csgo_foliage, csgo_simple_3layer_parallax, vr_complex
 uniform int F_NO_SPECULAR_AT_FULL_ROUGHNESS; // csgo_lightmappedgeneric, pbr
 // SKIN
+#define F_SUBSURFACE_SCATTERING 0 // csgo_character, vr_skin
 //#define F_USE_FACE_OCCLUSION_TEXTURE 0 // todo: weird; vr_skin, vr_xen_foliage
-//#define F_USE_PER_VERTEX_CURVATURE 0 // todo; vr_skin, vr_skin_blended
+#define F_USE_PER_VERTEX_CURVATURE 0 // vr_skin, vr_skin_blended
 //#define F_SSS_MASK 0 // todo; vr_skin
 
 //End of feature defines
@@ -95,13 +96,19 @@ in vec3 vBitangentOut;
 in vec2 vTexCoordOut;
 centroid in vec4 vVertexColorOut;
 
+#if (F_USE_PER_VERTEX_CURVATURE == 1)
+    in float vCurvatureOut;
+#endif
+
 out vec4 outputColor;
 
 uniform sampler2D g_tBlueNoise; // reserved
 uniform sampler2D g_tColor; // SrgbRead(true) Sampler(UserConfig)
 uniform sampler2D g_tNormal; // Sampler(UserConfig)
 uniform sampler2D g_tTintMask;
-uniform sampler2D g_tSssMask;
+#if (F_SUBSURFACE_SCATTERING == 1)
+    uniform sampler2D g_tSssMask;
+#endif
 
 #if defined(foliage_vfx_common)
     in vec4 vFoliageParamsOut;
@@ -153,6 +160,7 @@ uniform sampler2D g_tSssMask;
 #define _uniformMetalness (defined(simple_vfx_common) || defined(complex_vfx_common)) && (F_METALNESS_TEXTURE == 0)
 #define _colorAlphaMetalness ((defined(simple_vfx_common) || defined(complex_vfx_common)) && (F_METALNESS_TEXTURE == 1))
 #define _colorAlphaAO ((GameVfx_vr_simple != 0) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 0)) || (defined(simple_blend_common) && (F_ENABLE_AMBIENT_OCCLUSION == 1))
+#define subsurface ((F_SUBSURFACE_SCATTERING == 1) || (GameVfx_vr_skin != 0))
 #define _metalnessTexture (defined(complex_vfx_common) && (F_METALNESS_TEXTURE == 1) && ((F_ALPHA_TEST == 1) || (F_TRANSLUCENT == 1))) || (GameVfx_csgo_weapon != 0) || (GameVfx_csgo_character != 0) || (GameVfx_csgo_vertexlitgeneric != 0)
 #define _ambientOcclusionTexture (((GameVfx_vr_simple != 0) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 1)) || defined(complex_vfx_common) || (GameVfx_csgo_foliage != 0) || (GameVfx_csgo_weapon != 0) || (GameVfx_csgo_character != 0) || defined(csgo_generic_vfx_common) || (GameVfx_csgo_simple_3layer_parallax != 0))
 
@@ -418,20 +426,15 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
             //float flTintMask = combinedMasks.z;
         #endif
 
-        #if (F_SSS_MASK == 1)
-            mat.SSSMask = combinedMasks.a;
-        #endif
+        mat.SSSMask = combinedMasks.a;
 
         #if (translucent) || (alphatest)
             mat.Opacity = combinedMasks.a;
         #endif
     #endif
 
-#if (GameVfx_csgo_character != 0)
-    if (F_SUBSURFACE_SCATTERING == 1)
-    {
-        mat.SSSMask = texture(g_tSssMask, texCoord).g;
-    }
+#if (GameVfx_csgo_character != 0) && (F_SUBSURFACE_SCATTERING == 1)
+    mat.SSSMask = texture(g_tSssMask, texCoord).g;
 #endif
 #endif
 

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -165,6 +165,14 @@ uniform sampler2D g_tTintMask;
 #define subsurface ((F_SUBSURFACE_SCATTERING == 1) || (GameVfx_vr_skin != 0))
 #define subsurfaceSkin (GameVfx_vr_skin != 0)
 #define secondSpecularLobe (GameVfx_vr_skin != 0)
+#define clothSheen (GameVfx_csgo_character != 0)
+#define detailAlwaysColorAndNormal (GameVfx_vr_xen_foliage != 0)
+#define diffuseWrap ((F_DIFFUSE_WRAP == 1) || (GameVfx_vr_xen_foliage != 0))
+#define anisoCubemapWarpOptional (GameVfx_vr_complex != 0)
+
+#if (GameVfx_vr_skin != 0) || (GameVfx_vr_xen_foliage != 0)
+#define DIFFUSE_AO_COLOR_BLEED
+#endif
 #define _metalnessTexture (defined(complex_vfx_common) && (F_METALNESS_TEXTURE == 1) && ((F_ALPHA_TEST == 1) || (F_TRANSLUCENT == 1))) || (GameVfx_csgo_weapon != 0) || (GameVfx_csgo_character != 0) || (GameVfx_csgo_vertexlitgeneric != 0)
 #define _ambientOcclusionTexture (((GameVfx_vr_simple != 0) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 1)) || defined(complex_vfx_common) || (GameVfx_csgo_foliage != 0) || (GameVfx_csgo_weapon != 0) || (GameVfx_csgo_character != 0) || defined(csgo_generic_vfx_common) || (GameVfx_csgo_simple_3layer_parallax != 0))
 

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -84,7 +84,7 @@ uniform int F_NO_SPECULAR_AT_FULL_ROUGHNESS; // csgo_lightmappedgeneric, pbr
 #define F_SUBSURFACE_SCATTERING 0 // csgo_character, vr_skin
 //#define F_USE_FACE_OCCLUSION_TEXTURE 0 // todo: weird; vr_skin, vr_xen_foliage
 #define F_USE_PER_VERTEX_CURVATURE 0 // vr_skin, vr_skin_blended
-//#define F_SSS_MASK 0 // todo; vr_skin
+#define F_SSS_MASK 0 // vr_skin
 
 //End of feature defines
 
@@ -154,6 +154,7 @@ uniform sampler2D g_tTintMask;
     uniform sampler2D g_tCombinedMasks;
     uniform vec3 g_vTransmissionColor = vec3(0.74902, 0.231373, 0.011765); // SrgbRead(true)
     uniform float g_flMouthInteriorBrightnessScale = 1.0;
+    uniform float g_flDiffuseNormalBlur = 0.5;
 #endif
 
 
@@ -417,7 +418,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
         // r=MouthMask, g=AO, b=selfillum/tint mask, a=SSS/opacity
         vec4 combinedMasks = texture(g_tCombinedMasks, texCoord);
 
-        mat.ExtraParams.a = combinedMasks.x; // Mouth Mask
+        mat.MouthMask = combinedMasks.x; // Mouth Mask
         mat.AmbientOcclusion = combinedMasks.y;
 
         #if (F_SELF_ILLUM == 1)
@@ -426,7 +427,11 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
             //float flTintMask = combinedMasks.z;
         #endif
 
-        mat.SSSMask = combinedMasks.a;
+        #if (F_SSS_MASK == 1)
+            mat.SSSMask = combinedMasks.a;
+        #else
+            mat.SSSMask = 1.0;
+        #endif
 
         #if (translucent) || (alphatest)
             mat.Opacity = combinedMasks.a;
@@ -543,6 +548,18 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
 
     mat.Normal = calculateWorldNormal(mat.NormalMap, mat.GeometricNormal, mat.Tangent, mat.Bitangent);
 
+#if (GameVfx_vr_skin != 0)
+    vec2 vNormalTexels = texCoord * vec2(textureSize(g_tNormal, 0));
+    vec2 vNormalDdx = dFdx(vNormalTexels);
+    vec2 vNormalDdy = dFdy(vNormalTexels);
+    float flBlurLod = max(0.5 * log2(max(dot(vNormalDdx, vNormalDdx), dot(vNormalDdy, vNormalDdy))), g_flDiffuseNormalBlur);
+
+    vec3 vBlurredNormalMap = DecodeHemiOctahedronNormal(textureLod(g_tNormal, texCoord, flBlurLod).rg);
+    vec3 vBlurredNormal = calculateWorldNormal(vBlurredNormalMap, mat.GeometricNormal, mat.Tangent, mat.Bitangent);
+
+    mat.SoftNormal = normalize(mix(mat.Normal, vBlurredNormal, mat.SSSMask));
+#endif
+
     // Metalness
 #if (_metalnessTexture)
     // a = rimmask
@@ -551,7 +568,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
     mat.Metalness = metalnessTexture.g;
 
     if (F_RETRO_REFLECTIVE == 1)
-        mat.ExtraParams.x = metalnessTexture.r;
+        mat.RetroReflectivity = metalnessTexture.r;
 
     #if (GameVfx_csgo_character != 0)
         mat.ClothMask = metalnessTexture.b * (1.0 - metalnessTexture.g);
@@ -592,7 +609,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
     #endif
 
 #if (GameVfx_vr_complex != 0) && (F_METALNESS_TEXTURE == 0)
-    mat.ExtraParams.x = F_RETRO_REFLECTIVE == 1 ? g_flRetroReflectivity : 0.0;
+    mat.RetroReflectivity = F_RETRO_REFLECTIVE == 1 ? g_flRetroReflectivity : 0.0;
 #endif
 
 #if (GameVfx_vr_complex != 0)
@@ -642,7 +659,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
     #if (GameVfx_vr_skin != 0)
         mat.TransmissiveColor = g_vTransmissionColor.rgb * color.a;
 
-        float mouthOcclusion = mix(1.0, g_flMouthInteriorBrightnessScale, mat.ExtraParams.a);
+        float mouthOcclusion = mix(1.0, g_flMouthInteriorBrightnessScale, mat.MouthMask);
         mat.TransmissiveColor *= mouthOcclusion;
         mat.AmbientOcclusion *= mouthOcclusion;
     #endif

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -81,7 +81,6 @@ uniform int F_DECAL_BLEND_MODE; // csgo_character, csgo_complex, csgo_vertexlitg
 #define F_TRANSMISSIVE_BACKFACE_NDOTL 0 // csgo_complex, csgo_foliage, csgo_simple_3layer_parallax, vr_complex
 uniform int F_NO_SPECULAR_AT_FULL_ROUGHNESS; // csgo_lightmappedgeneric, pbr
 // SKIN
-// F_SUBSURFACE_SCATTERING is a uniform int in pbr.slang, not a define - do not declare it here.
 //#define F_USE_FACE_OCCLUSION_TEXTURE 0 // todo: weird; vr_skin, vr_xen_foliage
 //#define F_USE_PER_VERTEX_CURVATURE 0 // todo; vr_skin, vr_skin_blended
 //#define F_SSS_MASK 0 // todo; vr_skin

--- a/Renderer/Shaders/complex.vert.slang
+++ b/Renderer/Shaders/complex.vert.slang
@@ -31,7 +31,13 @@ in vec2 vTEXCOORD;
 #define F_TEXTURE_ANIMATION 0 // csgo_complex, csgo_static_overlay, csgo_unlitgeneric, vr_complex, vr_monitor, vr_panorama_hint_ui, vr_simple, vr_standard
 uniform int F_TEXTURE_ANIMATION_MODE; // csgo_complex, csgo_static_overlay, csgo_unlitgeneric, vr_complex, vr_monitor
 #define F_SPHERICAL_PROJECTED_ANISOTROPIC_TANGENTS 0 // csgo_character
+#define F_USE_PER_VERTEX_CURVATURE 0 // vr_skin, vr_skin_blended
 //End of parameter defines
+
+#if (F_USE_PER_VERTEX_CURVATURE == 1)
+    in float flSSSCurvature;
+    out float vCurvatureOut;
+#endif
 
 #if (GameVfx_vr_simple_2way_blend != 0) || (GameVfx_vr_simple_2way_parallax != 0) || (GameVfx_vr_simple_3way_parallax != 0) || (GameVfx_vr_simple_blend_to_triplanar != 0) || (GameVfx_vr_simple_blend_to_xen_membrane != 0)
     #define vr_blend_vfx_common
@@ -334,6 +340,10 @@ void main()
 #endif
 
     vTexCoordOut = GetAnimatedUVs(vTEXCOORD.xy);
+
+#if (F_USE_PER_VERTEX_CURVATURE == 1)
+    vCurvatureOut = flSSSCurvature;
+#endif
 
 #if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1)
     vLightmapUVScaled = vec3(vLightmapUV * g_vLightmapUvScale.xy, 0);

--- a/Renderer/Shaders/water.frag.slang
+++ b/Renderer/Shaders/water.frag.slang
@@ -24,7 +24,7 @@ uniform vec3 g_vLowEndReflectionColor;
 
 uniform float g_flFlowTimeScale;
 
-uniform vec2 TextureFlow;
+uniform vec2 g_vTextureFlow;
 
 uniform float g_flNormalUvScale = 1.0;
 uniform float g_flNormalFlowUvScrollDistance = 1.0;
@@ -35,7 +35,7 @@ uniform float g_flLowEndSurfaceMinimumColor;
 vec3 calculateWorldNormal()
 {
     // If this is a flowmap, this is wrong
-    vec2 offset = TextureFlow.xy * g_flTime * g_flFlowTimeScale;
+    vec2 offset = g_vTextureFlow.xy * g_flTime * g_flFlowTimeScale;
     vec4 textureNormal = texture(g_tNormal, (vFragPosition.xy / g_flNormalUvScale) + offset);
 
     //Reconstruct the bump vector from the map

--- a/Renderer/Shaders/water_csgo.frag.slang
+++ b/Renderer/Shaders/water_csgo.frag.slang
@@ -898,8 +898,8 @@ void main()
     if (g_iRenderMode != 0)
     {
         // for debug vis
-        mat.ExtraParams.r = 1.0 - flEdgeBlend;
-        mat.ExtraParams.g = adjustedWaterColumnDepth;
+        mat.WaterEdgeBlend = 1.0 - flEdgeBlend;
+        mat.WaterColumnDepth = adjustedWaterColumnDepth;
         lighting.SpecularIndirect = finalReflectionColor * returnColorMixFac;
 
         if (!HandleMaterialRenderModes(outputColor, mat)


### PR DESCRIPTION
Fix lightmap directionality.
Match cloth shading with that in CS2.
Implement transmissive and sub-surface scattering, from Half-Life: Alyx skin shader.