### PR TITLE
Remove directional lightmap min-Z floor

### DIFF
--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -251,7 +251,6 @@ void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialPrope
 
 #define UseLightmapDirectionality true
 uniform float g_flDirectionalLightmapStrength = 1.0;
-uniform float g_flDirectionalLightmapMinZ = 0.05;
 
 const float LIGHTMAP_DIRECTION_MIN_Z = 0.0872; // sin(5 degrees)
 const float LIGHTMAP_DIRECTION_MAX_XY = sqrt(1.0 - LIGHTMAP_DIRECTION_MIN_Z * LIGHTMAP_DIRECTION_MIN_Z);
@@ -278,7 +277,7 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, Mate
         vec3 vNonDirectionalLightmap = irradianceColor * saturate(flDirectionality);
 
         float NoL = ClampToPositive(dot(vTangentSpaceLightVector, mat.NormalMap));
-        float LightmapZ = max(vTangentSpaceLightVector.z, g_flDirectionalLightmapMinZ);
+        float LightmapZ = vTangentSpaceLightVector.z;
 
         irradianceColor = (NoL * (irradianceColor - vNonDirectionalLightmap) / LightmapZ) + vNonDirectionalLightmap;
     }


### PR DESCRIPTION
## Description
`ComputeLightmapShading` floors the directional divisor at `g_flDirectionalLightmapMinZ = 0.05`, but the floor can never engage: the XY clamp above it bounds the direction z to at least `LIGHTMAP_DIRECTION_MIN_Z = 0.0872` before the rescale, and `flZScale` stays within [0.28, 1.8] (the flatness weight caps at 0.8), so the renormalized z that reaches the divide never drops below 0.0872

## Reproduction
The game's shipped pixel shaders decode the same block with no floor — in `csgo_lightmappedgeneric`, `csgo_vertexlitgeneric` and `csgo_environment` (shader quality 1, baked lightmap combos) the XY clamp is the only guard on the direction

Before: `float LightmapZ = max(vTangentSpaceLightVector.z, g_flDirectionalLightmapMinZ);`
After: `float LightmapZ = vTangentSpaceLightVector.z;`

## Note
`g_flDirectionalLightmapMinZ` has no other reference, so the uniform is removed together with the clamp