### PR TITLE
Particles: review fixes, draw distance culling, threaded stepping

### DIFF
--- a/GUI/Types/GLViewers/GLSceneViewer.cs
+++ b/GUI/Types/GLViewers/GLSceneViewer.cs
@@ -176,6 +176,8 @@ namespace GUI.Types.GLViewers
 
                 UiControl.AddCheckBox("Debug Sound Sources", Renderer.ShowSoundDebug, v => Renderer.ShowSoundDebug = v);
 
+                UiControl.AddCheckBox("Disable threaded sim", !Renderer.ParallelSimulation, v => Renderer.ParallelSimulation = !v);
+
                 perfDisplayComboBox = UiControl.AddSelection("Debug Performance", (_, i) => perfDisplay = (PerfDisplay)i);
                 perfDisplayComboBox.Items.AddRange([nameof(PerfDisplay.Off), nameof(PerfDisplay.Stats), nameof(PerfDisplay.Timings), nameof(PerfDisplay.Allocations)]);
                 perfDisplayComboBox.SelectedIndex = (int)perfDisplay;

--- a/Renderer/Particles/ParticleRenderer.cs
+++ b/Renderer/Particles/ParticleRenderer.cs
@@ -130,7 +130,21 @@ namespace ValveResourceFormat.Renderer.Particles
         {
             foreach (var renderer in renderers)
             {
-                renderer.Update(particles, state);
+                renderer.Simulate(particles, state);
+            }
+        }
+
+        /// <summary>Finishes the step for this system's renderers and its children's, on one thread.</summary>
+        public void Act()
+        {
+            foreach (var renderer in renderers)
+            {
+                renderer.Act(Simulation.Particles, Simulation.RenderState);
+            }
+
+            foreach (var childRenderer in childRenderers)
+            {
+                childRenderer.Act();
             }
         }
 

--- a/Renderer/Particles/ParticleRenderer.cs
+++ b/Renderer/Particles/ParticleRenderer.cs
@@ -165,7 +165,7 @@ namespace ValveResourceFormat.Renderer.Particles
                 childRenderer.Render(camera, pass);
             }
 
-            if (Simulation.Particles.Count == 0)
+            if (!IsWithinDrawDistance(camera) || Simulation.Particles.Count == 0)
             {
                 return;
             }
@@ -193,6 +193,11 @@ namespace ValveResourceFormat.Renderer.Particles
                 PerfStats.Active.Count(Counter.ParticleSystem);
             }
         }
+
+        /// <summary>
+        /// Whether the camera is near enough for this system to draw and simulate.
+        /// </summary>
+        public bool IsWithinDrawDistance(Camera camera) => Simulation.IsWithinDrawDistance(camera.Location);
 
         /// <summary>
         /// Force-renders each active sub-renderer once with temporary particles.

--- a/Renderer/Particles/Renderers/ParticleFunctionRenderer.cs
+++ b/Renderer/Particles/Renderers/ParticleFunctionRenderer.cs
@@ -154,7 +154,17 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
         /// </summary>
         public SceneNode? OwnerNode { get; set; }
 
-        public virtual void Update(ParticleCollection particles, ParticleSystemState systemState)
+        /// <summary>Called as the system finishes a step. Runs on the pool, so touch only what this renderer owns.</summary>
+        /// <param name="particles">The system's particles, as the step left them.</param>
+        /// <param name="systemState">The state the system's functions read it through.</param>
+        public virtual void Simulate(ParticleCollection particles, ParticleSystemState systemState)
+        {
+        }
+
+        /// <summary>Finishes work done on <see cref="Simulate"/>, for what reaches past the system.</summary>
+        /// <param name="particles">The system's particles, as the step left them.</param>
+        /// <param name="systemState">The state the system's functions read it through.</param>
+        public virtual void Act(ParticleCollection particles, ParticleSystemState systemState)
         {
         }
 

--- a/Renderer/Particles/Renderers/RenderOmni2Light.cs
+++ b/Renderer/Particles/Renderers/RenderOmni2Light.cs
@@ -7,6 +7,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// <summary>
     /// Render an Omni2 light from particle data.
     /// </summary>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderOmni2Light">C_OP_RenderOmni2Light</seealso>
     internal class RenderOmni2Light : ParticleFunctionRenderer
     {
         private readonly Scene scene;

--- a/Renderer/Particles/Renderers/RenderOmni2Light.cs
+++ b/Renderer/Particles/Renderers/RenderOmni2Light.cs
@@ -54,7 +54,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             scene.LightingInfo.BarnLights.Add(light);
         }
 
-        public override void Update(ParticleCollection particles, ParticleSystemState systemState)
+        public override void Simulate(ParticleCollection particles, ParticleSystemState systemState)
         {
             if (particles.Count == 0)
             {

--- a/Renderer/Particles/Renderers/RenderRopes.cs
+++ b/Renderer/Particles/Renderers/RenderRopes.cs
@@ -162,12 +162,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
         }
 
         /// <inheritdoc/>
-        public override void SetWireframe(bool isWireframe)
-        {
-            shader.SetUniform1("isWireframe", isWireframe ? 1 : 0);
-        }
-
-        /// <inheritdoc/>
         public override void SetTextureOverride(RenderTexture texture)
         {
             // The override stands in for the base texture; layers composited over it keep their own.
@@ -611,13 +605,18 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
             var spriteSheetData = layerTexture.SpriteSheetData;
 
-            if (spriteSheetData == null || spriteSheetData.Sequences.Length == 0 || spriteSheetData.Sequences[0].Frames.Length == 0)
+            if (spriteSheetData == null || spriteSheetData.Sequences.Length == 0)
             {
                 return identity;
             }
 
             ref var head = ref particleBag.Current[0];
             var sequence = spriteSheetData.Sequences[head.SequenceNumber % spriteSheetData.Sequences.Length];
+
+            if (sequence.Frames.Length == 0)
+            {
+                return identity;
+            }
             var (frame, nextFrame, blend) = GetSheetFrame(ref head, sequence, animationRate, animationType, animateInFps);
 
             var currentImage = sequence.Frames[frame].Images[0];
@@ -656,7 +655,10 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             ParticleTextureLayer.Bind(shader, layers, systemState);
             SetSharedUniforms(shader, systemState);
             shader.SetUniform1("uBlendFrames", blendFrames);
+
+            // Set every draw: the program is shared with every other spritecard renderer, whatever their mode.
             shader.SetUniform1("uBlendMode", (int)blendMode);
+            shader.SetUniform1("uOutline", false);
 
             PerfStats.Active.Count(Counter.ParticleDraw);
             GL.DrawElements(PrimitiveType.Triangles, quadCount * 6, DrawElementsType.UnsignedShort, 0);

--- a/Renderer/Particles/Renderers/RenderSound.cs
+++ b/Renderer/Particles/Renderers/RenderSound.cs
@@ -41,7 +41,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             }
         }
 
-        public override void Update(ParticleCollection particles, ParticleSystemState systemState)
+        public override void Act(ParticleCollection particles, ParticleSystemState systemState)
         {
             if (soundName.Length == 0)
             {
@@ -87,7 +87,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
         public override void Render(ParticleCollection particles, ParticleSystemState systemState, Camera camera)
         {
-            // Nothing to draw; the sound is started from Update.
+            // Nothing to draw; the sound is started from Act.
         }
     }
 }

--- a/Renderer/Particles/Renderers/RenderSprites.cs
+++ b/Renderer/Particles/Renderers/RenderSprites.cs
@@ -112,12 +112,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             }
         }
 
-        public override void SetWireframe(bool isWireframe)
-        {
-            // Solid color
-            shader.SetUniform1("isWireframe", isWireframe ? 1 : 0);
-        }
-
         /// <inheritdoc/>
         // The override stands in for the card's base texture; the layers composited over it keep their
         // own textures along with the channels and blend settings that fold them together.
@@ -138,12 +132,17 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             frameBlend = 0f;
 
             var spriteSheetData = layers[layer].Texture.SpriteSheetData;
-            if (spriteSheetData == null || spriteSheetData.Sequences.Length == 0 || spriteSheetData.Sequences[0].Frames.Length == 0)
+            if (spriteSheetData == null || spriteSheetData.Sequences.Length == 0)
             {
                 return (Vector2.Zero, Vector2.One, Vector2.Zero, Vector2.One);
             }
 
             var sequence = spriteSheetData.Sequences[particle.SequenceNumber % spriteSheetData.Sequences.Length];
+
+            if (sequence.Frames.Length == 0)
+            {
+                return (Vector2.Zero, Vector2.One, Vector2.Zero, Vector2.One);
+            }
 
             var (frame, nextFrame, blend) = GetSheetFrame(ref particle, sequence, animationRate, animationType, animateInFps);
             frameBlend = blend;

--- a/Renderer/Particles/Renderers/RenderSprites.cs
+++ b/Renderer/Particles/Renderers/RenderSprites.cs
@@ -265,12 +265,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                 CenterXOffset.NextNumber(systemState),
                 CenterYOffset.NextNumber(systemState));
 
-            // Distance from the quad centre to its furthest corner, in half-widths, so a particle can be
-            // bounded by a sphere without building its basis first.
-            var cornerDistance = new Vector2(1f + MathF.Abs(centerOffset.X), 1f + MathF.Abs(centerOffset.Y)).Length();
-            var cullFrustum = camera.ViewFrustum;
-            const bool PerParticleFrustumCull = false;
-
             // Only the two normal-aligned modes fade by view angle, and only when the range can actually
             // be entered: the value it tests is a dot product magnitude, so it never exceeds 1.
             var viewAngleFadeActive = startFadeDot < 1f
@@ -336,26 +330,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                     if (halfWidth <= 0f || alpha < 1f / 255f)
                     {
                         continue;
-                    }
-
-                    // Off-screen particles still cost their vertices and a scan-out of the whole quad.
-                    // The bound is the corner furthest from the centre: the axes of every orientation
-                    // basis are unit length or shorter, so the offset corner distance covers all of them.
-                    if (PerParticleFrustumCull && !cullFrustum.IsEmpty)
-                    {
-                        var cornerReach = halfWidth * cornerDistance;
-
-                        if (orientationType == ParticleOrientation.PARTICLE_ORIENTATION_ALIGN_TO_PARTICLE_NORMAL)
-                        {
-                            // Its right axis is cross(up, normal) left un-normalized, so a normal that is
-                            // not unit length widens the quad past what the corner distance alone covers.
-                            cornerReach *= MathF.Max(1f, particle.Normal.Length());
-                        }
-
-                        if (!cullFrustum.Intersects(particle.Position, cornerReach))
-                        {
-                            continue;
-                        }
                     }
 
                     // Per-mode quad orientation, ported from the spritecard vertex shader. Every mode folds in

--- a/Renderer/Particles/Renderers/RenderStandardLight.cs
+++ b/Renderer/Particles/Renderers/RenderStandardLight.cs
@@ -28,7 +28,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             scene.LightingInfo.BarnLights.Add(light);
         }
 
-        public override void Update(ParticleCollection particles, ParticleSystemState systemState)
+        public override void Simulate(ParticleCollection particles, ParticleSystemState systemState)
         {
             if (particles.Count == 0)
             {

--- a/Renderer/Particles/Renderers/RenderStandardLight.cs
+++ b/Renderer/Particles/Renderers/RenderStandardLight.cs
@@ -6,6 +6,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// <summary>
     /// Render a standard point light.
     /// </summary>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderStandardLight">C_OP_RenderStandardLight</seealso>
     internal class RenderStandardLight : ParticleFunctionRenderer
     {
         private readonly Scene scene;

--- a/Renderer/Particles/Renderers/RenderTrails.cs
+++ b/Renderer/Particles/Renderers/RenderTrails.cs
@@ -121,11 +121,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             }
         }
 
-        public override void SetWireframe(bool isWireframe)
-        {
-            shader.SetUniform1("isWireframe", isWireframe ? 1 : 0);
-        }
-
         /// <inheritdoc/>
         public override void SetTextureOverride(RenderTexture texture)
         {
@@ -300,9 +295,12 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                         var nextMax = max;
 
                         var spriteSheetData = layers[layer].Texture.SpriteSheetData;
-                        if (spriteSheetData != null && spriteSheetData.Sequences.Length > 0 && spriteSheetData.Sequences[0].Frames.Length > 0)
+                        var sequence = spriteSheetData != null && spriteSheetData.Sequences.Length > 0
+                            ? spriteSheetData.Sequences[particle.SequenceNumber % spriteSheetData.Sequences.Length]
+                            : null;
+
+                        if (sequence is { Frames.Length: > 0 })
                         {
-                            var sequence = spriteSheetData.Sequences[particle.SequenceNumber % spriteSheetData.Sequences.Length];
                             var (frame, nextFrame, blend) = GetSheetFrame(ref particle, sequence, animationRate, animationType, animateInFps);
 
                             // TODO: Support more than one image per frame?
@@ -408,6 +406,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
             // Set every draw: the program is shared with every other spritecard renderer, whatever their mode.
             shader.SetUniform1("uBlendMode", (int)blendMode);
+            shader.SetUniform1("uOutline", false);
 
             PerfStats.Active.Count(Counter.ParticleDraw);
             GL.DrawElements(PrimitiveType.Triangles, quadCount * 6, DrawElementsType.UnsignedShort, 0);

--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -210,6 +210,11 @@ public class Renderer
     public bool EnableBarnLights { get; set; } = true;
 
     /// <summary>
+    /// Whether scene nodes simulate across the thread pool. Off runs them in scene order.
+    /// </summary>
+    public bool ParallelSimulation { get; set; } = true;
+
+    /// <summary>
     /// Initializes a new renderer with the given context.
     /// </summary>
     /// <param name="rendererContext">Shared context providing loaders and caches.</param>
@@ -1107,6 +1112,8 @@ public class Renderer
         {
             throw new InvalidOperationException("Initialize() must be called before updating");
         }
+
+        RendererContext.ParallelSimulation = ParallelSimulation;
 
         Uptime += updateContext.Timestep;
         DeltaTime = updateContext.Timestep;

--- a/Renderer/Renderer/RendererContext.cs
+++ b/Renderer/Renderer/RendererContext.cs
@@ -55,6 +55,11 @@ public class RendererContext : IDisposable
     public float ViewmodelFieldOfView { get; set; } = 64.0f;
 
     /// <summary>
+    /// Whether scene nodes simulate across the thread pool, published by the renderer each frame.
+    /// </summary>
+    public bool ParallelSimulation { get; set; } = true;
+
+    /// <summary>
     /// Initializes a new renderer context.
     /// </summary>
     /// <param name="fileLoader">Game file loader for resource access.</param>

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -20,11 +20,27 @@ namespace ValveResourceFormat.Renderer
     /// </summary>
     public class Scene : IDisposable
     {
+        /// <summary>Which pass of the frame an update belongs to.</summary>
+        public enum UpdatePhase
+        {
+            /// <summary>One node at a time, in scene order.</summary>
+            Place,
+
+            /// <summary>Across the thread pool. Touch only what the node owns.</summary>
+            Simulate,
+
+            /// <summary>Finish work done on simulate. Back on the calling thread.</summary>
+            Act,
+        }
+
         /// <summary>
         /// Context data passed to scene nodes during per-frame update.
         /// </summary>
         public readonly struct UpdateContext
         {
+            /// <summary>Gets which pass of the frame this update is.</summary>
+            public UpdatePhase Phase { get; init; }
+
             /// <summary>Gets the camera used for view-dependent node updates.</summary>
             public required Camera Camera { get; init; }
 
@@ -202,6 +218,26 @@ namespace ValveResourceFormat.Renderer
 
         private readonly List<SceneNode> staticNodes = [];
         private readonly List<SceneNode> dynamicNodes = [];
+
+        private readonly ParallelDispatch simulationDispatch = new();
+        private SimulationWork? simulationWork;
+
+        private readonly List<SceneNode> CullResults = [];
+        private int StaticCount;
+        private int LastFrustum = -1;
+
+        private List<SceneNode> CulledShadowNodes { get; } = [];
+        private readonly List<RenderableMesh> listWithSingleMesh = [null!];
+
+        private ObjectDataStandard[]? instanceDataCpu;
+        private readonly List<SceneAggregate> lodAggregates = [];
+        private uint[] activeLodBits = [];
+
+        private Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>>? barnShadowDrawCalls;
+
+        // Bound probes in precedence order: most indoor first, then smallest, so the first volume
+        // containing a point is the best one
+        private List<SceneLightProbe>? boundLightProbes;
 
         private Shader? OutlineShader;
 
@@ -428,6 +464,60 @@ namespace ValveResourceFormat.Renderer
         }
 
         /// <summary>
+        /// The dynamic nodes are the work: the index picks one, so no filtered list is kept in step
+        /// with the scene. Holds the list itself, not a copy, so running it allocates nothing.
+        /// </summary>
+        private sealed class SimulationWork(List<SceneNode> nodes) : IParallelWork
+        {
+            public UpdateContext Context;
+
+            public void Execute(int index)
+            {
+                var node = nodes[index];
+
+                // Parented nodes are placed by their parent, but simulate here like every other one
+                if (node.Simulation == NodeSimulation.Parallel)
+                {
+                    node.Update(Context);
+                }
+            }
+        }
+
+        /// <summary>Runs the two passes after placement, for the nodes that take part in them.</summary>
+        private void SimulateNodes(UpdateContext updateContext)
+        {
+            var parallelSimulation = RendererContext.ParallelSimulation;
+
+            var simulate = updateContext with { Phase = UpdatePhase.Simulate };
+
+            if (parallelSimulation)
+            {
+                simulationWork ??= new SimulationWork(dynamicNodes);
+                simulationWork.Context = simulate;
+
+                // The dispatch publishes the context, and runs counts too small to fan out inline
+                simulationDispatch.Run(simulationWork, dynamicNodes.Count);
+            }
+
+            var act = updateContext with { Phase = UpdatePhase.Act };
+
+            foreach (var node in dynamicNodes)
+            {
+                if (node.Simulation == NodeSimulation.None)
+                {
+                    continue;
+                }
+
+                if (!parallelSimulation)
+                {
+                    node.Update(simulate);
+                }
+
+                node.Update(act);
+            }
+        }
+
+        /// <summary>
         /// Updates all scene nodes for the current frame, advancing animations and rebuilding spatial sets and GPU buffers if the scene changed.
         /// </summary>
         /// <param name="updateContext">Per-frame context data including camera and timestep.</param>
@@ -450,6 +540,8 @@ namespace ValveResourceFormat.Renderer
 
                 node.Update(updateContext);
             }
+
+            SimulateNodes(updateContext);
 
             foreach (var node in dynamicNodes)
             {
@@ -601,9 +693,6 @@ namespace ValveResourceFormat.Renderer
             instanceDataCpu = instanceData;
         }
 
-        private ObjectDataStandard[]? instanceDataCpu;
-        private readonly List<SceneAggregate> lodAggregates = [];
-        private uint[] activeLodBits = [];
 
         /// <summary>
         /// Uploads the LOD level each setup selected this frame, which the cull shader tests fragments against.
@@ -820,9 +909,6 @@ namespace ValveResourceFormat.Renderer
             LightBinner.Bind();
         }
 
-        private readonly List<SceneNode> CullResults = [];
-        private int StaticCount;
-        private int LastFrustum = -1;
 
         /// <summary>
         /// Returns all scene nodes whose bounding boxes intersect the given frustum, caching static results across frames when the frustum is unchanged.
@@ -1107,8 +1193,6 @@ namespace ValveResourceFormat.Renderer
             }
         }
 
-        private List<SceneNode> CulledShadowNodes { get; } = [];
-        private readonly List<RenderableMesh> listWithSingleMesh = [null!];
         internal Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>>[] CulledShadowDrawCallsCascades { get; } = CreateSunCascadeDrawCallCollections();
         internal static Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>> CreateDepthOnlyDrawCallCollection()
             => Enum.GetValues<DepthOnlyBucket>().ToDictionary(static bucket => bucket, static _ => new List<MeshBatchRenderer.Request>());
@@ -1163,7 +1247,6 @@ namespace ValveResourceFormat.Renderer
             }
         }
 
-        private Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>>? barnShadowDrawCalls;
 
         /// <summary>
         /// Collects the shadow draw calls for a single barn light face. The returned buckets are
@@ -1983,9 +2066,6 @@ namespace ValveResourceFormat.Renderer
             }
         }
 
-        // Bound probes in precedence order: most indoor first, then smallest, so the first volume
-        // containing a point is the best one
-        private List<SceneLightProbe>? boundLightProbes;
 
         /// <summary>
         /// Returns the best probe volume containing the given position, or <see langword="null"/> when
@@ -2291,6 +2371,7 @@ namespace ValveResourceFormat.Renderer
                 lightingBuffer?.Dispose();
                 lpvBuffer?.Dispose();
                 envMapBuffer?.Dispose();
+                simulationDispatch.Dispose();
                 LightingInfo.DisposeBarnLights();
             }
         }

--- a/Renderer/Renderer/SceneNode.cs
+++ b/Renderer/Renderer/SceneNode.cs
@@ -4,6 +4,18 @@ using ValveResourceFormat.ResourceTypes;
 namespace ValveResourceFormat.Renderer
 {
     /// <summary>
+    /// Which passes of the frame beyond <see cref="Scene.UpdatePhase.Place"/> a node takes part in.
+    /// </summary>
+    public enum NodeSimulation
+    {
+        /// <summary>The node has nothing to advance once the scene has been updated.</summary>
+        None,
+
+        /// <summary> The node update can be parallelized. Affects only inner state.</summary>
+        Parallel,
+    }
+
+    /// <summary>
     /// Base class for all objects in the scene graph.
     /// </summary>
 #if DEBUG
@@ -178,6 +190,13 @@ namespace ValveResourceFormat.Renderer
         public virtual void Update(Scene.UpdateContext context)
         {
         }
+
+        /// <summary>
+        /// Gets or sets which passes after <see cref="Scene.UpdatePhase.Place"/> this node takes part
+        /// in. Simulating nodes get <see cref="Scene.UpdatePhase.Act"/> too, and belong in the dynamic
+        /// partition even if they never move.
+        /// </summary>
+        public NodeSimulation Simulation { get; protected set; }
 
         /// <summary>
         /// Called each frame to render this node.

--- a/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
@@ -68,6 +68,8 @@ namespace ValveResourceFormat.Renderer.SceneNodes
 
             RenderPasses = particleRenderer.Passes;
 
+            Simulation = NodeSimulation.Parallel;
+
             if (preview)
             {
                 Preview = true;
@@ -488,16 +490,35 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 return;
             }
 
-            // Control point 0 is seeded from the node transform (position, full rotation frame, and its
-            // transformed +X as the forward direction) whenever the transform changes from outside, like a
-            // non-follow attachment in game. Between seeds the control point belongs to the simulation:
-            // particle functions may move it, and the node transform reflects it back after each step.
-            // Preview drives the control point separately.
+            switch (context.Phase)
+            {
+                case Scene.UpdatePhase.Place:
+                    Place();
+                    break;
+
+                case Scene.UpdatePhase.Simulate:
+                    Simulate(context);
+                    break;
+
+                case Scene.UpdatePhase.Act:
+                    Act();
+                    break;
+            }
+        }
+
+        /// <summary>Places the effect. The half that reads other nodes: bound control points, the preview attachment.</summary>
+        private void Place()
+        {
             if (controlPointBindings != null)
             {
                 UpdateBoundControlPoints();
             }
 
+            // Control point 0 is seeded from the node transform (position, full rotation frame, and its
+            // transformed +X as the forward direction) whenever the transform changes from outside, like a
+            // non-follow attachment in game. Between seeds the control point belongs to the simulation:
+            // particle functions may move it, and the node transform reflects it back after each step.
+            // Preview drives the control point separately.
             if (seededTransform != Transform)
             {
                 var controlPoint = particleRenderer.MainControlPoint;
@@ -520,7 +541,13 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             {
                 particleRenderer.MainControlPoint.Position = PreviewModel.GetAttachmentTransform(PreviewModelAttachmentPoint).Translation;
             }
+        }
 
+        /// <summary>
+        /// Runs the effect. Touches only its own control points, particles and lights.
+        /// </summary>
+        private void Simulate(Scene.UpdateContext context)
+        {
             var frameTime = context.Timestep * FrametimeMultiplier;
 
             if (pendingRestart)
@@ -542,6 +569,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             {
                 particleRenderer.SetCameraPosition(context.Camera.Location);
                 particleRenderer.Update(frameTime, context.Uptime);
+                stepped = true;
 
                 if (!Preview)
                 {
@@ -565,6 +593,23 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             {
                 pendingRestart = true;
             }
+        }
+
+        /// <summary>Whether <see cref="Simulate"/> stepped, so there is something to finish.</summary>
+        private bool stepped;
+
+        /// <summary>
+        /// Finishes the step, on the particles it left and where reaching past the effect is safe.
+        /// </summary>
+        private void Act()
+        {
+            if (!stepped)
+            {
+                return;
+            }
+
+            stepped = false;
+            particleRenderer.Act();
         }
 
         // The node transform mirrors control point 0 after simulation, so movement applied by particle

--- a/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
@@ -565,7 +565,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 }
             }
 
-            if (frameTime > 0f)
+            if (frameTime > 0f && (Preview || particleRenderer.IsWithinDrawDistance(context.Camera)))
             {
                 particleRenderer.SetCameraPosition(context.Camera.Location);
                 particleRenderer.Update(frameTime, context.Uptime);

--- a/Renderer/Shaders/particle_spritecard.frag.slang
+++ b/Renderer/Shaders/particle_spritecard.frag.slang
@@ -294,13 +294,12 @@ void main(void) {
         alpha = smoothstep(uAlphaRemapRange.x, uAlphaRemapRange.y, rawAlpha);
     }
 
-    // Overlay the outline colour across its alpha band. Solid between Start1 and End0, feathered outside;
-    // the second smoothstep runs with its edges swapped so that it falls rather than rises.
+    // Overlay the outline colour across its alpha band. Solid between Start1 and End0, feathered outside.
     if (uOutline && rawAlpha >= uOutlineRanges.x && rawAlpha <= uOutlineRanges.w)
     {
         float outlineRamp = rawAlpha <= uOutlineRanges.z
             ? smoothstep(uOutlineRanges.x, uOutlineRanges.z, rawAlpha)
-            : smoothstep(uOutlineRanges.w, uOutlineRanges.y, rawAlpha);
+            : 1.0 - smoothstep(uOutlineRanges.y, uOutlineRanges.w, rawAlpha);
 
         finalColor = mix(finalColor, uOutlineColor.rgb, outlineRamp);
         alpha = mix(alpha, uOutlineColor.a, outlineRamp);

--- a/Renderer/Shaders/particle_spritecard.vert.slang
+++ b/Renderer/Shaders/particle_spritecard.vert.slang
@@ -33,7 +33,8 @@ uniform bool uGammaCorrectVertexColors = true;
 uniform vec3 uColorScale = vec3(1.0);
 
 // m_flDepthBias, in world units along the view direction. The card keeps its drawn position and only
-// its depth is re-taken from the shifted point, so an effect can sit in front of nearby geometry.
+// its depth is re-taken from the shifted point, so a positive bias makes the card lose the depth test
+// against geometry it is in front of, and a negative one makes it win.
 uniform float uDepthBias = 0.0;
 
 out vec2 vTexCoordOut;

--- a/Renderer/Utils/ParallelDispatch.cs
+++ b/Renderer/Utils/ParallelDispatch.cs
@@ -1,0 +1,206 @@
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace ValveResourceFormat.Renderer.Utils;
+
+/// <summary>
+/// A body of work split by index across <see cref="ParallelDispatch"/>. Implemented by a long lived
+/// object, so that running it allocates nothing.
+/// </summary>
+public interface IParallelWork
+{
+    /// <summary>Runs one item, alongside other indices. Touch only what this index owns.</summary>
+    /// <param name="index">Item to run, within the count passed to <see cref="ParallelDispatch.Run"/>.</param>
+    void Execute(int index);
+}
+
+/// <summary>
+/// Runs an <see cref="IParallelWork"/> over a range of indices on the thread pool without allocating.
+/// </summary>
+public sealed class ParallelDispatch : IDisposable
+{
+    private readonly int chunkSize;
+    private readonly ManualResetEventSlim done = new(false);
+
+    private Worker[]? workers;
+    private IParallelWork? activeWork;
+    private Exception? exception;
+
+    /// <summary>Count in the high 32 bits, next unclaimed index in the low 32.</summary>
+    private long claim;
+    private int completedChunks;
+    private int chunkCount;
+
+    /// <summary>Creates a dispatch. The workers are built on the first <see cref="Run"/> that needs them.</summary>
+    /// <param name="chunkSize">
+    /// Indices claimed at a time: enough to amortize the interlocked handoff, few enough that heavy
+    /// items landing together do not strand a thread at the end.
+    /// </param>
+    public ParallelDispatch(int chunkSize = 16)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(chunkSize);
+
+        this.chunkSize = chunkSize;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="work"/> over <c>[0, count)</c> and returns once every index has run. A
+    /// worker's exception is rethrown here.
+    /// </summary>
+    /// <param name="work">Work to run. Held for the call only.</param>
+    /// <param name="count">Number of indices to run.</param>
+    public void Run(IParallelWork work, int count)
+    {
+        // Not enough to fill two chunks, so there is nothing for a second thread to take
+        if (count < chunkSize * 2)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                work.Execute(i);
+            }
+
+            return;
+        }
+
+        workers ??= CreateWorkers();
+
+        activeWork = work;
+        chunkCount = (count + chunkSize - 1) / chunkSize;
+        completedChunks = 0;
+        exception = null;
+        done.Reset();
+
+        // Armed last, with release semantics: a worker still draining from an earlier call reads that
+        // call's exhausted word or this one's published state, never a mix
+        Volatile.Write(ref claim, (long)count << 32);
+
+        foreach (var worker in workers)
+        {
+            worker.Queue();
+        }
+
+        // The calling thread is a worker too, so a starved pool costs latency rather than a stall
+        Drain();
+
+        // Blocking, not spinning: SpinWait escalates to Sleep(1), which rounds up to the scheduler tick
+        done.Wait();
+
+        activeWork = null;
+
+        if (exception != null)
+        {
+            ExceptionDispatchInfo.Throw(exception);
+        }
+    }
+
+    private Worker[] CreateWorkers()
+    {
+        // One short of the processor count, because the calling thread drains alongside them
+        var created = new Worker[Math.Max(1, Environment.ProcessorCount - 1)];
+
+        for (var i = 0; i < created.Length; i++)
+        {
+            created[i] = new Worker(this);
+        }
+
+        return created;
+    }
+
+    /// <summary>
+    /// Claims chunks until the range is exhausted, on the calling thread and every worker alike. Counting
+    /// chunks rather than workers means one the pool starts late is extra help, not a miscount.
+    /// </summary>
+    private void Drain()
+    {
+        while (TryClaim(out var start, out var end))
+        {
+            var work = activeWork!;
+
+            try
+            {
+                for (var i = start; i < end; i++)
+                {
+                    work.Execute(i);
+                }
+            }
+            catch (Exception thrown)
+            {
+                // Rethrown by the caller; escaping a pool thread would take the process down
+                Interlocked.CompareExchange(ref exception, thrown, null);
+            }
+            finally
+            {
+                // Every chunk increments once, so the total is only reached after the last one is done
+                if (Interlocked.Increment(ref completedChunks) == chunkCount)
+                {
+                    done.Set();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Takes the next chunk off <see cref="claim"/>. Count and index are packed together so a claim reads
+    /// both from one snapshot, and a worker outliving its call cannot mix two ranges.
+    /// </summary>
+    private bool TryClaim(out int start, out int end)
+    {
+        var current = Volatile.Read(ref claim);
+
+        while (true)
+        {
+            var index = (int)current;
+            var count = (int)(current >> 32);
+
+            if (index >= count)
+            {
+                start = 0;
+                end = 0;
+                return false;
+            }
+
+            end = Math.Min(index + chunkSize, count);
+
+            var claimed = (current & ~0xFFFFFFFFL) | (uint)end;
+            var previous = Interlocked.CompareExchange(ref claim, claimed, current);
+
+            if (previous == current)
+            {
+                start = index;
+                return true;
+            }
+
+            current = previous;
+        }
+    }
+
+    /// <summary>
+    /// A reusable thread pool work item, queued once per <see cref="Run"/>. The item itself is queued
+    /// rather than a delegate, which would allocate.
+    /// </summary>
+    private sealed class Worker(ParallelDispatch dispatch) : IThreadPoolWorkItem
+    {
+        private int queued;
+
+        /// <summary>Queues this worker unless it is still unstarted in the pool from an earlier call.</summary>
+        public void Queue()
+        {
+            if (Interlocked.Exchange(ref queued, 1) == 1)
+            {
+                return;
+            }
+
+            ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+        }
+
+        public void Execute()
+        {
+            Volatile.Write(ref queued, 0);
+
+            dispatch.Drain();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => done.Dispose();
+}

--- a/ValveResourceFormat/Particles/AttributeMapping.cs
+++ b/ValveResourceFormat/Particles/AttributeMapping.cs
@@ -150,30 +150,26 @@ namespace ValveResourceFormat.Particles
                     return value * multFactor;
 
                 case PfMapType.Remap:
-                    var valueIn = inputMode switch
-                    {
-                        PfInputMode.Clamped => Math.Clamp(value, input0, input1),
-                        PfInputMode.Looped => value % (input1 - input0),
-                        _ => value
-                    };
+                    var valueIn = WrapInput(value);
 
-                    return MathUtils.RemapRange(valueIn, input0, input1, output0, output1);
+                    if (input0 == input1)
+                    {
+                        return valueIn >= input1 ? output1 : output0;
+                    }
+
+                    return ClampToOutputRange(
+                        MathUtils.RemapRange(valueIn, input0, input1, output0, output1));
 
                 case PfMapType.RemapBiased:
-                    var remappedTo0_1RangeBiased = MathUtils.Remap(value, input0, input1);
-
-                    remappedTo0_1RangeBiased = inputMode == PfInputMode.Looped
-                        ? MathUtils.Fract(remappedTo0_1RangeBiased)
-                        : MathF.Min(remappedTo0_1RangeBiased, 1f);
-
-                    var biased = ParticleMath.BiasFromParameter(remappedTo0_1RangeBiased, biasParameter, biasType);
+                    var remappedTo0_1RangeBiased = MathUtils.Remap(WrapInput(value), input0, input1);
 
                     // The lower end of the input range is never clamped; the output range is what bounds
                     // the result, and the bias curve is free to run past either end on the way there
-                    return Math.Clamp(
-                        float.Lerp(output0, output1, biased),
-                        MathF.Min(output0, output1),
-                        MathF.Max(output0, output1));
+                    remappedTo0_1RangeBiased = MathF.Min(remappedTo0_1RangeBiased, 1f);
+
+                    var biased = ParticleMath.BiasFromParameter(remappedTo0_1RangeBiased, biasParameter, biasType);
+
+                    return ClampToOutputRange(float.Lerp(output0, output1, biased));
 
                 case PfMapType.Curve:
                     return curve!.Evaluate(value);
@@ -195,5 +191,23 @@ namespace ValveResourceFormat.Particles
                     return value;
             }
         }
+
+        /// <summary>
+        /// Folds the input back into <c>[0, m_flInput1)</c> when the input mode is looped. The period is
+        /// the range's upper end alone, so a range that does not start at zero still wraps at
+        /// <see cref="input1"/>, and a negative input wraps forward rather than keeping its sign.
+        /// </summary>
+        private float WrapInput(float value)
+        {
+            if (inputMode != PfInputMode.Looped || input1 == 0f)
+            {
+                return value;
+            }
+
+            return input1 * MathUtils.Fract(value / input1);
+        }
+
+        private float ClampToOutputRange(float value)
+            => Math.Clamp(value, MathF.Min(output0, output1), MathF.Max(output0, output1));
     }
 }

--- a/ValveResourceFormat/Particles/Constraints/ParticleFunctionConstraint.cs
+++ b/ValveResourceFormat/Particles/Constraints/ParticleFunctionConstraint.cs
@@ -11,6 +11,11 @@ namespace ValveResourceFormat.Particles.Constraints
         {
         }
 
+        /// <summary>Drops any state the constraint captured from the particles it has seen so far.</summary>
+        public virtual void Reset()
+        {
+        }
+
         /// <summary>
         /// Applies one relaxation pass of the constraint to the particle collection. Returns true when the
         /// constraint may have moved particles, which the renderer's work list uses to decide whether other

--- a/ValveResourceFormat/Particles/Constraints/RopeSpringConstraint.cs
+++ b/ValveResourceFormat/Particles/Constraints/RopeSpringConstraint.cs
@@ -41,6 +41,12 @@ namespace ValveResourceFormat.Particles.Constraints
             adjustmentScale = parse.Float("m_flAdjustmentScale", adjustmentScale);
         }
 
+        public override void Reset()
+        {
+            captured = false;
+            baseLength = 0f;
+        }
+
         public override bool ApplyConstraint(ParticleCollection particles, float frameTime, ParticleSystemState particleSystemState)
         {
             var current = particles.Current;

--- a/ValveResourceFormat/Particles/Emitters/InstantaneousEmitter.cs
+++ b/ValveResourceFormat/Particles/Emitters/InstantaneousEmitter.cs
@@ -57,6 +57,8 @@ namespace ValveResourceFormat.Particles.Emitters
 
             remainingToEmit = 0;
             countResolved = false;
+            snapshotResolved = false;
+            snapshotTimes = null;
             snapshotCursor = 0;
         }
 
@@ -126,7 +128,10 @@ namespace ValveResourceFormat.Particles.Emitters
 
             for (var i = 0; i < numToEmit; i++)
             {
-                // Every particle is stamped at the start-time instant, offset by its snapshot release time
+                // Every particle is stamped at the start-time instant, offset by its snapshot release time.
+                // An entry is due once the elapsed time alone reaches its release time, while the stamp also
+                // subtracts the start time, so a snapshot released under a non-zero start time carries ages
+                // below zero and the particles concerned outlive their authored lifetime.
                 var ageAtSpawn = elapsed - nextStartTime;
 
                 if (snapshotTimes != null)

--- a/ValveResourceFormat/Particles/ForceGenerators/TwistAroundAxis.cs
+++ b/ValveResourceFormat/Particles/ForceGenerators/TwistAroundAxis.cs
@@ -47,7 +47,7 @@ class TwistAroundAxis : ParticleFunctionForceGenerator
                 continue;
             }
 
-            var direction = Vector3.Normalize(delta);
+            var direction = ParticleMath.Normalize(delta);
             var alignment = 1f - Vector3.Dot(direction, axis);
 
             if (alignment * alignment <= ParticleMath.MinimumLengthSquared)

--- a/ValveResourceFormat/Particles/ITransformProvider.cs
+++ b/ValveResourceFormat/Particles/ITransformProvider.cs
@@ -1,3 +1,4 @@
+using ValveResourceFormat.Particles.Utils;
 using ValveResourceFormat.ResourceTypes;
 
 namespace ValveResourceFormat.Particles
@@ -107,7 +108,7 @@ namespace ValveResourceFormat.Particles
             // direction itself, so there is nothing to build here.
             orientation = cp.Rotation is { } fullRotation
                 ? Vector3.Transform(Vector3.UnitX, fullRotation)
-                : Vector3.Normalize(cp.Orientation);
+                : ParticleMath.Normalize(cp.Orientation);
 
             return true;
         }

--- a/ValveResourceFormat/Particles/Initializers/CreateOnGrid.cs
+++ b/ValveResourceFormat/Particles/Initializers/CreateOnGrid.cs
@@ -73,15 +73,16 @@ namespace ValveResourceFormat.Particles.Initializers
 
             // Slower but infinitely better and more stable code
 
-            // If hollow but the size never gets above 2 in any dimension.
-            // Important note: hollow + 1x1x1 actually will cause a crash in Source 2
             var totalCount = dimenX * dimenY * dimenZ;
 
             var hollowDimenX = 0;
             var hollowDimenY = 0;
             var hollowDimenZ = 0;
 
-            if (hollow)
+            // A grid one cell across in every dimension has no interior to hollow out, and is filled
+            var isHollow = hollow && (dimenX != 1 || dimenY != 1 || dimenZ != 1);
+
+            if (isHollow)
             {
                 // dimenX = ceil(rawDimenX)
                 // ceil(rawDimX) - RawDimX = extra leftover value
@@ -110,13 +111,13 @@ namespace ValveResourceFormat.Particles.Initializers
             // really slow but the cleanest way to do it
             for (var z = 0; z < dimenZ; z++)
             {
-                hollowZ = hollow && HollowTest(z, dimenZ, hollowDimenZ);
+                hollowZ = isHollow && HollowTest(z, dimenZ, hollowDimenZ);
                 for (var y = 0; y < dimenY; y++)
                 {
-                    hollowY = hollow && HollowTest(y, dimenY, hollowDimenY);
+                    hollowY = isHollow && HollowTest(y, dimenY, hollowDimenY);
                     for (var x = 0; x < dimenX; x++)
                     {
-                        hollowX = hollow && HollowTest(x, dimenX, hollowDimenX);
+                        hollowX = isHollow && HollowTest(x, dimenX, hollowDimenX);
 
                         if (hollowX && hollowY && hollowZ)
                         {

--- a/ValveResourceFormat/Particles/Initializers/CreateWithinBox.cs
+++ b/ValveResourceFormat/Particles/Initializers/CreateWithinBox.cs
@@ -34,7 +34,7 @@ namespace ValveResourceFormat.Particles.Initializers
 
             var offset = particleSystemState.GetControlPoint(controlPointNumber).Position;
 
-            particle.Position += position + offset;
+            particle.Position = position + offset;
 
             return particle;
         }

--- a/ValveResourceFormat/Particles/Initializers/CreateWithinSphere.cs
+++ b/ValveResourceFormat/Particles/Initializers/CreateWithinSphere.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -103,7 +105,7 @@ namespace ValveResourceFormat.Particles.Initializers
 
             var bias = distanceBias.NextVector(ref particle, particleSystemState);
 
-            var biasedDirection = Vector3.Normalize(randomVector * bias);
+            var biasedDirection = ParticleMath.Normalize(randomVector * bias);
 
             var radiusMinValue = radiusMin.NextNumber(ref particle, particleSystemState);
             var radiusMaxValue = radiusMax.NextNumber(ref particle, particleSystemState);

--- a/ValveResourceFormat/Particles/Initializers/InitFloat.cs
+++ b/ValveResourceFormat/Particles/Initializers/InitFloat.cs
@@ -12,15 +12,8 @@ namespace ValveResourceFormat.Particles.Initializers
         private readonly INumberProvider inputStrength = new LiteralNumberProvider(1f);
         private readonly ParticleSetMethod setMethod = ParticleSetMethod.PARTICLE_SET_REPLACE_VALUE;
 
-        /// <summary>
-        /// Whether an angle output is converted from degrees. The collection-scoped variant of this
-        /// initializer does not convert, so it passes false.
-        /// </summary>
-        private readonly bool convertsAngles;
-
-        public InitFloat(ParticleDefinitionParser parse, bool convertsAngles = true) : base(parse)
+        public InitFloat(ParticleDefinitionParser parse) : base(parse)
         {
-            this.convertsAngles = convertsAngles;
             outputField = parse.ParticleField("m_nOutputField", outputField);
             inputValue = parse.NumberProvider("m_InputValue", inputValue);
             inputStrength = parse.NumberProvider("m_InputStrength", inputStrength);
@@ -32,21 +25,24 @@ namespace ValveResourceFormat.Particles.Initializers
         public override Particle Initialize(ref Particle particle, ParticleCollection particles, ParticleSystemState particleSystemState)
         {
             var value = inputValue.NextNumber(ref particle, particleSystemState);
-            value *= inputStrength.NextNumber(ref particle, particleSystemState);
 
             // Angles are authored in degrees and stored in radians, the same conversion the dedicated
             // rotation initializers do. The scaling set methods take a unitless multiplier, not an angle,
             // so they are left alone.
-            if (convertsAngles
-                && outputField.IsAngleField()
+            if (outputField.IsAngleField()
                 && setMethod is not (ParticleSetMethod.PARTICLE_SET_SCALE_INITIAL_VALUE or ParticleSetMethod.PARTICLE_SET_SCALE_CURRENT_VALUE))
             {
                 value = float.DegreesToRadians(value);
             }
 
-            var finalValue = particle.ModifyScalarBySetMethodAtSpawn(particles, outputField, value, setMethod);
+            var target = particle.ModifyScalarBySetMethodAtSpawn(particles, outputField, value, setMethod);
 
-            particle.SetScalar(outputField, finalValue);
+            // The strength blends the attribute toward what the set method produced; it is not a
+            // multiplier on the input, so at zero the attribute keeps the value it already had
+            var current = particle.GetScalar(outputField);
+            var strength = inputStrength.NextNumber(ref particle, particleSystemState);
+
+            particle.SetScalar(outputField, float.Lerp(current, target, strength));
 
             return particle;
         }

--- a/ValveResourceFormat/Particles/Initializers/InitFloatCollection.cs
+++ b/ValveResourceFormat/Particles/Initializers/InitFloatCollection.cs
@@ -1,0 +1,37 @@
+namespace ValveResourceFormat.Particles.Initializers
+{
+    /// <summary>
+    /// Sets a scalar particle attribute to a value read once for the whole collection, so every
+    /// particle spawned in a frame receives the same number.
+    /// </summary>
+    /// <remarks>
+    /// The collection-scoped counterpart of <see cref="InitFloat"/>. It carries neither a set method
+    /// nor an input strength, so the value always replaces the attribute, and an angle output is
+    /// stored as authored rather than converted from degrees.
+    ///
+    /// <para>The engine reads the input once for a whole batch of new particles. This reads it once
+    /// per particle instead, which differs only for an input that does not hold still within a
+    /// frame, such as a randomised one.</para>
+    /// </remarks>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_INIT_InitFloatCollection">C_INIT_InitFloatCollection</seealso>
+    class InitFloatCollection : ParticleFunctionInitializer
+    {
+        private readonly ParticleField outputField = ParticleField.Radius;
+        private readonly INumberProvider inputValue = new LiteralNumberProvider(0);
+
+        public InitFloatCollection(ParticleDefinitionParser parse) : base(parse)
+        {
+            outputField = parse.ParticleField("m_nOutputField", outputField);
+            inputValue = parse.NumberProvider("m_InputValue", inputValue);
+        }
+
+        public override ulong WrittenFields => FieldMask(outputField);
+
+        public override Particle Initialize(ref Particle particle, ParticleCollection particles, ParticleSystemState particleSystemState)
+        {
+            particle.SetScalar(outputField, inputValue.NextNumber(particleSystemState));
+
+            return particle;
+        }
+    }
+}

--- a/ValveResourceFormat/Particles/Initializers/NormalAlignToCP.cs
+++ b/ValveResourceFormat/Particles/Initializers/NormalAlignToCP.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -20,7 +22,7 @@ namespace ValveResourceFormat.Particles.Initializers
             // The control point orientation is a forward direction; zero means unset, so keep the default normal.
             if (orientation != Vector3.Zero)
             {
-                particle.Normal = Vector3.Normalize(orientation);
+                particle.Normal = ParticleMath.Normalize(orientation);
             }
 
             return particle;

--- a/ValveResourceFormat/Particles/Initializers/NormalOffset.cs
+++ b/ValveResourceFormat/Particles/Initializers/NormalOffset.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -36,7 +38,7 @@ namespace ValveResourceFormat.Particles.Initializers
 
             if (normalize && normal != Vector3.Zero)
             {
-                normal = Vector3.Normalize(normal);
+                normal = ParticleMath.Normalize(normal);
             }
 
             particle.SetVector(ParticleField.Normal, normal);

--- a/ValveResourceFormat/Particles/Initializers/RemapInitialDirectionToTransformToVector.cs
+++ b/ValveResourceFormat/Particles/Initializers/RemapInitialDirectionToTransformToVector.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -58,7 +60,7 @@ namespace ValveResourceFormat.Particles.Initializers
 
             if (normalize && direction != Vector3.Zero)
             {
-                direction = Vector3.Normalize(direction);
+                direction = ParticleMath.Normalize(direction);
             }
 
             particle.SetVector(fieldOutput, direction * scale);

--- a/ValveResourceFormat/Particles/Initializers/RemapInitialDirectionToTransformToVector.cs
+++ b/ValveResourceFormat/Particles/Initializers/RemapInitialDirectionToTransformToVector.cs
@@ -58,8 +58,12 @@ namespace ValveResourceFormat.Particles.Initializers
                 Vector3.Dot(delta, rotationRowY),
                 Vector3.Dot(delta, rotationRowZ));
 
-            if (normalize && direction != Vector3.Zero)
+            if (normalize)
             {
+                // Z carries an epsilon before the length is taken, so a delta with no direction
+                // comes out pointing along the transform's third axis rather than staying at zero
+                direction.Z += ParticleMath.FloatEpsilon;
+
                 direction = ParticleMath.Normalize(direction);
             }
 

--- a/ValveResourceFormat/Particles/Initializers/RingWave.cs
+++ b/ValveResourceFormat/Particles/Initializers/RingWave.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -21,6 +23,9 @@ namespace ValveResourceFormat.Particles.Initializers
         /// <summary>Transform the ring is centred on, and whose rotation the ring plane lies in.</summary>
         private readonly ITransformProvider transformInput = new ControlPointTransformProvider();
 
+        /// <summary>Drops the vertical part of the outward speed, leaving the ring to spread flat.</summary>
+        private readonly bool xyVelocityOnly;
+
         private float orbitCount;
 
         public RingWave(ParticleDefinitionParser parse) : base(parse)
@@ -32,8 +37,10 @@ namespace ValveResourceFormat.Particles.Initializers
             initialSpeedMin = parse.NumberProvider("m_flInitialSpeedMin", initialSpeedMin);
             initialSpeedMax = parse.NumberProvider("m_flInitialSpeedMax", initialSpeedMax);
             transformInput = parse.TransformInput("m_TransformInput", transformInput);
+            xyVelocityOnly = parse.Boolean("m_bXYVelocityOnly", xyVelocityOnly);
 
-            // other properties: m_flRoll
+            // m_flRoll, m_flPitch and m_flYaw rotate the ring circle, but not the thickness offset,
+            // before the transform is applied. All three default to zero and are not read here.
         }
 
         public override void Reset()
@@ -59,11 +66,18 @@ namespace ValveResourceFormat.Particles.Initializers
 
             particle.Position = Vector3.Transform((radius * radialDirection) + thicknessOffset, transform);
 
-            // Initial speed pushes outward along the ring direction (positive = outward).
+            // Initial speed pushes outward, along the line from the transform to where the particle
+            // actually landed, so the thickness offset tilts the direction as well as the position.
+            var outward = ParticleMath.Normalize(particle.Position - transform.Translation);
+
+            if (xyVelocityOnly)
+            {
+                outward.Z = 0f;
+            }
+
             var speedMin = initialSpeedMin.NextNumber(ref particle, particleSystemState);
             var speedMax = initialSpeedMax.NextNumber(ref particle, particleSystemState);
-            particle.Velocity += Vector3.TransformNormal(radialDirection, transform)
-                * particleSystemState.Random.NextBetween(speedMin, speedMax);
+            particle.Velocity += outward * particleSystemState.Random.NextBetween(speedMin, speedMax);
 
             return particle;
         }

--- a/ValveResourceFormat/Particles/Initializers/RingWave.cs
+++ b/ValveResourceFormat/Particles/Initializers/RingWave.cs
@@ -18,6 +18,9 @@ namespace ValveResourceFormat.Particles.Initializers
         private readonly INumberProvider initialSpeedMin = new LiteralNumberProvider(0);
         private readonly INumberProvider initialSpeedMax = new LiteralNumberProvider(0);
 
+        /// <summary>Transform the ring is centred on, and whose rotation the ring plane lies in.</summary>
+        private readonly ITransformProvider transformInput = new ControlPointTransformProvider();
+
         private float orbitCount;
 
         public RingWave(ParticleDefinitionParser parse) : base(parse)
@@ -28,8 +31,14 @@ namespace ValveResourceFormat.Particles.Initializers
             thickness = parse.NumberProvider("m_flThickness", thickness);
             initialSpeedMin = parse.NumberProvider("m_flInitialSpeedMin", initialSpeedMin);
             initialSpeedMax = parse.NumberProvider("m_flInitialSpeedMax", initialSpeedMax);
+            transformInput = parse.TransformInput("m_TransformInput", transformInput);
 
             // other properties: m_flRoll
+        }
+
+        public override void Reset()
+        {
+            orbitCount = 0;
         }
 
         public override ulong WrittenFields => FieldMask(ParticleField.Position) | FieldMask(ParticleField.PositionPrevious);
@@ -46,12 +55,15 @@ namespace ValveResourceFormat.Particles.Initializers
             var angle = GetNextAngle(particlesPerOrbit, particles.Capacity, particleSystemState);
             var radialDirection = new Vector3(MathF.Cos(angle), MathF.Sin(angle), 0);
 
-            particle.Position += (radius * radialDirection) + thicknessOffset;
+            var transform = transformInput.NextTransform(ref particle, particleSystemState);
+
+            particle.Position = Vector3.Transform((radius * radialDirection) + thicknessOffset, transform);
 
             // Initial speed pushes outward along the ring direction (positive = outward).
             var speedMin = initialSpeedMin.NextNumber(ref particle, particleSystemState);
             var speedMax = initialSpeedMax.NextNumber(ref particle, particleSystemState);
-            particle.Velocity += radialDirection * particleSystemState.Random.NextBetween(speedMin, speedMax);
+            particle.Velocity += Vector3.TransformNormal(radialDirection, transform)
+                * particleSystemState.Random.NextBetween(speedMin, speedMax);
 
             return particle;
         }

--- a/ValveResourceFormat/Particles/Initializers/VelocityFromCP.cs
+++ b/ValveResourceFormat/Particles/Initializers/VelocityFromCP.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -27,7 +29,7 @@ namespace ValveResourceFormat.Particles.Initializers
 
             if (directionOnly && velocity != Vector3.Zero)
             {
-                velocity = Vector3.Normalize(velocity);
+                velocity = ParticleMath.Normalize(velocity);
             }
 
             velocity *= velocityScale;

--- a/ValveResourceFormat/Particles/Initializers/VelocityRadialRandom.cs
+++ b/ValveResourceFormat/Particles/Initializers/VelocityRadialRandom.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Initializers
 {
     /// <summary>
@@ -45,7 +47,7 @@ namespace ValveResourceFormat.Particles.Initializers
 
             var scale = vectorScale.NextVector(ref particle, particleSystemState);
 
-            var direction = Vector3.Normalize(particle.Position - particleSystemState.GetControlPoint(controlPoint).Position);
+            var direction = ParticleMath.Normalize(particle.Position - particleSystemState.GetControlPoint(controlPoint).Position);
 
             particle.Velocity += direction * speed * scale;
 

--- a/ValveResourceFormat/Particles/Operators/FadeAndKill.cs
+++ b/ValveResourceFormat/Particles/Operators/FadeAndKill.cs
@@ -32,32 +32,46 @@ namespace ValveResourceFormat.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
+                // The particle ends when it outlives its lifetime, which is not the same instant as
+                // the end of the fade-out: a fade-out that finishes early leaves it alive and faded
+                if (HasExpired(particle.Age, particle.Lifetime))
+                {
+                    Expire(ref particle, frameTime);
+                    continue;
+                }
+
                 var time = particle.NormalizedAge;
                 var initialAlpha = particle.GetInitialScalar(particles, ParticleField.Alpha);
+                var alpha = particle.Alpha;
 
-                // If fading in
-                if (time >= startFadeInTime && time <= endFadeInTime)
+                if (time >= startFadeInTime && time < endFadeInTime)
                 {
-                    var blend = MathUtils.Remap(time, startFadeInTime, endFadeInTime);
+                    var blend = MathUtils.Smoothstep(startFadeInTime, endFadeInTime, time);
 
-                    // Interpolate from initialAlpha * startAlpha up to initialAlpha
-                    particle.Alpha = float.Lerp(particle.Alpha, float.Lerp(initialAlpha * startAlpha, initialAlpha, blend), strength);
+                    alpha = initialAlpha * float.Lerp(startAlpha, 1f, blend);
                 }
 
-                // If fading out
-                if (time >= startFadeOutTime && time <= endFadeOutTime)
+                if (time >= startFadeOutTime && time < endFadeOutTime)
                 {
-                    var blend = MathUtils.Remap(time, startFadeOutTime, endFadeOutTime);
+                    var blend = MathUtils.Smoothstep(startFadeOutTime, endFadeOutTime, time);
 
-                    // Interpolate from initialAlpha down to initialAlpha * endAlpha
-                    particle.Alpha = float.Lerp(particle.Alpha, float.Lerp(initialAlpha, initialAlpha * endAlpha, blend), strength);
+                    alpha = initialAlpha * float.Lerp(1f, endAlpha, blend);
                 }
 
-                if (time >= endFadeOutTime)
-                {
-                    particle.Kill();
-                }
+                particle.Alpha = BlendsWithStrength ? float.Lerp(particle.Alpha, alpha, strength) : alpha;
             }
+        }
+
+        /// <summary>Whether a particle whose age has exactly reached its lifetime counts as spent.</summary>
+        protected virtual bool HasExpired(float age, float lifetime) => lifetime < age;
+
+        /// <summary>Whether the run strength blends the alpha this operator writes.</summary>
+        protected virtual bool BlendsWithStrength => true;
+
+        /// <summary>Ends a particle that has outlived its lifetime.</summary>
+        protected virtual void Expire(ref Particle particle, float frameTime)
+        {
+            particle.Kill();
         }
     }
 }

--- a/ValveResourceFormat/Particles/Operators/FadeAndKillForTracers.cs
+++ b/ValveResourceFormat/Particles/Operators/FadeAndKillForTracers.cs
@@ -1,0 +1,44 @@
+namespace ValveResourceFormat.Particles.Operators
+{
+    /// <summary>
+    /// Fades a particle's alpha in over a configurable time window and then fades it out, killing
+    /// the particle once it outlives its lifetime.
+    /// </summary>
+    /// <remarks>
+    /// The tracer counterpart of <see cref="FadeAndKill"/>. A particle that runs out mid-frame is
+    /// first pulled back along its own step to the point it ran out at, and only dies on the frame
+    /// after, so the tracer it draws ends where the particle expired rather than wherever the
+    /// frame's movement carried it. It carries no particle-order option.
+    /// </remarks>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_FadeAndKillForTracers">C_OP_FadeAndKillForTracers</seealso>
+    class FadeAndKillForTracers : FadeAndKill
+    {
+        public FadeAndKillForTracers(ParticleDefinitionParser parse) : base(parse)
+        {
+        }
+
+        /// <summary>A particle landing exactly on its lifetime is spent here, one tick sooner than the base does.</summary>
+        protected override bool HasExpired(float age, float lifetime) => lifetime <= age;
+
+        /// <summary>The alpha is written outright; this operator does not read its run strength.</summary>
+        protected override bool BlendsWithStrength => false;
+
+        protected override void Expire(ref Particle particle, float frameTime)
+        {
+            var ageAtFrameStart = particle.Age - frameTime;
+
+            if (ageAtFrameStart >= particle.Lifetime || frameTime <= 0f)
+            {
+                particle.Kill();
+                return;
+            }
+
+            // Pulled back along the step it died on, and left alive for one more frame so the tracer
+            // is drawn ending there. The trail shrinks by the same fraction so its tail follows.
+            var livedThisFrame = (particle.Lifetime - ageAtFrameStart) / frameTime;
+
+            particle.Position = Vector3.Lerp(particle.PositionPrevious, particle.Position, livedThisFrame);
+            particle.TrailLength *= livedThisFrame;
+        }
+    }
+}

--- a/ValveResourceFormat/Particles/Operators/FadeInRandom.cs
+++ b/ValveResourceFormat/Particles/Operators/FadeInRandom.cs
@@ -7,6 +7,7 @@ namespace ValveResourceFormat.Particles.Operators
     /// "Alpha Fade In Random" in the particle editor. Unlike "Alpha Fade In Simple", the range
     /// can be defined in seconds rather than a fraction of the lifespan by turning proportional off.
     /// </remarks>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_FadeIn">C_OP_FadeIn</seealso>
     class FadeInRandom : CGeneralRandomFade
     {
         public FadeInRandom(ParticleDefinitionParser parse) : base(parse, "m_flFadeInTime")

--- a/ValveResourceFormat/Particles/Operators/FadeInRandom.cs
+++ b/ValveResourceFormat/Particles/Operators/FadeInRandom.cs
@@ -23,9 +23,10 @@ namespace ValveResourceFormat.Particles.Operators
                     ? particle.NormalizedAge
                     : particle.Age;
 
-                if (time <= fadeInTime)
+                if (time < fadeInTime)
                 {
-                    particle.Alpha = (time / fadeInTime) * particle.GetInitialScalar(particles, ParticleField.Alpha);
+                    particle.Alpha = MathUtils.Smoothstep(0f, fadeInTime, time)
+                        * particle.GetInitialScalar(particles, ParticleField.Alpha);
                 }
             }
         }

--- a/ValveResourceFormat/Particles/Operators/FadeOutRandom.cs
+++ b/ValveResourceFormat/Particles/Operators/FadeOutRandom.cs
@@ -11,7 +11,11 @@ namespace ValveResourceFormat.Particles.Operators
     /// </remarks>
     class FadeOutRandom : CGeneralRandomFade
     {
+        /// <summary>The bias curve's parameter. 0.5 is the identity, and an authored 0 means 0.5.</summary>
         private readonly float fadeBias = 0.5f;
+
+        /// <summary>Eases the fade along a smoothstep instead of the bias curve, which it replaces.</summary>
+        private readonly bool easeInAndOut = true;
 
         public FadeOutRandom(ParticleDefinitionParser parse) : base(parse, "m_flFadeOutTime")
         {
@@ -23,9 +27,7 @@ namespace ValveResourceFormat.Particles.Operators
             }
 
             fadeBias = bias;
-
-            // Other things that exist that don't seem to do anything:
-            // m_bEaseInAndOut
+            easeInAndOut = parse.Boolean("m_bEaseInAndOut", easeInAndOut);
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemState particleSystemState, float strength)
@@ -38,11 +40,15 @@ namespace ValveResourceFormat.Particles.Operators
                     ? 1.0f - particle.NormalizedAge
                     : particle.Lifetime - particle.Age;
 
-                if (timeLeft <= fadeOutTime)
+                if (timeLeft < fadeOutTime)
                 {
-                    var elapsedFraction = Math.Clamp(1f - timeLeft / fadeOutTime, 0f, 1f);
+                    var elapsedFraction = MathUtils.Saturate(1f - timeLeft / fadeOutTime);
 
-                    if (fadeBias != 0.5f)
+                    if (easeInAndOut)
+                    {
+                        elapsedFraction = MathUtils.Smoothstep(0f, 1f, elapsedFraction);
+                    }
+                    else if (fadeBias != 0.5f)
                     {
                         elapsedFraction = ParticleMath.Bias(elapsedFraction, fadeBias);
                     }

--- a/ValveResourceFormat/Particles/Operators/FadeOutRandom.cs
+++ b/ValveResourceFormat/Particles/Operators/FadeOutRandom.cs
@@ -9,25 +9,18 @@ namespace ValveResourceFormat.Particles.Operators
     /// "Alpha Fade Out Random" in the particle editor. Unlike "Alpha Fade Out Simple", the range
     /// can be defined in seconds rather than a fraction of the lifespan by turning proportional off.
     /// </remarks>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_FadeOut">C_OP_FadeOut</seealso>
     class FadeOutRandom : CGeneralRandomFade
     {
-        /// <summary>The bias curve's parameter. 0.5 is the identity, and an authored 0 means 0.5.</summary>
-        private readonly float fadeBias = 0.5f;
-
-        /// <summary>Eases the fade along a smoothstep instead of the bias curve, which it replaces.</summary>
+        /// <summary>Eases the fade along a smoothstep rather than running it out linearly.</summary>
         private readonly bool easeInAndOut = true;
 
         public FadeOutRandom(ParticleDefinitionParser parse) : base(parse, "m_flFadeOutTime")
         {
-            var bias = parse.Float("m_flFadeBias", fadeBias);
-
-            if (bias == 0.0f)
-            {
-                bias = 0.5f;
-            }
-
-            fadeBias = bias;
             easeInAndOut = parse.Boolean("m_bEaseInAndOut", easeInAndOut);
+
+            // m_flFadeBias is read but never applied: the variant that carries the bias curve is
+            // selected only when the bias is 0.5, the one value at which that curve is the identity.
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemState particleSystemState, float strength)
@@ -47,10 +40,6 @@ namespace ValveResourceFormat.Particles.Operators
                     if (easeInAndOut)
                     {
                         elapsedFraction = MathUtils.Smoothstep(0f, 1f, elapsedFraction);
-                    }
-                    else if (fadeBias != 0.5f)
-                    {
-                        elapsedFraction = ParticleMath.Bias(elapsedFraction, fadeBias);
                     }
 
                     particle.Alpha = (1f - elapsedFraction) * particle.GetInitialScalar(particles, ParticleField.Alpha);

--- a/ValveResourceFormat/Particles/Operators/InterpolateRadius.cs
+++ b/ValveResourceFormat/Particles/Operators/InterpolateRadius.cs
@@ -45,9 +45,21 @@ namespace ValveResourceFormat.Particles.Operators
 
             foreach (ref var particle in particles.Current)
             {
-                var time = particle.NormalizedAge;
+                if (particle.Lifetime <= 0f)
+                {
+                    continue;
+                }
 
-                if (time >= startTime && time < endTime)
+                var time = particle.NormalizedAge;
+                var frameFraction = frameTime / particle.Lifetime;
+
+                // A window shorter than a frame would otherwise fall between two updates and never
+                // be entered, so the window's far end carries a frame's worth of slack
+                var windowEnd = particle.Lifetime * (endTime - startTime) <= frameTime
+                    ? startTime + frameFraction
+                    : endTime;
+
+                if (time >= startTime && time <= frameFraction + windowEnd)
                 {
                     var startScale = this.startScale.NextNumber(ref particle, particleSystemState);
                     var endScale = this.endScale.NextNumber(ref particle, particleSystemState);
@@ -63,7 +75,10 @@ namespace ValveResourceFormat.Particles.Operators
                         timeScale = ParticleMath.Bias(timeScale, bias);
                     }
 
-                    var radiusScale = float.Lerp(startScale, endScale, timeScale);
+                    var radiusScale = Math.Clamp(
+                        float.Lerp(startScale, endScale, timeScale),
+                        MathF.Min(startScale, endScale),
+                        MathF.Max(startScale, endScale));
 
                     particle.Radius = particle.GetInitialScalar(particles, ParticleField.Radius) * radiusScale;
                 }

--- a/ValveResourceFormat/Particles/Operators/InterpolateRadius.cs
+++ b/ValveResourceFormat/Particles/Operators/InterpolateRadius.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -17,7 +19,9 @@ namespace ValveResourceFormat.Particles.Operators
         private readonly INumberProvider startScale = new LiteralNumberProvider(1);
         private readonly INumberProvider endScale = new LiteralNumberProvider(1);
         private readonly bool easeInAndOut;
-        private readonly INumberProvider bias = new LiteralNumberProvider(0.5f);
+
+        /// <summary>The bias curve's parameter. 0.5 is the identity, and an authored 0 means 0.5.</summary>
+        private readonly float bias = 0.5f;
 
 
         public InterpolateRadius(ParticleDefinitionParser parse) : base(parse)
@@ -27,16 +31,23 @@ namespace ValveResourceFormat.Particles.Operators
             startScale = parse.NumberProvider("m_flStartScale", startScale);
             endScale = parse.NumberProvider("m_flEndScale", endScale);
             easeInAndOut = parse.Boolean("m_bEaseInAndOut", easeInAndOut);
-            bias = parse.NumberProvider("m_flBias", bias);
+
+            var authoredBias = parse.Float("m_flBias", bias);
+            bias = authoredBias == 0f ? 0.5f : authoredBias;
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemState particleSystemState, float strength)
         {
+            if (endTime <= startTime)
+            {
+                return;
+            }
+
             foreach (ref var particle in particles.Current)
             {
                 var time = particle.NormalizedAge;
 
-                if (time >= startTime && time <= endTime)
+                if (time >= startTime && time < endTime)
                 {
                     var startScale = this.startScale.NextNumber(ref particle, particleSystemState);
                     var endScale = this.endScale.NextNumber(ref particle, particleSystemState);
@@ -47,8 +58,11 @@ namespace ValveResourceFormat.Particles.Operators
                     {
                         timeScale = timeScale * timeScale * (3 - 2 * timeScale); // smoothstep
                     }
+                    else if (bias != 0.5f)
+                    {
+                        timeScale = ParticleMath.Bias(timeScale, bias);
+                    }
 
-                    timeScale = MathF.Pow(timeScale, 1.0f - bias.NextNumber(ref particle, particleSystemState)); // apply bias to timescale
                     var radiusScale = float.Lerp(startScale, endScale, timeScale);
 
                     particle.Radius = particle.GetInitialScalar(particles, ParticleField.Radius) * radiusScale;

--- a/ValveResourceFormat/Particles/Operators/MovementRotateParticleAroundAxis.cs
+++ b/ValveResourceFormat/Particles/Operators/MovementRotateParticleAroundAxis.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -23,8 +25,10 @@ namespace ValveResourceFormat.Particles.Operators
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemState particleSystemState, float strength)
         {
-            var axis = rotationAxis.NextVector(particleSystemState);
-            axis = axis == Vector3.Zero ? Vector3.UnitZ : Vector3.Normalize(axis);
+            var authoredAxis = rotationAxis.NextVector(particleSystemState);
+
+            // The whole axis is replaced when its x is zero, so a pure Y axis rotates about Z
+            var axis = authoredAxis.X == 0f ? Vector3.UnitZ : ParticleMath.Normalize(authoredAxis);
 
             var transform = transformInput.NextTransform(particleSystemState);
 

--- a/ValveResourceFormat/Particles/Operators/NormalizeVector.cs
+++ b/ValveResourceFormat/Particles/Operators/NormalizeVector.cs
@@ -23,11 +23,9 @@ namespace ValveResourceFormat.Particles.Operators
             {
                 var vector = particle.GetVector(outputField);
 
-                // A zero vector has no direction to normalize
-                if (vector == Vector3.Zero)
-                {
-                    continue;
-                }
+                // Z carries an epsilon before the length is taken, so a vector with no direction
+                // comes out pointing along Z rather than staying at zero
+                vector.Z += ParticleMath.FloatEpsilon;
 
                 vector = ParticleMath.Normalize(vector) * scale;
 

--- a/ValveResourceFormat/Particles/Operators/NormalizeVector.cs
+++ b/ValveResourceFormat/Particles/Operators/NormalizeVector.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -27,7 +29,7 @@ namespace ValveResourceFormat.Particles.Operators
                     continue;
                 }
 
-                vector = Vector3.Normalize(vector) * scale;
+                vector = ParticleMath.Normalize(vector) * scale;
 
                 particle.SetVector(outputField, vector);
             }

--- a/ValveResourceFormat/Particles/Operators/PlaneCull.cs
+++ b/ValveResourceFormat/Particles/Operators/PlaneCull.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -44,7 +46,7 @@ namespace ValveResourceFormat.Particles.Operators
                 direction = ControlPointTransformProvider.TransformDirection(particleSystemState, cp, direction);
             }
 
-            var planeNormal = Vector3.Normalize(direction);
+            var planeNormal = ParticleMath.Normalize(direction);
 
             foreach (ref var particle in particles.Current)
             {

--- a/ValveResourceFormat/Particles/Operators/PointVectorAtNextParticle.cs
+++ b/ValveResourceFormat/Particles/Operators/PointVectorAtNextParticle.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -46,7 +48,7 @@ namespace ValveResourceFormat.Particles.Operators
                 }
 
                 var interp = interpolation.NextNumber(ref particle, particleSystemState);
-                var pointed = Vector3.Lerp(particle.GetVector(outputField), Vector3.Normalize(direction), interp);
+                var pointed = Vector3.Lerp(particle.GetVector(outputField), ParticleMath.Normalize(direction), interp);
                 particle.SetVector(outputField, pointed);
             }
 

--- a/ValveResourceFormat/Particles/Operators/PositionLock.cs
+++ b/ValveResourceFormat/Particles/Operators/PositionLock.cs
@@ -111,8 +111,10 @@ namespace ValveResourceFormat.Particles.Operators
 
                 if (!alwaysLocked)
                 {
-                    var startTime = particleSystemState.Random.ForParticleWithExponentBetween(particle.ParticleId, 11, startTimeExp, startTimeMin, startTimeMax);
-                    var endTime = particleSystemState.Random.ForParticleWithExponentBetween(particle.ParticleId, 12, endTimeExp, endTimeMin, endTimeMax);
+                    // Redrawn every frame from the running counter rather than fixed by the particle,
+                    // so the window a particle unlocks over moves under it while it is alive
+                    var startTime = particleSystemState.Random.NextWithExponentBetween(startTimeExp, startTimeMin, startTimeMax);
+                    var endTime = particleSystemState.Random.NextWithExponentBetween(endTimeExp, endTimeMin, endTimeMax);
 
                     // Fully locked until startTime, fading the lock out until endTime, using normalized lifetime
                     timeFade = particle.NormalizedAge <= startTime

--- a/ValveResourceFormat/Particles/Operators/PositionLock.cs
+++ b/ValveResourceFormat/Particles/Operators/PositionLock.cs
@@ -111,8 +111,8 @@ namespace ValveResourceFormat.Particles.Operators
 
                 if (!alwaysLocked)
                 {
-                    var startTime = ParticleRandom.ForSampleWithExponentBetween(particle.ParticleId, startTimeExp, startTimeMin, startTimeMax);
-                    var endTime = ParticleRandom.ForSampleWithExponentBetween(particle.ParticleId, endTimeExp, endTimeMin, endTimeMax);
+                    var startTime = particleSystemState.Random.ForParticleWithExponentBetween(particle.ParticleId, 11, startTimeExp, startTimeMin, startTimeMax);
+                    var endTime = particleSystemState.Random.ForParticleWithExponentBetween(particle.ParticleId, 12, endTimeExp, endTimeMin, endTimeMax);
 
                     // Fully locked until startTime, fading the lock out until endTime, using normalized lifetime
                     timeFade = particle.NormalizedAge <= startTime

--- a/ValveResourceFormat/Particles/Operators/RemapCrossProductOfTwoVectorsToVector.cs
+++ b/ValveResourceFormat/Particles/Operators/RemapCrossProductOfTwoVectorsToVector.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -30,7 +32,7 @@ namespace ValveResourceFormat.Particles.Operators
 
                 if (normalize)
                 {
-                    cross = Vector3.Normalize(cross);
+                    cross = ParticleMath.Normalize(cross);
                 }
 
                 particle.SetVector(fieldOutput, cross);

--- a/ValveResourceFormat/Particles/Operators/RemapVelocityToVector.cs
+++ b/ValveResourceFormat/Particles/Operators/RemapVelocityToVector.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -42,7 +44,7 @@ namespace ValveResourceFormat.Particles.Operators
                 {
                     if (velocity != Vector3.Zero)
                     {
-                        particle.SetVector(outputField, Vector3.Normalize(velocity) * scale);
+                        particle.SetVector(outputField, ParticleMath.Normalize(velocity) * scale);
                     }
                 }
                 else

--- a/ValveResourceFormat/Particles/Operators/RotateVector.cs
+++ b/ValveResourceFormat/Particles/Operators/RotateVector.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -44,7 +46,7 @@ namespace ValveResourceFormat.Particles.Operators
                     continue;
                 }
 
-                var axis = Vector3.Normalize(drawnAxis);
+                var axis = ParticleMath.Normalize(drawnAxis);
                 var rotationRate = float.DegreesToRadians(float.Lerp(rotRateMin, rotRateMax, random));
 
                 var scale = perParticleScale.NextNumber(ref particle, particleSystemState);
@@ -53,7 +55,7 @@ namespace ValveResourceFormat.Particles.Operators
                 var rotatedVector = Vector3.TransformNormal(currentVector, Matrix4x4.CreateFromAxisAngle(axis, rotationRate * scale * frameTime));
 
                 rotatedVector = normalize
-                    ? Vector3.Normalize(rotatedVector)
+                    ? ParticleMath.Normalize(rotatedVector)
                     : rotatedVector;
 
                 particle.SetVector(outputField, Vector3.Lerp(currentVector, rotatedVector, strength));

--- a/ValveResourceFormat/Particles/Operators/SetFloat.cs
+++ b/ValveResourceFormat/Particles/Operators/SetFloat.cs
@@ -12,15 +12,8 @@ namespace ValveResourceFormat.Particles.Operators
         private readonly ParticleSetMethod setMethod = ParticleSetMethod.PARTICLE_SET_REPLACE_VALUE;
         private readonly INumberProvider lerp = new LiteralNumberProvider(1f);
 
-        /// <summary>
-        /// Whether an angle output is converted from degrees. The collection-scoped variant of this
-        /// operator does not convert, so it passes false.
-        /// </summary>
-        private readonly bool convertsAngles;
-
-        public SetFloat(ParticleDefinitionParser parse, bool convertsAngles = true) : base(parse)
+        public SetFloat(ParticleDefinitionParser parse) : base(parse)
         {
-            this.convertsAngles = convertsAngles;
             outputField = parse.ParticleField("m_nOutputField", outputField);
             value = parse.NumberProvider("m_InputValue", value);
             setMethod = parse.Enum<ParticleSetMethod>("m_nSetMethod", setMethod);
@@ -39,8 +32,7 @@ namespace ValveResourceFormat.Particles.Operators
 
                 // Angles are authored in degrees and stored in radians, as in InitFloat. The scaling
                 // set methods take a unitless multiplier, not an angle, so they are left alone.
-                if (convertsAngles
-                    && outputField.IsAngleField()
+                if (outputField.IsAngleField()
                     && setMethod is not (ParticleSetMethod.PARTICLE_SET_SCALE_INITIAL_VALUE or ParticleSetMethod.PARTICLE_SET_SCALE_CURRENT_VALUE))
                 {
                     value = float.DegreesToRadians(value);
@@ -49,7 +41,8 @@ namespace ValveResourceFormat.Particles.Operators
                 var target = particle.ModifyScalarBySetMethod(particles, outputField, value, setMethod);
                 var currentValue = particle.GetScalar(outputField);
 
-                var blended = float.Lerp(currentValue, target, lerp);
+                var (min, max) = outputField.SetFloatRange();
+                var blended = Math.Clamp(float.Lerp(currentValue, target, lerp), min, max);
 
                 // Strength lerps from the spawn initial for the two initial-value set methods
                 var strengthBase = setMethod is ParticleSetMethod.PARTICLE_SET_SCALE_INITIAL_VALUE or ParticleSetMethod.PARTICLE_SET_ADD_TO_INITIAL_VALUE

--- a/ValveResourceFormat/Particles/Operators/SetFloatCollection.cs
+++ b/ValveResourceFormat/Particles/Operators/SetFloatCollection.cs
@@ -1,0 +1,81 @@
+namespace ValveResourceFormat.Particles.Operators
+{
+    /// <summary>
+    /// Sets a scalar particle attribute from a value read once for the whole collection, blended
+    /// toward by an interpolation factor that is also read once, so the whole collection moves
+    /// toward the same target each frame.
+    /// </summary>
+    /// <remarks>
+    /// The collection-scoped counterpart of <see cref="SetFloat"/>, and not simply that operator with
+    /// a wider input. The run strength multiplies both the value and the interpolation factor before
+    /// either is used, rather than blending the finished result, so strength acts on the outcome
+    /// twice over. An angle output is stored as authored rather than converted from degrees.
+    /// </remarks>
+    /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_SetFloatCollection">C_OP_SetFloatCollection</seealso>
+    class SetFloatCollection : ParticleFunctionOperator
+    {
+        private readonly ParticleField outputField = ParticleField.Radius;
+        private readonly INumberProvider value = new LiteralNumberProvider(0f);
+        private readonly ParticleSetMethod setMethod = ParticleSetMethod.PARTICLE_SET_REPLACE_VALUE;
+        private readonly INumberProvider lerp = new LiteralNumberProvider(1f);
+
+        public SetFloatCollection(ParticleDefinitionParser parse) : base(parse)
+        {
+            outputField = parse.ParticleField("m_nOutputField", outputField);
+            value = parse.NumberProvider("m_InputValue", value);
+            setMethod = parse.Enum<ParticleSetMethod>("m_nSetMethod", setMethod);
+            lerp = parse.NumberProvider("m_Lerp", lerp);
+        }
+
+        public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemState particleSystemState, float strength)
+        {
+            if (particles.Count == 0)
+            {
+                return;
+            }
+
+            var input = value.NextNumber(particleSystemState) * strength;
+            var blend = MathUtils.Saturate(lerp.NextNumber(particleSystemState) * strength);
+            var (min, max) = outputField.SetFloatRange();
+
+            // Replacing resolves to one number for the whole collection, taken from the first
+            // particle's value alone, which every other particle then receives regardless of its own
+            if (setMethod == ParticleSetMethod.PARTICLE_SET_REPLACE_VALUE)
+            {
+                var first = particles.Current[0].GetScalar(outputField);
+                var replacement = Math.Clamp(float.Lerp(first, input, blend), min, max);
+
+                foreach (ref var particle in particles.Current)
+                {
+                    particle.SetScalar(outputField, replacement);
+                }
+
+                return;
+            }
+
+            foreach (ref var particle in particles.Current)
+            {
+                var current = particle.GetScalar(outputField);
+
+                if (setMethod == ParticleSetMethod.PARTICLE_SET_RAMP_CURRENT_VALUE)
+                {
+                    particle.SetScalar(outputField, Math.Clamp(current + (blend * frameTime * input), min, max));
+                    continue;
+                }
+
+                var initial = particle.GetInitialScalar(particles, outputField);
+
+                var target = setMethod switch
+                {
+                    ParticleSetMethod.PARTICLE_SET_SCALE_INITIAL_VALUE => input * initial,
+                    ParticleSetMethod.PARTICLE_SET_ADD_TO_INITIAL_VALUE => initial + input,
+                    ParticleSetMethod.PARTICLE_SET_SCALE_CURRENT_VALUE => input * current,
+                    ParticleSetMethod.PARTICLE_SET_ADD_TO_CURRENT_VALUE => current + input,
+                    _ => input,
+                };
+
+                particle.SetScalar(outputField, Math.Clamp(float.Lerp(current, target, blend), min, max));
+            }
+        }
+    }
+}

--- a/ValveResourceFormat/Particles/Operators/SetVec.cs
+++ b/ValveResourceFormat/Particles/Operators/SetVec.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.Operators
 {
     /// <summary>
@@ -36,7 +38,7 @@ namespace ValveResourceFormat.Particles.Operators
 
                 if (normalizedOutput && value != Vector3.Zero)
                 {
-                    value = Vector3.Normalize(value);
+                    value = ParticleMath.Normalize(value);
                 }
 
                 particle.SetVector(outputField, value);

--- a/ValveResourceFormat/Particles/Particle.cs
+++ b/ValveResourceFormat/Particles/Particle.cs
@@ -1,3 +1,4 @@
+using ValveResourceFormat.Particles.Utils;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.Serialization.KeyValues;
 
@@ -109,7 +110,7 @@ namespace ValveResourceFormat.Particles
         public float Speed
         {
             readonly get => Velocity.Length();
-            set => Velocity = Vector3.Normalize(Velocity) * value;
+            set => Velocity = ParticleMath.Normalize(Velocity) * value;
         }
         /// <summary>
         /// Gets or sets the acceleration accumulated by force generators this frame; consumed and

--- a/ValveResourceFormat/Particles/ParticleControllerFactory.cs
+++ b/ValveResourceFormat/Particles/ParticleControllerFactory.cs
@@ -69,7 +69,7 @@ namespace ValveResourceFormat.Particles
                 ["C_INIT_GlobalScale"] = initializerInfo => new GlobalScale(initializerInfo),
                 ["C_INIT_InitFromCPSnapshot"] = initializerInfo => new InitFromCPSnapshot(initializerInfo),
                 ["C_INIT_InitFloat"] = initializerInfo => new InitFloat(initializerInfo),
-                ["C_INIT_InitFloatCollection"] = initializerInfo => new InitFloat(initializerInfo, convertsAngles: false), // initfloat but the numberprovider has fewer options
+                ["C_INIT_InitFloatCollection"] = initializerInfo => new InitFloatCollection(initializerInfo),
                 ["C_INIT_InitVec"] = initializerInfo => new InitVec(initializerInfo),
                 ["C_INIT_InitialVelocityNoise"] = initializerInfo => new InitialVelocityNoise(initializerInfo),
                 ["C_INIT_PointList"] = initializerInfo => new PointList(initializerInfo),
@@ -117,7 +117,7 @@ namespace ValveResourceFormat.Particles
                 ["C_OP_EndCapTimedDecay"] = operatorInfo => new EndCapTimedDecay(operatorInfo),
                 ["C_OP_EndCapTimedFreeze"] = operatorInfo => new EndCapTimedFreeze(operatorInfo),
                 ["C_OP_FadeAndKill"] = operatorInfo => new FadeAndKill(operatorInfo),
-                ["C_OP_FadeAndKillForTracers"] = operatorInfo => new FadeAndKill(operatorInfo), // alias to C_OP_FadeAndKill
+                ["C_OP_FadeAndKillForTracers"] = operatorInfo => new FadeAndKillForTracers(operatorInfo),
                 ["C_OP_FadeIn"] = operatorInfo => new FadeInRandom(operatorInfo),
                 ["C_OP_FadeInSimple"] = operatorInfo => new FadeInSimple(operatorInfo),
                 ["C_OP_FadeOut"] = operatorInfo => new FadeOutRandom(operatorInfo),
@@ -171,7 +171,7 @@ namespace ValveResourceFormat.Particles
                 ["C_OP_RotateVector"] = operatorInfo => new RotateVector(operatorInfo),
                 ["C_OP_SetAttributeToScalarExpression"] = operatorInfo => new SetAttributeToScalarExpression(operatorInfo),
                 ["C_OP_SetFloat"] = operatorInfo => new SetFloat(operatorInfo),
-                ["C_OP_SetFloatCollection"] = operatorInfo => new SetFloat(operatorInfo, convertsAngles: false), // same as initfloatcollection
+                ["C_OP_SetFloatCollection"] = operatorInfo => new SetFloatCollection(operatorInfo),
                 ["C_OP_SetFromCPSnapshot"] = operatorInfo => new SetFromCPSnapshot(operatorInfo),
                 ["C_OP_SetToCP"] = operatorInfo => new SetToCP(operatorInfo),
                 ["C_OP_SetVec"] = operatorInfo => new SetVec(operatorInfo),

--- a/ValveResourceFormat/Particles/ParticleFieldExtensions.cs
+++ b/ValveResourceFormat/Particles/ParticleFieldExtensions.cs
@@ -385,6 +385,18 @@ namespace ValveResourceFormat.Particles
             => field is ParticleField.Roll or ParticleField.Yaw or ParticleField.Pitch;
 
         /// <summary>
+        /// The range the float set operators hold a written value inside. Alpha is bounded to [0, 1],
+        /// radius and trail length to the non-negative half, and every other field is left free.
+        /// </summary>
+        public static (float Min, float Max) SetFloatRange(this ParticleField field)
+            => field switch
+            {
+                ParticleField.Alpha or ParticleField.AlphaAlternate => (0f, 1f),
+                ParticleField.Radius or ParticleField.TrailLength => (0f, float.MaxValue),
+                _ => (float.MinValue, float.MaxValue),
+            };
+
+        /// <summary>
         /// Whether the field is normalized to [0, 1], which the operators that write it clamp into.
         /// </summary>
         public static bool IsNormalizedField(this ParticleField field)

--- a/ValveResourceFormat/Particles/ParticleSystemSimulation.Simulation.cs
+++ b/ValveResourceFormat/Particles/ParticleSystemSimulation.Simulation.cs
@@ -445,6 +445,11 @@ namespace ValveResourceFormat.Particles
                     continue;
                 }
 
+                if (!childSimulation.IsWithinDrawDistance(systemState.CameraPosition))
+                {
+                    continue;
+                }
+
                 childSimulation.UpdateFrame(frameTime, presimulating);
             }
         }

--- a/ValveResourceFormat/Particles/ParticleSystemSimulation.Simulation.cs
+++ b/ValveResourceFormat/Particles/ParticleSystemSimulation.Simulation.cs
@@ -73,6 +73,11 @@ namespace ValveResourceFormat.Particles
                 particleOperator.Reset();
             }
 
+            foreach (var constraint in constraints)
+            {
+                constraint.Reset();
+            }
+
             foreach (var emitter in emitters)
             {
                 emitter.Start(emitParticleAction, systemState);

--- a/ValveResourceFormat/Particles/ParticleSystemSimulation.cs
+++ b/ValveResourceFormat/Particles/ParticleSystemSimulation.cs
@@ -52,6 +52,32 @@ namespace ValveResourceFormat.Particles
         public AABB LocalBoundingBox { get; private set; } = new AABB(new Vector3(float.MinValue), new Vector3(float.MaxValue));
 
         /// <summary>
+        /// The squared camera distance past which the system is not drawn (<c>m_flMaxDrawDistance</c>),
+        /// or <see cref="float.MaxValue"/> when it draws at any distance. Each system in a tree carries
+        /// its own, so a child can drop out while its parent still draws.
+        /// </summary>
+        public float MaxDrawDistanceSquared { get; }
+
+        /// <summary>
+        /// Whether the camera is near enough for the system to draw. Measured to the nearest point of
+        /// its bounds rather than to their centre, so a system wide enough to reach the camera is kept
+        /// wherever its centre happens to sit.
+        /// </summary>
+        /// <param name="cameraPosition">The world position to measure from.</param>
+        public bool IsWithinDrawDistance(Vector3 cameraPosition)
+        {
+            if (MaxDrawDistanceSquared == float.MaxValue)
+            {
+                return true;
+            }
+
+            var bounds = LocalBoundingBox.Translate(MainControlPoint.Position);
+            var nearest = Vector3.Clamp(cameraPosition, bounds.Min, bounds.Max);
+
+            return Vector3.DistanceSquared(cameraPosition, nearest) <= MaxDrawDistanceSquared;
+        }
+
+        /// <summary>
         /// Watches this system so a drawing layer can follow it. Set by whatever draws the system,
         /// and null when nothing does.
         /// </summary>
@@ -208,6 +234,13 @@ namespace ValveResourceFormat.Particles
             minimumFrames = parse.Int32("m_nMinimumFrames", 0);
             preSimulationTime = parse.Float("m_flPreSimulationTime", 0f);
             stopSimulationAfterTime = parse.Float("m_flStopSimulationAfterTime", 0f);
+
+            // A non-positive distance draws at any range, and one large enough to overflow when squared
+            // is taken as the same thing.
+            var maxDrawDistance = parse.Float("m_flMaxDrawDistance", -1f);
+            MaxDrawDistanceSquared = maxDrawDistance is <= 0f or >= 1e10f
+                ? float.MaxValue
+                : maxDrawDistance * maxDrawDistance;
 
             maximumTimeStep = Math.Max(minimumTimeStep, maximumTimeStep);
 

--- a/ValveResourceFormat/Particles/ParticleSystemSimulation.cs
+++ b/ValveResourceFormat/Particles/ParticleSystemSimulation.cs
@@ -196,6 +196,11 @@ namespace ValveResourceFormat.Particles
             groupId = parse.Int32("m_nGroupID", 0);
             initialParticles = parse.Int32("m_nInitialParticles", 0);
             maxParticles = parse.Int32("m_nMaxParticles", 1000);
+
+            // The pool is capped whatever the file asks for, and a system that simulates on the GPU
+            // is allowed a far larger one
+            var particleCeiling = parse.Boolean("m_bIsGPUParticleSystem", false) ? 100000 : 20000;
+            maxParticles = Math.Min(maxParticles, particleCeiling);
             minimumTimeStep = parse.Float("m_flMinimumTimeStep", 0f);
             maximumTimeStep = parse.Float("m_flMaximumTimeStep", 0.1f);
             minimumSimTime = parse.Float("m_flMinimumSimTime", 0f);

--- a/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointOrientation.cs
+++ b/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointOrientation.cs
@@ -1,3 +1,4 @@
+using ValveResourceFormat.Particles.Utils;
 using ValveResourceFormat.ResourceTypes;
 
 namespace ValveResourceFormat.Particles.PreEmissionOperators
@@ -63,7 +64,7 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
                 var referenceOrientation = particleSystemState.GetControlPoint(headLocation).Orientation;
                 if (referenceOrientation != Vector3.Zero)
                 {
-                    targetOrientation = Vector3.Normalize(targetOrientation + referenceOrientation);
+                    targetOrientation = ParticleMath.Normalize(targetOrientation + referenceOrientation);
                 }
             }
 
@@ -73,7 +74,7 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
 
             if (outputOrientation != Vector3.Zero)
             {
-                outputOrientation = Vector3.Normalize(outputOrientation);
+                outputOrientation = ParticleMath.Normalize(outputOrientation);
             }
 
             particleSystemState.SetControlPointOrientation(cp, outputOrientation);

--- a/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointPositions.cs
+++ b/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointPositions.cs
@@ -37,6 +37,11 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
             cpOffset = parse.Int32("m_nHeadLocation", cpOffset);
         }
 
+        public override void Reset()
+        {
+            hasRunBefore = false;
+        }
+
         public override void Operate(ref ParticleSystemState particleSystemState, float frameTime)
         {
             if (!(setOnce && hasRunBefore))

--- a/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointRotation.cs
+++ b/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointRotation.cs
@@ -23,14 +23,12 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
 
         public override void Operate(ref ParticleSystemState particleSystemState, float frameTime)
         {
-            var axis = this.axis.NextVector(particleSystemState);
+            var authoredAxis = this.axis.NextVector(particleSystemState);
 
-            if (axis == Vector3.Zero)
-            {
-                return;
-            }
-
-            axis = ParticleMath.Normalize(axis);
+            // The whole axis is replaced when its x is zero, so a pure Y axis rotates about Z
+            var axis = authoredAxis.X == 0f
+                ? Vector3.UnitZ
+                : ParticleMath.Normalize(authoredAxis);
 
             if (localCP > -1)
             {

--- a/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointRotation.cs
+++ b/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointRotation.cs
@@ -1,3 +1,5 @@
+using ValveResourceFormat.Particles.Utils;
+
 namespace ValveResourceFormat.Particles.PreEmissionOperators
 {
     /// <summary>
@@ -28,7 +30,7 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
                 return;
             }
 
-            axis = Vector3.Normalize(axis);
+            axis = ParticleMath.Normalize(axis);
 
             if (localCP > -1)
             {

--- a/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointToVectorExpression.cs
+++ b/ValveResourceFormat/Particles/PreEmissionOperators/SetControlPointToVectorExpression.cs
@@ -3,6 +3,9 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
     /// <summary>
     /// Evaluates a binary vector expression (add, subtract, multiply, divide, cross product, etc.)
     /// on two input vectors and writes the result to a control point.
+    ///
+    /// <para>Division is component-wise and takes no special path for a zero divisor, so it writes an
+    /// infinity or a NaN into the control point. The scalar expression operators substitute zero.</para>
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_SetControlPointToVectorExpression">C_OP_SetControlPointToVectorExpression</seealso>
     class SetControlPointToVectorExpression : ParticleFunctionPreEmissionOperator

--- a/ValveResourceFormat/Particles/PreEmissionOperators/SetSingleControlPointPosition.cs
+++ b/ValveResourceFormat/Particles/PreEmissionOperators/SetSingleControlPointPosition.cs
@@ -23,6 +23,11 @@ namespace ValveResourceFormat.Particles.PreEmissionOperators
             transformInput = parse.TransformInput("m_transformInput", transformInput);
         }
 
+        public override void Reset()
+        {
+            hasRunBefore = false;
+        }
+
         public override void Operate(ref ParticleSystemState particleSystemState, float frameTime)
         {
             if (!(setOnce && hasRunBefore))

--- a/ValveResourceFormat/Particles/Upgrade/Vpcf27ToVpcf28.cs
+++ b/ValveResourceFormat/Particles/Upgrade/Vpcf27ToVpcf28.cs
@@ -7,6 +7,12 @@ namespace ValveResourceFormat.Particles.Upgrade;
 /// renderers into m_vecTexturesInput entries plus m_nOutputBlendMode. Two-sequence combine
 /// modes emit a second entry with per-entry channel masks, and motion-vector and normal-map
 /// textures append typed entries.
+///
+/// <para>Two of the members written here look wrong and are what the engine's own converter
+/// produces. The first entry's zoom goes to <c>m_flZoomMax</c>, which no schema declares, so it
+/// is dropped again when the upgraded file binds; only the second entry's <c>m_flZoomScale</c>
+/// survives. <c>m_flAnimationRate2</c> becomes a UV rotation, there being no per-layer rate
+/// member to carry it.</para>
 /// </summary>
 internal sealed class Vpcf27ToVpcf28 : ParticleUpgradeStep
 {

--- a/ValveResourceFormat/Particles/Utils/ParticleMath.cs
+++ b/ValveResourceFormat/Particles/Utils/ParticleMath.cs
@@ -28,6 +28,17 @@ namespace ValveResourceFormat.Particles.Utils
         /// </summary>
         public static float HalfWave(float t) => (4f - (4f * t)) * t;
 
+        /// <summary>
+        /// Scales <paramref name="value"/> to unit length, returning <see cref="Vector3.Zero"/> for a
+        /// vector with no length rather than the NaN a plain divide would give.
+        /// </summary>
+        public static Vector3 Normalize(Vector3 value)
+        {
+            var lengthSquared = value.LengthSquared();
+
+            return lengthSquared == 0f ? Vector3.Zero : value / MathF.Sqrt(lengthSquared);
+        }
+
         public static float Square(float value) => value * value;
 
         /// <summary>

--- a/ValveResourceFormat/Particles/Utils/SnapshotBinding.cs
+++ b/ValveResourceFormat/Particles/Utils/SnapshotBinding.cs
@@ -68,14 +68,10 @@ namespace ValveResourceFormat.Particles.Utils
         /// </summary>
         public ParticleSnapshot? Resolve(ParticleSystemState particleSystemState)
         {
-            if (!resolved)
+            if (!resolved && IsBound)
             {
-                resolved = true;
-
-                if (IsBound)
-                {
-                    snapshot = particleSystemState.GetControlPointSnapshot(controlPoint);
-                }
+                snapshot = particleSystemState.GetControlPointSnapshot(controlPoint);
+                resolved = snapshot != null;
             }
 
             return snapshot;


### PR DESCRIPTION
The simulation maths now follows the engine: bias-eased radius interpolation, smoothstepped fades, looped remaps, guarded normalisation, clamped SetFloat writes, and per-function state that resets on restart. 

Three classes that collapsed distinct engine pairs are split into their own implementations.

Systems past their m_flMaxDrawDistance stop drawing and simulating, the particle pool is clamped to the engine's ceiling, and the scene steps its systems across the thread pool.