### PR TITLE
Match water effects render target

### DIFF
--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -148,7 +148,9 @@ public class Renderer
     /// The value the water effects map means "nothing here" by: the ripple, silt and foam channels are
     /// read signed around 0.5.
     /// </summary>
-    private static readonly Color4 WaterEffectsNeutral = new(0.5f, 0.5f, 0.5f, 0f);
+    private static readonly Color4 WaterEffectsNeutral = new(32767f / 65535f, 32767f / 65535f, 32767f / 65535f, 0f);
+
+    private Shader waterEffectsDepthShader = null!;
 
     /// <summary>Whether <see cref="WaterEffectsBuffer"/> currently holds nothing but <see cref="WaterEffectsNeutral"/>.</summary>
     private bool waterEffectsMapIsNeutral;
@@ -293,6 +295,7 @@ public class Renderer
         //depthOnlyShaders[(int)DepthOnlyProgram.StaticAlphaTest] = GuiContext.ShaderLoader.LoadShader("depth_only", ("F_ALPHA_TEST", 1));
         depthOnlyShaders[(int)DepthOnlyProgram.Animated] = Scene.RendererContext.ShaderLoader.LoadShader("depth_only", ("D_ANIMATED", 1));
         depthOnlyShaders[(int)DepthOnlyProgram.AnimatedEightBones] = Scene.RendererContext.ShaderLoader.LoadShader("depth_only", ("D_ANIMATED", 1), ("D_EIGHT_BONE_BLENDING", 1));
+        waterEffectsDepthShader = Scene.RendererContext.ShaderLoader.LoadShader("water_effects_depth");
 
         histogramShaders[0] = Scene.RendererContext.ShaderLoader.LoadShader("histogram");
         histogramShaders[1] = Scene.RendererContext.ShaderLoader.LoadShader("histogram", ("D_HISTOGRAM_MODE", 1));
@@ -309,14 +312,12 @@ public class Renderer
         Textures.Add(new(ReservedTextureSlots.SceneColor, "g_tSceneColor", ResolvedSceneColor));
         Textures.Add(new(ReservedTextureSlots.SceneDepth, "g_tSceneDepth", ResolvedSceneDepth));
 
-        // Eight bits a channel is what the water shader gets out of it: every read is either recentered
-        // around 0.5 or saturated, so the map never carries range beyond what a unorm target holds.
         WaterEffectsBuffer = Framebuffer.Prepare(nameof(WaterEffectsBuffer), 4, 4, 0,
-            new(PixelInternalFormat.Rgba8, PixelFormat.Rgba, PixelType.UnsignedByte), null);
+            new(PixelInternalFormat.Rgba16, PixelFormat.Rgba, PixelType.UnsignedShort),
+            new(PixelInternalFormat.DepthComponent24, PixelType.UnsignedInt));
         WaterEffectsBuffer.Initialize();
         WaterEffectsBuffer.CheckStatus_ThrowIfIncomplete(nameof(WaterEffectsBuffer));
         WaterEffectsBuffer.ClearColor = WaterEffectsNeutral;
-        WaterEffectsBuffer.ClearMask = ClearBufferMask.ColorBufferBit;
         SetupWaterEffectsTexture();
 
         EnsureDepthPyramidSize(256, 256);
@@ -1025,7 +1026,8 @@ public class Renderer
 
         using var _ = new GLDebugGroup("Water Effects Render");
 
-        var (width, height) = (renderContext.Framebuffer.Width, renderContext.Framebuffer.Height);
+        var width = Math.Max(1, (renderContext.Framebuffer.Width + 5) / 6);
+        var height = Math.Max(1, (renderContext.Framebuffer.Height + 2) / 3);
 
         if (WaterEffectsBuffer.Resize(width, height))
         {
@@ -1036,16 +1038,35 @@ public class Renderer
         // restored: only the GL state below outlives this call.
         var sceneFramebuffer = renderContext.Framebuffer;
 
+        if (hasDraws)
+        {
+            GrabFramebufferCopy(sceneFramebuffer, false, true);
+        }
+
         GL.Viewport(0, 0, width, height);
         WaterEffectsBuffer.BindAndClear();
 
-        // The map is a flat screen space accumulation with no depth of its own, and the particle renderers
-        // set up their own blend state per draw.
-        GL.Disable(EnableCap.DepthTest);
         renderContext.Framebuffer = WaterEffectsBuffer;
 
         if (hasDraws)
         {
+            Debug.Assert(ResolvedSceneDepth != null);
+
+            GL.Disable(EnableCap.Blend);
+            GL.Enable(EnableCap.DepthTest);
+            GL.DepthMask(true);
+            GL.DepthFunc(DepthFunction.Always);
+            GL.ColorMask(false, false, false, false);
+
+            waterEffectsDepthShader.Use();
+            waterEffectsDepthShader.SetTexture(0, "g_tSceneDepth", ResolvedSceneDepth);
+            GL.BindVertexArray(RendererContext.MeshBufferCache.EmptyVAO);
+            GL.DrawArrays(PrimitiveType.Triangles, 0, 3);
+
+            GL.ColorMask(true, true, true, true);
+            GL.DepthMask(false);
+            GL.DepthFunc(DepthFunction.Gequal);
+
             if (skyboxScene != null)
             {
                 renderContext.Scene = skyboxScene;
@@ -1058,6 +1079,7 @@ public class Renderer
 
         GL.Disable(EnableCap.Blend);
         GL.DepthMask(true);
+        GL.DepthFunc(DepthFunction.Greater);
         GL.Enable(EnableCap.DepthTest);
 
         GL.Viewport(0, 0, sceneFramebuffer.Width, sceneFramebuffer.Height);

--- a/Renderer/Shaders/water_effects_depth.frag.slang
+++ b/Renderer/Shaders/water_effects_depth.frag.slang
@@ -1,0 +1,21 @@
+#version 460
+
+uniform sampler2D g_tSceneDepth;
+
+void main()
+{
+    ivec2 sourceOrigin = ivec2(gl_FragCoord.xy) * ivec2(6, 3);
+    ivec2 sourceMax = textureSize(g_tSceneDepth, 0) - 1;
+    float nearestDepth = 0.0;
+
+    for (int y = 0; y < 3; y++)
+    {
+        for (int x = 0; x < 6; x++)
+        {
+            ivec2 sourceCoord = min(sourceOrigin + ivec2(x, y), sourceMax);
+            nearestDepth = max(nearestDepth, texelFetch(g_tSceneDepth, sourceCoord, 0).r);
+        }
+    }
+
+    gl_FragDepth = nearestDepth;
+}

--- a/Renderer/Shaders/water_effects_depth.vert.slang
+++ b/Renderer/Shaders/water_effects_depth.vert.slang
@@ -1,0 +1,2 @@
+#version 460
+#include "texture_decode.vert.slang"


### PR DESCRIPTION
## Description
The existing water-effects pass allocates its map at full viewport size as `RGBA8` and renders it without scene depth

A captured `de_anubis` frame uses a `192×288 R16G16B16A16_UNORM` target for a `1152×864` view. Before the effects-only sprite draws, the game reduces the full-resolution scene depth into a matching `D24S8` attachment

This changes the pass to use the same 6×3 reduction, 16-bit UNORM color and depth rejection. When using reverse-Z the reduction keeps the maximum depth and the particles use `GEQUAL`

## Reproduction
`de_anubis`
setpos 1534.071045 1846.553345 116.899536; setang 24.639988 20.839748 0.000000

Before:
- water effects target: `1152×864 RGBA8`
- no depth attachment

After:
- water effects target: `192×288 RGBA16 UNORM`
- D24 depth attachment populated from scene depth
- RGB clear: `32767 / 65535 = 0.49999237`, matching the captured value


## Note
The captured engine target uses `D24S8`. This pass does not read stencil, so the renderer allocates `D24`
This only changes the target and occlusion for the existing water-effects layer
Renderer builds with 0 warnings and the added shader validates
