### PR TITLE
Fix bloom being weighted by exposure twice

### DIFF
--- a/Renderer/Shaders/downsample_bloomthreshold.frag.slang
+++ b/Renderer/Shaders/downsample_bloomthreshold.frag.slang
@@ -65,7 +65,7 @@ void main() {
 
     vec4 downsampledColor = DownsampleJimenez(uv);
     vec3 thresholdedColor = ApplyThreshold(downsampledColor.rgb);
-    vec3 bloomColor = thresholdedColor * g_flBloomScale * g_flToneMapScalarLinear;
+    vec3 bloomColor = thresholdedColor * g_flBloomScale;
 
     outputColor = vec4(bloomColor, 1.0);
 }


### PR DESCRIPTION
## Description

The bloom bright pass multiplies its output by `g_flToneMapScalarLinear` and the composite
multiplies the same bloom sample by the exposure again


## Previous work
28e861a1 scaled bloom by the exposure in the bright pass back when the composite weighted the bloom terms by `vRawColor` instead

b811a5fa then switched those terms to `flExposure`, which is what the game does. With both in
place the scalar is applied twice

## Verification
I dumped every dynamic combo of `gaussian_bloom_blur` from the shaders VPK
18 of 23 never reference the per-view tonemap scalar
Each of the rest do reference it exactly twice: constant buffer declaration and inside the `saturate(...)` threshold
There is no output multiply anywhere
A frame capture of the same pass agrees as well

So only the exposure factor is removed

## Examples

5 sec video: https://github.com/user-attachments/assets/3ffef81d-a8d5-44f6-abed-49f8d8d9420e

<img width="430" height="430" alt="sun_exposure_vrf" src="https://github.com/user-attachments/assets/4a144f1e-f68d-449a-bdaf-35247a1aae41" />

`AutoAdjustExposure` clamps the scalar only to the volume's authored exposure range, so the size of the error follows the scene rather than being bounded