### PR TITLE
SteamVR indirect lighting fix

### DIFF
--- a/Renderer/Shaders/common/environment.slang
+++ b/Renderer/Shaders/common/environment.slang
@@ -235,7 +235,7 @@ vec3 GetEnvironmentNoBRDF(MaterialProperties_t mat, float reflectionCorrectionAm
 
         vec3 coords = GetCorrectedSampleCoords(R, envMapWorldToLocal, envMapLocalPos, isBoxProjection, envMapBoxMin, envMapBoxMax);
         #if (S_LIGHTMAP_VERSION_MINOR == 0)
-            envMap = DecodeRGBM(textureLod(g_tEnvironmentMap, coords, lod));
+            envMap = SrgbGammaToLinear(DecodeRGBM(textureLod(g_tEnvironmentMap, coords, lod)));
         #else
             envMap = textureLod(g_tEnvironmentMap, coords, lod).rgb;
         #endif

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -328,11 +328,7 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
 
     // Environment Maps
 #if defined(IBL) && (IBL == 1)
-    #if (S_LIGHTMAP_VERSION_MINOR == 0)
-        vec3 environment = SrgbGammaToLinear(GetEnvironment(mat));
-    #else
-        vec3 environment = GetEnvironment(mat);
-    #endif
+    vec3 environment = GetEnvironment(mat);
 
     lighting.SpecularIndirect = environment
         * GetEnvMapNormalization(mat.IsometricRoughness, mat.AmbientNormal, lighting.DiffuseIndirect);

--- a/Renderer/Shaders/common/lighting.slang
+++ b/Renderer/Shaders/common/lighting.slang
@@ -328,7 +328,11 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
 
     // Environment Maps
 #if defined(IBL) && (IBL == 1)
-    vec3 environment = GetEnvironment(mat);
+    #if (S_LIGHTMAP_VERSION_MINOR == 0)
+        vec3 environment = SrgbGammaToLinear(GetEnvironment(mat));
+    #else
+        vec3 environment = GetEnvironment(mat);
+    #endif
 
     lighting.SpecularIndirect = environment
         * GetEnvMapNormalization(mat.IsometricRoughness, mat.AmbientNormal, lighting.DiffuseIndirect);


### PR DESCRIPTION
The previous RGBM change didn't quite fix the indirect lighting within SteamVR maps which still seem to require the envmaps to be read as SRGB to appear correct. The method I used in the previous PR seemed to make things a bit darker than it should have, or at least did after the RGBM changes, so this version should be better.

Not sure if there's any better way but I'd be happy to hear if there might be!

Before:
<img width="1696" height="898" alt="S2VMaster" src="https://github.com/user-attachments/assets/4b2538b3-176f-4734-bf0a-c21503152d92" />

After:
<img width="1696" height="898" alt="S2VFix" src="https://github.com/user-attachments/assets/06c7b12a-06a0-4b10-8200-694d114ea99d" />

SteamVR:
<img width="1696" height="898" alt="SteamVR" src="https://github.com/user-attachments/assets/7914f878-e945-4ce9-af4a-9fa471c62969" />
