### PR TITLE
Evaluate sound event curves as cubic Hermite

### DIFF
--- a/Renderer/Audio/SoundEventCurve.cs
+++ b/Renderer/Audio/SoundEventCurve.cs
@@ -6,11 +6,40 @@ namespace ValveResourceFormat.Renderer.Audio;
 
 /// <summary>
 /// A piecewise mapping curve from sound event data (e.g. "distance_volume_mapping_curve").
-/// Each point is [x, y, tangent_in, tangent_out, curve_type_left, curve_type_right]; evaluation is linear between points.
+/// Each point is [x, y, tangent_in, tangent_out, curve_type_left, curve_type_right]; evaluation is cubic Hermite between points.
 /// </summary>
 public sealed class SoundEventCurve
 {
-    private readonly (float X, float Y)[] points;
+    private enum CurveTangentType
+    {
+        Linear = 0,
+        Spline = 1,
+        Free = 2,
+        Mirror = 3,
+        Sine = 4,
+    }
+
+    private struct Knot
+    {
+        public float X;
+        public float Y;
+        public float InTangent;
+        public float OutTangent;
+    }
+
+    private readonly record struct AuthoredPoint(
+        Knot Knot,
+        CurveTangentType TypeIn,
+        CurveTangentType TypeOut);
+
+    private const float XEpsilon = 0.0001f;
+    private const float SineSteep = 1.6030499935150146f;
+    private const float SineShallow = 0.04133769869804382f;
+
+    private readonly Knot[] points;
+    private readonly float outputMin;
+    private readonly float outputMax;
+    private readonly bool useLegacyLinearInterpolation;
 
     /// <summary>Gets the largest x value covered by the curve.</summary>
     public float MaxX => points[^1].X;
@@ -22,9 +51,12 @@ public sealed class SoundEventCurve
     /// </summary>
     public bool Attenuates => points[^1].Y < points[0].Y - 0.0001f;
 
-    private SoundEventCurve((float X, float Y)[] points)
+    private SoundEventCurve(Knot[] points, float outputMin, float outputMax, bool useLegacyLinearInterpolation = false)
     {
         this.points = points;
+        this.outputMin = outputMin;
+        this.outputMax = outputMax;
+        this.useLegacyLinearInterpolation = useLegacyLinearInterpolation;
     }
 
     /// <summary>
@@ -33,9 +65,19 @@ public sealed class SoundEventCurve
     /// </summary>
     internal static SoundEventCurve Linear(float x0, float y0, float x1, float y1)
     {
-        return x0 <= x1
-            ? new SoundEventCurve([(x0, y0), (x1, y1)])
-            : new SoundEventCurve([(x1, y1), (x0, y0)]);
+        var input = x0 <= x1
+            ? new List<AuthoredPoint>
+            {
+                new(new Knot { X = x0, Y = y0 }, CurveTangentType.Linear, CurveTangentType.Linear),
+                new(new Knot { X = x1, Y = y1 }, CurveTangentType.Linear, CurveTangentType.Linear),
+            }
+            : new List<AuthoredPoint>
+            {
+                new(new Knot { X = x1, Y = y1 }, CurveTangentType.Linear, CurveTangentType.Linear),
+                new(new Knot { X = x0, Y = y0 }, CurveTangentType.Linear, CurveTangentType.Linear),
+            };
+
+        return Build(input, useLegacyLinearInterpolation: true);
     }
 
     /// <summary>
@@ -57,11 +99,16 @@ public sealed class SoundEventCurve
             kept++;
         }
 
-        var cut = new (float X, float Y)[kept + 1];
+        var cut = new Knot[kept + 1];
         points.AsSpan(0, kept).CopyTo(cut);
-        cut[kept] = (x, 0f);
+        cut[kept] = new Knot { X = x, Y = 0f };
 
-        return new SoundEventCurve(cut);
+        var left = kept - 1;
+        var slope = (cut[kept].Y - cut[left].Y) / (cut[kept].X - cut[left].X);
+        cut[left].OutTangent = slope;
+        cut[kept].InTangent = slope;
+
+        return CreateWithMeasuredBounds(cut, useLegacyLinearInterpolation);
     }
 
     /// <summary>Parses a mapping curve property from sound event data, or returns null when it is missing or empty.</summary>
@@ -81,7 +128,7 @@ public sealed class SoundEventCurve
             return null;
         }
 
-        var points = new List<(float X, float Y)>(array.Count);
+        var points = new List<AuthoredPoint>(array.Count);
 
         // Indexed rather than foreach: enumerating the interface-typed list boxes an enumerator per
         // call, and this runs three times per event constructor during cold soundscape-tree builds
@@ -97,9 +144,20 @@ public sealed class SoundEventCurve
 
             var y = Convert.ToSingle(point[1], CultureInfo.InvariantCulture);
 
-            points.Add((
-                Convert.ToSingle(point[0], CultureInfo.InvariantCulture),
-                decibels ? MathUtils.DecibelsToLinear(y) : y));
+            points.Add(new AuthoredPoint(
+                new Knot
+                {
+                    X = Convert.ToSingle(point[0], CultureInfo.InvariantCulture),
+                    Y = decibels ? MathUtils.DecibelsToLinear(y) : y,
+                    InTangent = point.Count > 2 ? Convert.ToSingle(point[2], CultureInfo.InvariantCulture) : 0f,
+                    OutTangent = point.Count > 3 ? Convert.ToSingle(point[3], CultureInfo.InvariantCulture) : 0f,
+                },
+                decibels || point.Count <= 4
+                    ? CurveTangentType.Linear
+                    : (CurveTangentType)Convert.ToInt32(point[4], CultureInfo.InvariantCulture),
+                decibels || point.Count <= 5
+                    ? CurveTangentType.Linear
+                    : (CurveTangentType)Convert.ToInt32(point[5], CultureInfo.InvariantCulture)));
         }
 
         if (points.Count == 0)
@@ -107,35 +165,266 @@ public sealed class SoundEventCurve
             return null;
         }
 
-        points.Sort(static (a, b) => a.X.CompareTo(b.X));
+        return Build(points, useLegacyLinearInterpolation: decibels);
+    }
 
-        return new SoundEventCurve([.. points]);
+    private static SoundEventCurve Build(List<AuthoredPoint> input, bool useLegacyLinearInterpolation = false)
+    {
+        // Sort indices, keeping authored order between equal X so a later duplicate wins
+        var order = new int[input.Count];
+        for (var i = 0; i < order.Length; i++)
+        {
+            order[i] = i;
+        }
+
+        Array.Sort(order, (a, b) =>
+        {
+            var byX = input[a].Knot.X.CompareTo(input[b].Knot.X);
+            return byX != 0 ? byX : a.CompareTo(b);
+        });
+        var knots = new List<Knot>(input.Count);
+        var types = new List<(CurveTangentType TypeIn, CurveTangentType TypeOut)>(input.Count);
+        var outputMin = input[0].Knot.Y;
+        var outputMax = input[0].Knot.Y;
+        AuthoredPoint? previous = null;
+
+        for (var sortedIndex = 0; sortedIndex < order.Length; sortedIndex++)
+        {
+            var source = input[order[sortedIndex]];
+            if (sortedIndex != 0)
+            {
+                outputMin = BoundsMin(outputMin, source.Knot.Y);
+                outputMax = BoundsMax(outputMax, source.Knot.Y);
+            }
+
+            if (previous is { } previousValue && source.Knot.X == previousValue.Knot.X)
+            {
+                knots[^1] = source.Knot;
+                previous = source;
+                continue;
+            }
+
+            knots.Add(source.Knot);
+            types.Add((source.TypeIn, source.TypeOut));
+            previous = source;
+        }
+
+        var result = knots.ToArray();
+        ResolveTangents(result, types);
+        return new SoundEventCurve(result, outputMin, outputMax, useLegacyLinearInterpolation);
+    }
+
+    private static void ResolveTangents(Knot[] result, List<(CurveTangentType TypeIn, CurveTangentType TypeOut)> types)
+    {
+        if (result.Length == 1)
+        {
+            ResolveSingleKnotTangents(ref result[0], types[0].TypeIn, types[0].TypeOut);
+            return;
+        }
+
+        var nextMin = result[0].X + XEpsilon;
+
+        for (var i = 1; i < result.Length; i++)
+        {
+            result[i].X = MathF.Max(result[i].X, nextMin);
+            nextMin = result[i].X + XEpsilon;
+        }
+
+        for (var i = 0; i < result.Length; i++)
+        {
+            ref var knot = ref result[i];
+            var (typeIn, typeOut) = types[i];
+            var hasPrev = i > 0;
+            var hasNext = i + 1 < result.Length;
+            var prev = hasPrev ? result[i - 1] : default;
+            var next = hasNext ? result[i + 1] : default;
+            var prevSlope = hasPrev ? Slope(prev, knot) : 0f;
+            var nextSlope = hasNext ? Slope(knot, next) : 0f;
+            var span = hasPrev && hasNext ? Slope(prev, next) : (hasPrev ? prevSlope : nextSlope);
+
+            knot.InTangent = typeIn switch
+            {
+                CurveTangentType.Linear => prevSlope,
+                CurveTangentType.Spline => span,
+                CurveTangentType.Mirror => 0f,
+                CurveTangentType.Sine => SineIncoming(
+                    hasPrev ? knot.Y - prev.Y : 0f,
+                    hasPrev ? knot.X - prev.X : 0f),
+                _ => knot.InTangent,
+            };
+
+            knot.OutTangent = typeOut switch
+            {
+                CurveTangentType.Linear => nextSlope,
+                CurveTangentType.Spline => span,
+                CurveTangentType.Mirror => knot.InTangent,
+                CurveTangentType.Sine => SineOutgoing(
+                    hasNext ? next.Y - knot.Y : 0f,
+                    hasNext ? next.X - knot.X : 0f),
+                _ => knot.OutTangent,
+            };
+
+            if (typeIn == CurveTangentType.Mirror)
+            {
+                knot.InTangent = knot.OutTangent;
+            }
+        }
+
+    }
+
+    private static void ResolveSingleKnotTangents(ref Knot knot, CurveTangentType typeIn, CurveTangentType typeOut)
+    {
+        var inTangent = typeIn is CurveTangentType.Linear or CurveTangentType.Spline
+            ? 0f
+            : typeIn == CurveTangentType.Mirror
+                ? 0f
+                : typeIn == CurveTangentType.Sine ? -SineSteep : knot.InTangent;
+        var outTangent = typeOut is CurveTangentType.Linear or CurveTangentType.Spline
+            ? 0f
+            : typeOut == CurveTangentType.Mirror
+                ? inTangent
+                : typeOut == CurveTangentType.Sine ? SineShallow : knot.OutTangent;
+
+        if (typeIn == CurveTangentType.Mirror)
+        {
+            inTangent = outTangent;
+        }
+        knot.InTangent = inTangent;
+        knot.OutTangent = outTangent;
+    }
+
+    private static float Slope(in Knot from, in Knot to)
+    {
+        return (to.Y - from.Y) / (to.X - from.X);
+    }
+
+    private static float SineIncoming(float deltaY, float deltaX)
+    {
+        var value = deltaY > 0f ? -SineShallow : -SineSteep;
+        if (deltaX != 0f)
+        {
+            value = (1f / deltaX) * value;
+        }
+        return value;
+    }
+
+    private static float SineOutgoing(float deltaY, float deltaX)
+    {
+        var value = deltaY <= 0f ? SineShallow : SineSteep;
+        if (deltaX != 0f)
+        {
+            value = (1f / deltaX) * value;
+        }
+        return value;
+    }
+
+    private static float BoundsMin(float accumulator, float candidate)
+        => candidate < accumulator ? candidate : accumulator;
+
+    private static float BoundsMax(float accumulator, float candidate)
+        => candidate > accumulator ? candidate : accumulator;
+
+    private static SoundEventCurve CreateWithMeasuredBounds(Knot[] knots, bool useLegacyLinearInterpolation)
+    {
+        var minimum = knots[0].Y;
+        var maximum = knots[0].Y;
+        for (var i = 1; i < knots.Length; i++)
+        {
+            minimum = BoundsMin(minimum, knots[i].Y);
+            maximum = BoundsMax(maximum, knots[i].Y);
+        }
+        return new SoundEventCurve(knots, minimum, maximum, useLegacyLinearInterpolation);
     }
 
     /// <summary>Evaluates the curve at the given x, clamping to the first and last points.</summary>
     public float Evaluate(float x)
     {
-        if (x <= points[0].X)
+        if (useLegacyLinearInterpolation)
         {
-            return points[0].Y;
-        }
-
-        if (x >= points[^1].X)
-        {
+            if (x <= points[0].X)
+            {
+                return points[0].Y;
+            }
+            if (x >= points[^1].X)
+            {
+                return points[^1].Y;
+            }
+            for (var i = 1; i < points.Length; i++)
+            {
+                if (x <= points[i].X)
+                {
+                    var amount = (x - points[i - 1].X) / (points[i].X - points[i - 1].X);
+                    return float.Lerp(points[i - 1].Y, points[i].Y, amount);
+                }
+            }
             return points[^1].Y;
         }
 
-        for (var i = 1; i < points.Length; i++)
+        if (points.Length == 1)
         {
-            if (x <= points[i].X)
-            {
-                var (x0, y0) = points[i - 1];
-                var (x1, y1) = points[i];
-                var t = (x - x0) / (x1 - x0);
-                return float.Lerp(y0, y1, t);
-            }
+            return EvaluateMin(EvaluateMax(x, outputMin), outputMax);
         }
 
-        return points[^1].Y;
+        int rightIndex;
+        if (x <= points[0].X)
+        {
+            rightIndex = 1;
+        }
+        else if (x >= points[^1].X)
+        {
+            rightIndex = points.Length - 1;
+        }
+        else
+        {
+            var low = 1;
+            var high = points.Length - 1;
+            while (low < high)
+            {
+                var middle = (low + high) >> 1;
+                if (x > points[middle].X)
+                {
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle;
+                }
+            }
+            rightIndex = low;
+        }
+
+        var left = points[rightIndex - 1];
+        var right = points[rightIndex];
+        var width = right.X - left.X;
+        var t = x - left.X;
+        if (width != 0f)
+        {
+            t /= width;
+        }
+        t = t >= 0f ? MathF.Min(1f, t) : 0f;
+
+        var delta = right.Y - left.Y;
+        var m0 = left.OutTangent;
+        var m1 = right.InTangent;
+        var term1 = delta * 3f;
+        var term2A = (m1 + m0) * width;
+        term2A -= delta + delta;
+        term2A *= t;
+        var term2B = -m1 - (m0 + m0);
+        term2B *= width;
+        var value = term2A + term2B;
+        value = term1 + value;
+        value *= t;
+        value += width * m0;
+        value *= t;
+        value += left.Y;
+
+        return EvaluateMin(EvaluateMax(value, outputMin), outputMax);
     }
+
+    // Engine MINSS/MAXSS take the second operand on ties: +0.0 against a -0.0
+    // bound stays -0.0. The shipped corpus pins 130 such evaluations.
+    private static float EvaluateMax(float value, float bound) => value > bound ? value : bound;
+
+    private static float EvaluateMin(float value, float bound) => value < bound ? value : bound;
 }

--- a/Tests/SoundEventCurveTest.cs
+++ b/Tests/SoundEventCurveTest.cs
@@ -1,0 +1,180 @@
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using ValveResourceFormat.Renderer.Audio;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace Tests
+{
+    public class SoundEventCurveTest
+    {
+        private static SoundEventCurve ParseCurve(string points, bool decibels = false)
+        {
+            var text = "<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->\n{\n\tcurve = " + points + "\n}\n";
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text));
+            return SoundEventCurve.Parse(KVDocumentExtensions.ParseKV3(stream).Root, "curve", decibels)!;
+        }
+
+        private static SoundEventCurve LinearCurve(float x0, float y0, float x1, float y1)
+            => (SoundEventCurve)typeof(SoundEventCurve)
+                .GetMethod("Linear", BindingFlags.Static | BindingFlags.NonPublic)!
+                .Invoke(null, [x0, y0, x1, y1])!;
+
+        private static SoundEventCurve AddCutoff(SoundEventCurve curve, float x)
+            => (SoundEventCurve)typeof(SoundEventCurve)
+                .GetMethod("WithCutoff", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(curve, [x])!;
+
+        [Test]
+        public async Task LinearTangentsEvaluateLinearly()
+        {
+            var curve = ParseCurve("[[0.0, 1.0, 0.0, 0.0, 0.0, 0.0], [100.0, 0.0, 0.0, 0.0, 0.0, 0.0]]");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(0f)).IsEqualTo(1f);
+                await Assert.That(curve.Evaluate(25f)).IsEqualTo(0.75f);
+                await Assert.That(curve.Evaluate(50f)).IsEqualTo(0.5f);
+                await Assert.That(curve.Evaluate(100f)).IsEqualTo(0f);
+            }
+        }
+
+        [Test]
+        public async Task SplineTangentsBendTheSpan()
+        {
+            var curve = ParseCurve("[[0.0, 0.0, 0.0, 0.0, 1.0, 1.0], [50.0, 1.0, 0.0, 0.0, 1.0, 1.0], [100.0, 0.0, 0.0, 0.0, 1.0, 1.0]]");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(25f)).IsEqualTo(0.625f).Because("a linear read gives 0.5");
+                await Assert.That(curve.Evaluate(75f)).IsEqualTo(0.625f).Because("a linear read gives 0.5");
+                await Assert.That(curve.Evaluate(50f)).IsEqualTo(1f);
+            }
+        }
+
+        [Test]
+        public async Task FreeTangentsUseTheAuthoredValues()
+        {
+            var curve = ParseCurve("[[0.0, 1.0, 0.0, -0.02, 2.0, 2.0], [100.0, 0.0, -0.02, 0.0, 2.0, 2.0]]");
+
+            await Assert.That(curve.Evaluate(25f)).IsEqualTo(0.65625f).Because("a linear read gives 0.75");
+        }
+
+        [Test]
+        public async Task MirrorTangentCopiesTheOppositeHandle()
+        {
+            var curve = ParseCurve("[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], [50.0, 1.0, 0.0, -0.02, 3.0, 2.0], [100.0, 0.0, 0.0, 0.0, 0.0, 0.0]]");
+
+            await Assert.That(curve.Evaluate(25f)).IsEqualTo(0.75f).Because("a linear read gives 0.5");
+        }
+
+        [Test]
+        public async Task SineTangentsUseFixedSlopes()
+        {
+            var curve = ParseCurve("[[0.0, 1.0, 0.0, 0.0, 4.0, 4.0], [100.0, 0.0, 0.0, 0.0, 4.0, 4.0]]");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(25f)).IsEqualTo(0.92470610f).Within(0.000001f).Because("a linear read gives 0.75");
+                await Assert.That(curve.Evaluate(75f)).IsEqualTo(0.38361669f).Within(0.000001f).Because("a linear read gives 0.25");
+            }
+        }
+
+        [Test]
+        public async Task LinearFactoryRemainsLinear()
+        {
+            var curve = LinearCurve(0f, 1f, 100f, 0f);
+            var reversed = LinearCurve(100f, 0f, 0f, 1f);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(25f)).IsEqualTo(0.75f);
+                await Assert.That(reversed.Evaluate(25f)).IsEqualTo(0.75f);
+            }
+        }
+
+        [Test]
+        public async Task CutoffAddsALinearFinalSpan()
+        {
+            var curve = AddCutoff(
+                ParseCurve("[[0.0, 1.0, 0.0, 0.0, 0.0, 0.0], [100.0, 0.5, 0.0, 0.0, 0.0, 0.0]]"),
+                200f);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(125f)).IsEqualTo(0.375f);
+                await Assert.That(curve.Evaluate(200f)).IsEqualTo(0f);
+            }
+        }
+
+        [Test]
+        public async Task DecibelCurveKeepsLegacyLinearInterpolationUntilTangentUnitsAreProved()
+        {
+            var curve = ParseCurve(
+                "[[0.0, 0.0, 8.0, -8.0, 2.0, 2.0], [100.0, -6.0, -8.0, 8.0, 2.0, 2.0]]",
+                decibels: true);
+            var end = MathF.Pow(10f, -6f / 20f);
+
+            await Assert.That(curve.Evaluate(25f)).IsEqualTo(float.Lerp(1f, end, 0.25f));
+        }
+
+        [Test]
+        public async Task FootstepDistanceCurveMatchesTheGameShape()
+        {
+            var curve = ParseCurve(
+                "[[49.591427, 0.45, 0.010452, 0.010452, 3.0, 1.0], " +
+                "[116.563492, 1.0, -0.001429, -0.001429, 2.0, 3.0], " +
+                "[402.285736, 0.488971, -0.000991, -0.000991, 3.0, 1.0], " +
+                "[1095.0, 0.03, -0.000701, -0.000701, 1.0, 1.0], " +
+                "[1100.0, 0.0, -0.000476, -0.000476, 2.0, 3.0]]");
+
+            await Assert.That(curve.Evaluate(300f)).IsEqualTo(0.64675820f).Within(0.000001f).Because("a linear read gives 0.6719");
+        }
+
+        [Test]
+        public async Task GrenadeExplosionDistanceCurveMatchesTheGameShape()
+        {
+            var curve = ParseCurve(
+                "[[0.0, 1.0, 0.0, 0.0, 0.0, 0.0], " +
+                "[231.428574, 1.0, -0.000553, -0.000553, 1.0, 1.0], " +
+                "[779.142883, 0.569231, -0.000405, -0.000405, 1.0, 1.0], " +
+                "[2700.0, 0.0, -0.000096, -0.000096, 2.0, 3.0]]");
+
+            await Assert.That(curve.Evaluate(1800f)).IsEqualTo(0.19140819f).Within(0.000001f).Because("a linear read gives 0.2667");
+        }
+
+        [Test]
+        public async Task EvaluateClampsToTheEndPoints()
+        {
+            var curve = ParseCurve("[[0.0, 1.0, 0.0, 0.0, 0.0, 0.0], [100.0, 0.0, 0.0, 0.0, 0.0, 0.0]]");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(-10f)).IsEqualTo(1f);
+                await Assert.That(curve.Evaluate(200f)).IsEqualTo(0f);
+            }
+        }
+
+        [Test]
+        public async Task EvaluateClampsOvershootToTheAuthoredExtent()
+        {
+            var curve = ParseCurve("[[0.0, 0.0, 0.0, 5.0, 2.0, 2.0], [10.0, 1.0, -5.0, 0.0, 2.0, 2.0]]");
+
+            await Assert.That(curve.Evaluate(5f)).IsEqualTo(1f);
+        }
+
+        [Test]
+        public async Task SingleKnotEvaluatesToItsValue()
+        {
+            var curve = ParseCurve("[[50.0, 0.75, 0.0, 0.0, 0.0, 0.0]]");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(curve.Evaluate(0f)).IsEqualTo(0.75f);
+                await Assert.That(curve.Evaluate(50f)).IsEqualTo(0.75f);
+                await Assert.That(curve.Evaluate(100f)).IsEqualTo(0.75f);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Sound event mapping curves (`distance_volume_mapping_curve` and friends) author six values per point: x, y, in/out tangents, and left/right tangent modes. `Evaluate` currently drops everything past y and lerps between the points

The game resolves each point's tangent modes (0 linear, 1 spline, 2 free, 3 mirror, 4 sine) into explicit tangents and evaluates each span as a cubic Hermite polynomial, clamping the result to the curve's y extent. With linear modes the resolved tangents are the segment slopes and the polynomial reduces exactly to the lerp, so flat and linear curves evaluate the same as before

Across the shipped CS2 sound events, 72% of the 105130 curve points author a non-linear tangent mode. Evaluating all 41841 curves both ways: half of the volume falloff curves are effectively linear, but 11% of them shift by at least 0.05 of full volume somewhere in their range, and the stereo (`distance_unfiltered_stereo_mapping_curve`) and fade curves are dominated by curved default shapes, with 86% and 80% shifting by at least 0.05

## Examples
The HE grenade explosion distance curve ("BaseGrenade.Explode") at 1800 units:

Before: 0.2667
After: 0.1914

The footstep `distance_volume_mapping_curve` at 300 units:

Before: 0.6719
After: 0.6468

## Note
Tests go through `Parse` and cover each tangent mode with values a lerp cannot produce, plus the grenade and footstep curves exactly as authored in the shipped soundevents, so the numbers above reproduce with `dotnet test Tests -- --treenode-filter '/*/*/SoundEventCurveTest/*'`