### PR TITLE
Fix vrman with groups being decompiled incorrectly

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/ResourceManifest.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ResourceManifest.cs
@@ -102,22 +102,35 @@ namespace ValveResourceFormat.ResourceTypes
         private KVDocument GetPrintabaleObject()
         {
             var root = new KVObject();
-            var index = 0;
 
-            foreach (var resource in Resources)
+            if (Resources.Count == 0)
+            {
+                root.Add("resourceManifest", KVObject.Array());
+                return root.ToKV3Document();
+            }
+            if (Resources.Count == 1)
             {
                 var arr = KVObject.Array();
-
-                foreach (var file in resource)
+                foreach (var file in Resources[0])
                 {
                     arr.Add(file);
                 }
-
-                var key = index > 0 ? $"resourceManifest{index}" : "resourceManifest";
-                root.Add(key, arr);
-                index++;
+                root.Add("resourceManifest", arr);
             }
-
+            else
+            {
+                var outerArray = KVObject.Array();
+                foreach (var resourceList in Resources)
+                {
+                    var innerArray = KVObject.Array();
+                    foreach (var file in resourceList)
+                    {
+                        innerArray.Add(file);
+                    }
+                    outerArray.Add(innerArray);
+                }
+                root.Add("resourceManifest", outerArray);
+            }
             return root.ToKV3Document();
         }
     }


### PR DESCRIPTION
Previously vrman with groups looked like this:
<img width="739" height="790" alt="Source2Viewer_4mIgRxhvCp" src="https://github.com/user-attachments/assets/51260d3c-0f93-460f-bced-020e686be23e" />
When attempting to compile, only the first resourcemanifest will compile into the vrman file, which may prevent some resources from being loaded in.

Turns out vrman with groups only compiles correctly if it looks like this:
<img width="1440" height="861" alt="R3Rtfh2l2p" src="https://github.com/user-attachments/assets/3edbc54b-5017-4f3a-b797-740003185387" />

<img width="714" height="727" alt="Source2Viewer_dXNVc0IR2A" src="https://github.com/user-attachments/assets/f8387011-ee2f-4919-9621-f96eb067bff1" />
