### PR TITLE
Fix alpha test overdraw and slow shadow path

### DIFF
--- a/GUI/Types/GLViewers/GLSceneViewer.cs
+++ b/GUI/Types/GLViewers/GLSceneViewer.cs
@@ -685,10 +685,7 @@ namespace GUI.Types.GLViewers
                 else if (QuadOverdrawRenderer?.IsActive == true)
                 {
                     QuadOverdrawRenderer.Prepare(MainFramebuffer.Width, MainFramebuffer.Height);
-                    renderContext.ReplacementShader = QuadOverdrawRenderer.SceneShader;
 
-                    // set to true to render quad overdraw later, first draw the scene normally in order to have a depth buffer
-                    // so things dont look weird in quad overdraw
                     quadOverdrawThisFrame = true;
                 }
 
@@ -699,7 +696,11 @@ namespace GUI.Types.GLViewers
                     using (new GLDebugGroup("Quad Overdraw Counting Pass"))
                     {
                         QuadOverdrawRenderer!.BeginCountingPass(MainFramebuffer);
+
+                        renderContext.OverdrawShader = QuadOverdrawRenderer.SceneShader;
                         Renderer.RenderScenesWithView(renderContext);
+                        renderContext.OverdrawShader = null;
+
                         QuadOverdrawRenderer.EndCountingPass(MainFramebuffer);
                     }
 

--- a/Renderer/Particles/ParticleRenderer.cs
+++ b/Renderer/Particles/ParticleRenderer.cs
@@ -117,6 +117,11 @@ namespace ValveResourceFormat.Renderer.Particles
                     : renderer.Pass == RenderPass.Opaque
                         ? CustomRenderPasses.Opaque
                         : CustomRenderPasses.Translucent;
+
+                if (renderer.CanRenderDepth)
+                {
+                    passes |= CustomRenderPasses.DepthOnly;
+                }
             }
 
             foreach (var childRenderer in childRenderers)
@@ -201,9 +206,18 @@ namespace ValveResourceFormat.Renderer.Particles
 
             var rendered = false;
 
+            var depthPass = pass == RenderPass.DepthOnly;
+
             foreach (var renderer in renderers)
             {
-                if (renderer.Pass != pass || renderer.OnlyRenderInEffectsWaterPass != waterEffectsLayer)
+                if (depthPass)
+                {
+                    if (!renderer.CanRenderDepth)
+                    {
+                        continue;
+                    }
+                }
+                else if (renderer.Pass != pass || renderer.OnlyRenderInEffectsWaterPass != waterEffectsLayer)
                 {
                     continue;
                 }
@@ -213,7 +227,15 @@ namespace ValveResourceFormat.Renderer.Particles
                     continue;
                 }
 
-                renderer.Render(Simulation.Particles, Simulation.RenderState, camera);
+                if (depthPass)
+                {
+                    renderer.RenderDepth(Simulation.Particles, Simulation.RenderState, camera);
+                }
+                else
+                {
+                    renderer.Render(Simulation.Particles, Simulation.RenderState, camera);
+                }
+
                 rendered = true;
             }
 

--- a/Renderer/Particles/ParticleRenderer.cs
+++ b/Renderer/Particles/ParticleRenderer.cs
@@ -210,19 +210,11 @@ namespace ValveResourceFormat.Renderer.Particles
 
             foreach (var renderer in renderers)
             {
-                if (depthPass)
-                {
-                    if (!renderer.CanRenderDepth)
-                    {
-                        continue;
-                    }
-                }
-                else if (renderer.Pass != pass || renderer.OnlyRenderInEffectsWaterPass != waterEffectsLayer)
-                {
-                    continue;
-                }
+                var inPass = depthPass
+                    ? renderer.CanRenderDepth
+                    : renderer.Pass == pass && renderer.OnlyRenderInEffectsWaterPass == waterEffectsLayer;
 
-                if (renderer.GetOperatorRunStrength(Simulation.RenderState) <= 0.0f)
+                if (!inPass || renderer.GetOperatorRunStrength(Simulation.RenderState) <= 0.0f)
                 {
                     continue;
                 }

--- a/Renderer/Particles/ParticleRenderer.cs
+++ b/Renderer/Particles/ParticleRenderer.cs
@@ -184,8 +184,6 @@ namespace ValveResourceFormat.Renderer.Particles
         /// </summary>
         public void Render(Camera camera, RenderPass pass, bool waterEffectsLayer = false)
         {
-            var wantedPass = pass == RenderPass.DepthOnly ? RenderPass.Opaque : pass;
-
             foreach (var childRenderer in childRenderers)
             {
                 if (!childRenderer.Simulation.ShouldRunAsChildOf(Simulation.RenderState))
@@ -205,7 +203,7 @@ namespace ValveResourceFormat.Renderer.Particles
 
             foreach (var renderer in renderers)
             {
-                if (renderer.Pass != wantedPass || renderer.OnlyRenderInEffectsWaterPass != waterEffectsLayer)
+                if (renderer.Pass != pass || renderer.OnlyRenderInEffectsWaterPass != waterEffectsLayer)
                 {
                     continue;
                 }

--- a/Renderer/Particles/Renderers/ParticleFunctionRenderer.cs
+++ b/Renderer/Particles/Renderers/ParticleFunctionRenderer.cs
@@ -181,11 +181,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
         public abstract void Render(ParticleCollection particles, ParticleSystemState systemState, Camera camera);
 
-        /// <summary>
-        /// Whether this renderer draws itself into <see cref="RenderPass.DepthOnly"/>, and so casts a shadow.
-        /// Set alongside <see cref="Pass"/>, and only for solid geometry that has a shader laying down depth
-        /// without shading: those passes render into the shadow maps a forward pixel shader samples.
-        /// </summary>
+        /// <summary>Whether this renderer draws itself into <see cref="RenderPass.DepthOnly"/>. Set alongside <see cref="Pass"/>.</summary>
         public bool CanRenderDepth { get; protected set; }
 
         /// <summary>Draws depth only.</summary>

--- a/Renderer/Particles/Renderers/ParticleFunctionRenderer.cs
+++ b/Renderer/Particles/Renderers/ParticleFunctionRenderer.cs
@@ -181,6 +181,18 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
         public abstract void Render(ParticleCollection particles, ParticleSystemState systemState, Camera camera);
 
+        /// <summary>
+        /// Whether this renderer draws itself into <see cref="RenderPass.DepthOnly"/>, and so casts a shadow.
+        /// Set alongside <see cref="Pass"/>, and only for solid geometry that has a shader laying down depth
+        /// without shading: those passes render into the shadow maps a forward pixel shader samples.
+        /// </summary>
+        public bool CanRenderDepth { get; protected set; }
+
+        /// <summary>Draws depth only.</summary>
+        public virtual void RenderDepth(ParticleCollection particles, ParticleSystemState systemState, Camera camera)
+        {
+        }
+
         /// <summary>A sheet frame rectangle as the shader reads it: minimum in xy, maximum in zw.</summary>
         /// <param name="min">Lower corner.</param>
         /// <param name="max">Upper corner.</param>

--- a/Renderer/Particles/Renderers/RenderCables.cs
+++ b/Renderer/Particles/Renderers/RenderCables.cs
@@ -393,7 +393,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             VertexArray.Bind(vaoHandle, drawShader);
             material.Render(drawShader);
 
-            // A depth mode shades nothing, so it reads none of the lighting the binds below are for.
             if (!depthOnly)
             {
                 // todo: batch tube draws and call this less often

--- a/Renderer/Particles/Renderers/RenderCables.cs
+++ b/Renderer/Particles/Renderers/RenderCables.cs
@@ -19,6 +19,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
         private const string ShaderName = "particle_cable";
 
         private Shader shader;
+        private readonly Shader? depthShader;
         private readonly Scene scene;
         private readonly RenderMaterial material;
         private readonly bool ownsMaterial;
@@ -107,6 +108,9 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
             Pass = material.IsTranslucent ? RenderPass.Translucent : RenderPass.Opaque;
 
+            depthShader = shader.DepthMode;
+            CanRenderDepth = Pass == RenderPass.Opaque && !OnlyRenderInEffectsWaterPass && depthShader != null;
+
             vaoHandle = SetupBuffers();
         }
 
@@ -162,7 +166,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
             if (!GeometryChanged(positions, levels, radii, colors))
             {
-                DrawTube();
                 return;
             }
 
@@ -232,7 +235,16 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
         public override void Render(ParticleCollection particles, ParticleSystemState systemState, Camera camera)
         {
-            DrawTube();
+            DrawTube(shader);
+        }
+
+        /// <inheritdoc/>
+        public override void RenderDepth(ParticleCollection particles, ParticleSystemState systemState, Camera camera)
+        {
+            if (depthShader != null)
+            {
+                DrawTube(depthShader, depthOnly: true);
+            }
         }
 
         /// <summary>
@@ -370,24 +382,28 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
         // Grow-only: reused buffers are sliced to the live count, so shrinking never reallocates.
         private static T[] EnsureCapacity<T>(T[] buffer, int size) => buffer.Length >= size ? buffer : new T[size];
 
-        private void DrawTube()
+        private void DrawTube(Shader drawShader, bool depthOnly = false)
         {
             if (indexCount == 0)
             {
                 return;
             }
 
-            shader.Use();
-            VertexArray.Bind(vaoHandle, shader);
-            material.Render(shader);
+            drawShader.Use();
+            VertexArray.Bind(vaoHandle, drawShader);
+            material.Render(drawShader);
 
-            // todo: batch tube draws and call this less often
-            scene.LightingInfo.BindLightmapTextures();
-
-            if (lightProbe is not null)
+            // A depth mode shades nothing, so it reads none of the lighting the binds below are for.
+            if (!depthOnly)
             {
-                shader.SetUniform1("uLightProbeIndex", (uint)lightProbe.ShaderIndex);
-                scene.LightingInfo.BindInstanceLightProbeTextures(lightProbe);
+                // todo: batch tube draws and call this less often
+                scene.LightingInfo.BindLightmapTextures();
+
+                if (lightProbe is not null)
+                {
+                    drawShader.SetUniform1("uLightProbeIndex", (uint)lightProbe.ShaderIndex);
+                    scene.LightingInfo.BindInstanceLightProbeTextures(lightProbe);
+                }
             }
 
             PerfStats.Active.Count(Counter.ParticleDraw);

--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -633,11 +633,10 @@ public class Renderer
         renderContext.Framebuffer.BindAndClear();
 
         var isMainFramebuffer = ReferenceEquals(renderContext.Framebuffer, MainFramebuffer);
-        var isStandardPass = renderContext.ReplacementShader == null && isMainFramebuffer;
+        var isMaterialPass = renderContext.ReplacementShader == null && isMainFramebuffer;
+        var isStandardPass = isMaterialPass && renderContext.OverdrawShader == null;
 
-        var isOverdrawRedraw = renderContext.OverdrawShader != null;
-
-        if (!isStandardPass || isOverdrawRedraw)
+        if (!isStandardPass)
         {
             PerfStats.Active.SuspendTriangleCounter();
         }
@@ -693,7 +692,7 @@ public class Renderer
         using (new GLDebugGroup("Main Scene Opaque Render"))
         {
             renderContext.Scene = Scene;
-            Scene.RenderOpaqueLayer(renderContext, isStandardPass ? depthOnlyShader : null);
+            Scene.RenderOpaqueLayer(renderContext, isMaterialPass ? depthOnlyShader : null);
         }
 
         //using (new GLDebugGroup("Sky Render"))
@@ -820,7 +819,7 @@ public class Renderer
 
         wireframeScope.Dispose();
 
-        if (isStandardPass && !isOverdrawRedraw)
+        if (isStandardPass)
         {
             if (computeFramebufferLuminance)
             {

--- a/Renderer/Renderer.cs
+++ b/Renderer/Renderer.cs
@@ -635,7 +635,9 @@ public class Renderer
         var isMainFramebuffer = ReferenceEquals(renderContext.Framebuffer, MainFramebuffer);
         var isStandardPass = renderContext.ReplacementShader == null && isMainFramebuffer;
 
-        if (!isStandardPass)
+        var isOverdrawRedraw = renderContext.OverdrawShader != null;
+
+        if (!isStandardPass || isOverdrawRedraw)
         {
             PerfStats.Active.SuspendTriangleCounter();
         }
@@ -818,7 +820,7 @@ public class Renderer
 
         wireframeScope.Dispose();
 
-        if (isStandardPass)
+        if (isStandardPass && !isOverdrawRedraw)
         {
             if (computeFramebufferLuminance)
             {

--- a/Renderer/Renderer/DepthOnlyBucket.cs
+++ b/Renderer/Renderer/DepthOnlyBucket.cs
@@ -9,11 +9,6 @@ public enum DepthOnlyBucket
     Specialized,
     /// <summary>Drawn with the depth-only shader's alpha test variant, which samples the material's color texture and discards below its alpha reference.</summary>
     AlphaTest,
-    /// <summary>
-    /// Drawn with the material's own shader in its depth mode, for geometry the shared depth-only shader
-    /// cannot place: vertex animation lives in the material's vertex shader. Resolved per draw, because
-    /// the mode belongs to the material. Materials whose shader has no depth mode fall back to the shared
-    /// depth-only shader in the shadow passes rather than run a forward pixel shader there.
-    /// </summary>
+    /// <summary>Drawn with the material's own shader in its depth mode, resolved per draw.</summary>
     MaterialDepthMode,
 }

--- a/Renderer/Renderer/DepthOnlyBucket.cs
+++ b/Renderer/Renderer/DepthOnlyBucket.cs
@@ -9,6 +9,11 @@ public enum DepthOnlyBucket
     Specialized,
     /// <summary>Drawn with the depth-only shader's alpha test variant, which samples the material's color texture and discards below its alpha reference.</summary>
     AlphaTest,
-    /// <summary>Drawn with the material's own shader.</summary>
-    MaterialShader,
+    /// <summary>
+    /// Drawn with the material's own shader in its depth mode, for geometry the shared depth-only shader
+    /// cannot place: vertex animation lives in the material's vertex shader. Resolved per draw, because
+    /// the mode belongs to the material. Materials whose shader has no depth mode fall back to the shared
+    /// depth-only shader in the shadow passes rather than run a forward pixel shader there.
+    /// </summary>
+    MaterialDepthMode,
 }

--- a/Renderer/Renderer/Materials/RenderMaterial.cs
+++ b/Renderer/Renderer/Materials/RenderMaterial.cs
@@ -323,7 +323,6 @@ namespace ValveResourceFormat.Renderer.Materials
                 return;
             }
 
-            // csgo_foliage sways from the shader name alone, with no combo on the material to read
             VertexAnimation = ShaderName == "csgo_foliage.vfx"
                 || IntParams.GetValueOrDefault("F_VERTEX_ANIMATION") > 0
                 || IntParams.GetValueOrDefault("F_FOLIAGE_ANIMATION") > 0;
@@ -553,9 +552,6 @@ namespace ValveResourceFormat.Renderer.Materials
             depthMaterial = null;
         }
 
-        /// <summary>The alpha reference used when a material does not name one.</summary>
-        private const float DefaultAlphaTestReference = 0.5f;
-
         private RenderMaterial? depthMaterial;
 
         /// <summary>This material as a shared depth-only shader sees it: the color texture and the alpha reference.</summary>
@@ -564,7 +560,7 @@ namespace ValveResourceFormat.Renderer.Materials
             depthMaterial ??= new RenderMaterial(depthShader);
 
             depthMaterial.FloatParams["g_flAlphaTestReference"] =
-                FloatParams.GetValueOrDefault("g_flAlphaTestReference", DefaultAlphaTestReference);
+                FloatParams.GetValueOrDefault("g_flAlphaTestReference", 0.5f);
 
             if (Textures.TryGetValue("g_tColor", out var colorTexture))
             {

--- a/Renderer/Renderer/Materials/RenderMaterial.cs
+++ b/Renderer/Renderer/Materials/RenderMaterial.cs
@@ -159,11 +159,7 @@ namespace ValveResourceFormat.Renderer.Materials
         /// <summary>Gets a value indicating whether this material uses alpha-to-coverage alpha testing.</summary>
         public bool IsAlphaTest => blendMode == BlendMode.AlphaTest;
 
-        /// <summary>
-        /// Gets whether this material's draws can be laid down in a depth prepass and then shaded testing for
-        /// equality against it. Anything that moves or ignores its own depth cannot: the two passes would not
-        /// land on the same value, and the shading pass would draw nothing.
-        /// </summary>
+        /// <summary>Gets whether this material's draws can be prepassed and then shaded testing for equality against it.</summary>
         public bool CanDepthPrepass => !hasDepthBias && !IsOverlay && !disableDepthTest;
 
         private readonly MaterialLoader? Loader;
@@ -557,23 +553,13 @@ namespace ValveResourceFormat.Renderer.Materials
             depthMaterial = null;
         }
 
-        /// <summary>The alpha reference the shaders declare, used when a material does not name one.</summary>
+        /// <summary>The alpha reference used when a material does not name one.</summary>
         private const float DefaultAlphaTestReference = 0.5f;
 
         private RenderMaterial? depthMaterial;
         private uint depthMaterialVersion;
 
-        /// <summary>
-        /// This material as a shared depth-only shader sees it: the texture it cuts out with and the value
-        /// it cuts at, and nothing else. Those shaders skip material data entirely (see
-        /// <see cref="Shader.IgnoreMaterialData"/>), so without this they would cut every material at the
-        /// reference the shader itself declares.
-        /// <para>
-        /// It is a material of its own rather than a few loose uniforms so that it owns its constant
-        /// buffer: filled once for the depth shader's layout and left alone, instead of this material's
-        /// being refilled every time a pass swaps between the two layouts.
-        /// </para>
-        /// </summary>
+        /// <summary>This material as a shared depth-only shader sees it: the color texture and the alpha reference.</summary>
         private RenderMaterial GetDepthMaterial(Shader depthShader)
         {
             if (depthMaterial == null)
@@ -600,8 +586,7 @@ namespace ValveResourceFormat.Renderer.Materials
 
         /// <summary>Binds textures, sets material uniforms, and applies blend/depth render state for this material.</summary>
         /// <param name="shader">The shader to use for this draw call, or <see langword="null"/> to use <see cref="Shader"/>.</param>
-        /// <param name="depthPass">Whether the draw only lays down depth, which a shared depth shader still has
-        /// to rasterize this material's own way; see <see cref="ApplyDepthRenderState"/>.</param>
+        /// <param name="depthPass">Whether the draw only lays down depth; see <see cref="ApplyDepthRenderState"/>.</param>
         public void Render(Shader? shader = default, bool depthPass = false)
         {
             textureUnit = TextureUnitStart;
@@ -881,14 +866,7 @@ namespace ValveResourceFormat.Renderer.Materials
             }
         }
 
-        /// <summary>
-        /// Applies the part of this material's state that a depth pass has to match: which faces it
-        /// rasterizes. A shared depth shader skips material data (see <see cref="Shader.IgnoreMaterialData"/>)
-        /// and would otherwise cull this material's back faces, leaving them without depth for the shading
-        /// pass to test against. Nothing else here needs matching: the material state that moves depth keeps
-        /// geometry out of the prepass entirely (see <see cref="CanDepthPrepass"/>), and blend state has no
-        /// color to act on.
-        /// </summary>
+        /// <summary>Applies the part of this material's state a depth pass has to match: which faces it rasterizes.</summary>
         public void ApplyDepthRenderState()
         {
             var renderState = GraphicsContext.RenderState;

--- a/Renderer/Renderer/Materials/RenderMaterial.cs
+++ b/Renderer/Renderer/Materials/RenderMaterial.cs
@@ -159,6 +159,13 @@ namespace ValveResourceFormat.Renderer.Materials
         /// <summary>Gets a value indicating whether this material uses alpha-to-coverage alpha testing.</summary>
         public bool IsAlphaTest => blendMode == BlendMode.AlphaTest;
 
+        /// <summary>
+        /// Gets whether this material's draws can be laid down in a depth prepass and then shaded testing for
+        /// equality against it. Anything that moves or ignores its own depth cannot: the two passes would not
+        /// land on the same value, and the shading pass would draw nothing.
+        /// </summary>
+        public bool CanDepthPrepass => !hasDepthBias && !IsOverlay && !disableDepthTest;
+
         private readonly MaterialLoader? Loader;
 
         private Globals? globals;
@@ -320,7 +327,9 @@ namespace ValveResourceFormat.Renderer.Materials
                 return;
             }
 
-            VertexAnimation = IntParams.GetValueOrDefault("F_VERTEX_ANIMATION") > 0
+            // csgo_foliage sways from the shader name alone, with no combo on the material to read
+            VertexAnimation = ShaderName == "csgo_foliage.vfx"
+                || IntParams.GetValueOrDefault("F_VERTEX_ANIMATION") > 0
                 || IntParams.GetValueOrDefault("F_FOLIAGE_ANIMATION") > 0;
 
             // :MaterialIsOverlay
@@ -543,11 +552,57 @@ namespace ValveResourceFormat.Renderer.Materials
             globals?.Delete();
             globals = null;
             filledLayout = null;
+
+            depthMaterial?.Delete();
+            depthMaterial = null;
+        }
+
+        /// <summary>The alpha reference the shaders declare, used when a material does not name one.</summary>
+        private const float DefaultAlphaTestReference = 0.5f;
+
+        private RenderMaterial? depthMaterial;
+        private uint depthMaterialVersion;
+
+        /// <summary>
+        /// This material as a shared depth-only shader sees it: the texture it cuts out with and the value
+        /// it cuts at, and nothing else. Those shaders skip material data entirely (see
+        /// <see cref="Shader.IgnoreMaterialData"/>), so without this they would cut every material at the
+        /// reference the shader itself declares.
+        /// <para>
+        /// It is a material of its own rather than a few loose uniforms so that it owns its constant
+        /// buffer: filled once for the depth shader's layout and left alone, instead of this material's
+        /// being refilled every time a pass swaps between the two layouts.
+        /// </para>
+        /// </summary>
+        private RenderMaterial GetDepthMaterial(Shader depthShader)
+        {
+            if (depthMaterial == null)
+            {
+                depthMaterial = new RenderMaterial(depthShader);
+            }
+            else if (depthMaterialVersion == InputsVersion)
+            {
+                return depthMaterial;
+            }
+
+            depthMaterialVersion = InputsVersion;
+
+            depthMaterial.FloatParams["g_flAlphaTestReference"] =
+                FloatParams.GetValueOrDefault("g_flAlphaTestReference", DefaultAlphaTestReference);
+
+            if (Textures.TryGetValue("g_tColor", out var colorTexture))
+            {
+                depthMaterial.Textures["g_tColor"] = colorTexture;
+            }
+
+            return depthMaterial;
         }
 
         /// <summary>Binds textures, sets material uniforms, and applies blend/depth render state for this material.</summary>
         /// <param name="shader">The shader to use for this draw call, or <see langword="null"/> to use <see cref="Shader"/>.</param>
-        public void Render(Shader? shader = default)
+        /// <param name="depthPass">Whether the draw only lays down depth, which a shared depth shader still has
+        /// to rasterize this material's own way; see <see cref="ApplyDepthRenderState"/>.</param>
+        public void Render(Shader? shader = default, bool depthPass = false)
         {
             textureUnit = TextureUnitStart;
 
@@ -555,15 +610,21 @@ namespace ValveResourceFormat.Renderer.Materials
 
             if (shader.IgnoreMaterialData)
             {
-                if (shader.IsDepthOnlyAlphaTest)
+                if (shader.IsAlphaTestVariant)
                 {
-                    shader.Default.BindGlobals(shader);
+                    var depthMaterial = GetDepthMaterial(shader);
+                    depthMaterial.BindGlobals(shader);
 
-                    var colorTexture = Textures.GetValueOrDefault("g_tColor");
+                    var colorTexture = depthMaterial.Textures.GetValueOrDefault("g_tColor");
                     if (colorTexture != null)
                     {
                         shader.SetTexture(textureUnit, "g_tColor", colorTexture);
                     }
+                }
+
+                if (depthPass)
+                {
+                    ApplyDepthRenderState();
                 }
 
                 return;
@@ -818,6 +879,27 @@ namespace ValveResourceFormat.Renderer.Materials
             {
                 GL.BindSampler(unit, 0);
             }
+        }
+
+        /// <summary>
+        /// Applies the part of this material's state that a depth pass has to match: which faces it
+        /// rasterizes. A shared depth shader skips material data (see <see cref="Shader.IgnoreMaterialData"/>)
+        /// and would otherwise cull this material's back faces, leaving them without depth for the shading
+        /// pass to test against. Nothing else here needs matching: the material state that moves depth keeps
+        /// geometry out of the prepass entirely (see <see cref="CanDepthPrepass"/>), and blend state has no
+        /// color to act on.
+        /// </summary>
+        public void ApplyDepthRenderState()
+        {
+            var renderState = GraphicsContext.RenderState;
+            var state = renderState.CurrentPass;
+
+            if (isRenderBackfaces)
+            {
+                state.Rasterizer.CullMode = RsCullMode.None;
+            }
+
+            renderState.Apply(state);
         }
 
         /// <summary>Composes this material's render state over the given pass baseline.</summary>

--- a/Renderer/Renderer/Materials/RenderMaterial.cs
+++ b/Renderer/Renderer/Materials/RenderMaterial.cs
@@ -159,8 +159,8 @@ namespace ValveResourceFormat.Renderer.Materials
         /// <summary>Gets a value indicating whether this material uses alpha-to-coverage alpha testing.</summary>
         public bool IsAlphaTest => blendMode == BlendMode.AlphaTest;
 
-        /// <summary>Gets whether this material's draws can be prepassed and then shaded testing for equality against it.</summary>
-        public bool CanDepthPrepass => !hasDepthBias && !IsOverlay && !disableDepthTest;
+        /// <summary>Gets whether this material can perform early depth priming and then shade with Equal comparison.</summary>
+        public bool CanPrimeDepth => !hasDepthBias && !IsOverlay && !disableDepthTest;
 
         private readonly MaterialLoader? Loader;
 
@@ -557,21 +557,11 @@ namespace ValveResourceFormat.Renderer.Materials
         private const float DefaultAlphaTestReference = 0.5f;
 
         private RenderMaterial? depthMaterial;
-        private uint depthMaterialVersion;
 
         /// <summary>This material as a shared depth-only shader sees it: the color texture and the alpha reference.</summary>
         private RenderMaterial GetDepthMaterial(Shader depthShader)
         {
-            if (depthMaterial == null)
-            {
-                depthMaterial = new RenderMaterial(depthShader);
-            }
-            else if (depthMaterialVersion == InputsVersion)
-            {
-                return depthMaterial;
-            }
-
-            depthMaterialVersion = InputsVersion;
+            depthMaterial ??= new RenderMaterial(depthShader);
 
             depthMaterial.FloatParams["g_flAlphaTestReference"] =
                 FloatParams.GetValueOrDefault("g_flAlphaTestReference", DefaultAlphaTestReference);
@@ -586,7 +576,7 @@ namespace ValveResourceFormat.Renderer.Materials
 
         /// <summary>Binds textures, sets material uniforms, and applies blend/depth render state for this material.</summary>
         /// <param name="shader">The shader to use for this draw call, or <see langword="null"/> to use <see cref="Shader"/>.</param>
-        /// <param name="depthPass">Whether the draw only lays down depth; see <see cref="ApplyDepthRenderState"/>.</param>
+        /// <param name="depthPass">Whether the draw only lays down depth, which a shared depth shader still rasterizes this material's way.</param>
         public void Render(Shader? shader = default, bool depthPass = false)
         {
             textureUnit = TextureUnitStart;
@@ -609,7 +599,8 @@ namespace ValveResourceFormat.Renderer.Materials
 
                 if (depthPass)
                 {
-                    ApplyDepthRenderState();
+                    var depthState = GraphicsContext.RenderState;
+                    depthState.Apply(ComposeRenderState(depthState.CurrentPass));
                 }
 
                 return;
@@ -864,20 +855,6 @@ namespace ValveResourceFormat.Renderer.Materials
             {
                 GL.BindSampler(unit, 0);
             }
-        }
-
-        /// <summary>Applies the part of this material's state a depth pass has to match: which faces it rasterizes.</summary>
-        public void ApplyDepthRenderState()
-        {
-            var renderState = GraphicsContext.RenderState;
-            var state = renderState.CurrentPass;
-
-            if (isRenderBackfaces)
-            {
-                state.Rasterizer.CullMode = RsCullMode.None;
-            }
-
-            renderState.Apply(state);
         }
 
         /// <summary>Composes this material's render state over the given pass baseline.</summary>

--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -146,6 +146,30 @@ namespace ValveResourceFormat.Renderer
             GL.BindTextureUnit((int)slot, texture.Handle);
         }
 
+        /// <summary>
+        /// Picks the program a draw runs with: the pass's replacement shader, built for what this mesh
+        /// supplies and cutting out what the material's alpha test would, or the material's own shader.
+        /// <para>
+        /// A pass that only lays down depth never gets the material's forward shader. It gets the material's
+        /// depth mode, or the shared depth-only shader when the material's shader has no depth mode.
+        /// </para>
+        /// </summary>
+        private static Shader ResolveShader(Scene.RenderContext context, RenderableMesh mesh, RenderMaterial material)
+        {
+            if (context.ReplacementShader is { } replacement)
+            {
+                return replacement.WithSkinning(mesh.ActiveSkinning).WithAlphaTest(material.IsAlphaTest);
+            }
+
+            if (context.DepthOnlyShader is { } depthOnly)
+            {
+                return material.Shader.DepthMode
+                    ?? depthOnly.WithSkinning(mesh.ActiveSkinning).WithAlphaTest(material.IsAlphaTest);
+            }
+
+            return material.Shader;
+        }
+
         private static void DrawBatch(List<Request> requests, Scene.RenderContext context)
         {
             var vao = -1;
@@ -166,7 +190,9 @@ namespace ValveResourceFormat.Renderer
             {
                 if (request.Call == null)
                 {
-                    if (context.RenderPass is RenderPass.Opaque or RenderPass.Translucent or RenderPass.Outline or RenderPass.DepthOnly)
+                    // Not RenderPass.DepthOnly: a node that draws itself has no material to take a depth
+                    // mode from, and its own shaders sample the shadow map that pass renders into.
+                    if (context.RenderPass is RenderPass.Opaque or RenderPass.Translucent or RenderPass.Outline)
                     {
                         material?.PostRender();
 
@@ -194,7 +220,7 @@ namespace ValveResourceFormat.Renderer
 
                 var requestMaterial = request.Call.Material;
 
-                var requestShader = context.ReplacementShader?.WithSkinning(request.Mesh.ActiveSkinning) ?? requestMaterial.Shader;
+                var requestShader = ResolveShader(context, request.Mesh, requestMaterial);
 
                 if (material != requestMaterial || shader != requestShader)
                 {
@@ -253,7 +279,7 @@ namespace ValveResourceFormat.Renderer
                     }
 
                     material = requestMaterial;
-                    material.Render(shader);
+                    material.Render(shader, depthPass: context.DepthOnlyShader != null);
                 }
 
                 var requestVao = request.Call.GetVertexArrayObject();

--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -190,9 +190,9 @@ namespace ValveResourceFormat.Renderer
             {
                 if (request.Call == null)
                 {
-                    // Not RenderPass.DepthOnly: a node that draws itself has no material to take a depth
-                    // mode from, and its own shaders sample the shadow map that pass renders into.
-                    if (context.RenderPass is RenderPass.Opaque or RenderPass.Translucent or RenderPass.Outline)
+                    // Nodes only reach RenderPass.DepthOnly when they declare CustomRenderPasses.DepthOnly,
+                    // which says they have a shader for it; the collection is what holds the rest out.
+                    if (context.RenderPass is RenderPass.Opaque or RenderPass.Translucent or RenderPass.Outline or RenderPass.DepthOnly)
                     {
                         material?.PostRender();
 

--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -146,14 +146,7 @@ namespace ValveResourceFormat.Renderer
             GL.BindTextureUnit((int)slot, texture.Handle);
         }
 
-        /// <summary>
-        /// Picks the program a draw runs with: the pass's replacement shader, built for what this mesh
-        /// supplies and cutting out what the material's alpha test would, or the material's own shader.
-        /// <para>
-        /// A pass that only lays down depth never gets the material's forward shader. It gets the material's
-        /// depth mode, or the shared depth-only shader when the material's shader has no depth mode.
-        /// </para>
-        /// </summary>
+        /// <summary>Picks the program a draw runs with: the pass's replacement shader, the material's mode for this pass, or the material's own.</summary>
         private static Shader ResolveShader(Scene.RenderContext context, RenderableMesh mesh, RenderMaterial material)
         {
             if (context.ReplacementShader is { } replacement)
@@ -165,6 +158,12 @@ namespace ValveResourceFormat.Renderer
             {
                 return material.Shader.DepthMode
                     ?? depthOnly.WithSkinning(mesh.ActiveSkinning).WithAlphaTest(material.IsAlphaTest);
+            }
+
+            if (context.OverdrawShader is { } overdraw)
+            {
+                return material.Shader.OverdrawMode
+                    ?? overdraw.WithSkinning(mesh.ActiveSkinning).WithAlphaTest(material.IsAlphaTest);
             }
 
             return material.Shader;

--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -189,8 +189,6 @@ namespace ValveResourceFormat.Renderer
             {
                 if (request.Call == null)
                 {
-                    // Nodes only reach RenderPass.DepthOnly when they declare CustomRenderPasses.DepthOnly,
-                    // which says they have a shader for it; the collection is what holds the rest out.
                     if (context.RenderPass is RenderPass.Opaque or RenderPass.Translucent or RenderPass.Outline or RenderPass.DepthOnly)
                     {
                         material?.PostRender();

--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -16,7 +16,7 @@ namespace ValveResourceFormat.Renderer
 #if DEBUG
         [DebuggerDisplay("{Node.DebugName,nq}")]
 #endif
-        public record struct Request(RenderableMesh Mesh, DrawCall? Call, float DistanceFromCamera, int RenderOrder, SceneNode Node);
+        public readonly record struct Request(RenderableMesh Mesh, DrawCall? Call, float DistanceFromCamera, int RenderOrder, SceneNode Node);
         record struct BatchRequest(RenderableMesh Mesh, DrawCall Call, SceneNode Node);
 
         /// <summary>Compares two requests by shader pipeline sort ID, placing custom-render nodes at the boundary.</summary>

--- a/Renderer/Renderer/QuadOverdraw.cs
+++ b/Renderer/Renderer/QuadOverdraw.cs
@@ -8,11 +8,8 @@ namespace ValveResourceFormat.Renderer;
 /// </summary>
 ///
 /// <remarks>
-/// The scene is rendered with a replacement shader that counts, per 2x2 pixel quad, how
-/// many primitives were shaded into it, using an atomic lock so a primitive spanning
-/// several pixels of the same quad counts once.
-///
-/// The first render only fills out the depth buffer, the second one renders overdraw
+/// The frame is drawn once for depth, then again through each material's overdraw mode to count primitives
+/// per 2x2 pixel quad.
 /// </remarks>
 public class QuadOverdraw(RendererContext rendererContext)
 {
@@ -24,7 +21,7 @@ public class QuadOverdraw(RendererContext rendererContext)
     private ClearBufferMask savedClearMask;
     private RenderState savedPassState;
 
-    /// <summary>Gets the replacement shader that counts quad overdraw while the scene renders.</summary>
+    /// <summary>Gets the counting shader used by materials whose own shader has no overdraw mode.</summary>
     public Shader SceneShader => sceneShader ??= rendererContext.ShaderLoader.LoadShader("quad_overdraw");
 
     /// <summary>Gets whether the current render mode has activated the quad overdraw visualization.</summary>
@@ -43,17 +40,9 @@ public class QuadOverdraw(RendererContext rendererContext)
         IsActive = SceneShader.RenderModes.Contains(renderMode);
     }
 
-    /// <summary>
-    /// Sizes the count buffer to the framebuffer, zeroes it, binds it to its slot, and puts
-    /// <see cref="SceneShader"/> in depth prime mode. Call before the first scene render of the frame.
-    /// </summary>
-    /// <param name="width">Framebuffer width in pixels.</param>
-    /// <param name="height">Framebuffer height in pixels.</param>
+    /// <summary>Sizes, zeroes and binds the count buffer. Call before the first scene render of the frame.</summary>
     public void Prepare(int width, int height)
     {
-        // All variants: skinned meshes draw with a skinning variant of this shader (see MeshBatchRenderer)
-        SceneShader.SetUniform1AllVariants("bCountQuads", 0u);
-
         // one entry per 2x2 pixel quad
         var quadWidth = (width + 1) / 2;
         var quadHeight = (height + 1) / 2;
@@ -70,10 +59,7 @@ public class QuadOverdraw(RendererContext rendererContext)
         quadBuffer.BindBufferBase();
     }
 
-    /// <summary>
-    /// Switches from the depth prime render to the counting render by enabling counting in <see cref="SceneShader"/>.
-    /// </summary>
-    /// <param name="framebuffer">The framebuffer the scene renders into.</param>
+    /// <summary>Keeps the first render's depth and has the counting render test against it.</summary>
     public void BeginCountingPass(Framebuffer framebuffer)
     {
         savedClearMask = framebuffer.ClearMask;
@@ -83,22 +69,16 @@ public class QuadOverdraw(RendererContext rendererContext)
         var countingState = savedPassState;
         countingState.DepthStencil.DepthFunc = RsComparison.CloserEqual;
         GraphicsContext.RenderState.SetPassBaseline(in countingState);
-
-        SceneShader.SetUniform1AllVariants("bCountQuads", 1u);
     }
 
     /// <summary>Restores the depth state changed by <see cref="BeginCountingPass"/>.</summary>
-    /// <param name="framebuffer">The framebuffer passed to <see cref="BeginCountingPass"/>.</param>
     public void EndCountingPass(Framebuffer framebuffer)
     {
         framebuffer.ClearMask = savedClearMask;
         GraphicsContext.RenderState.SetPassBaseline(in savedPassState);
     }
 
-    /// <summary>
-    /// Replaces the bound framebuffer contents with the overdraw heat map and legend.
-    /// Call after the scene rendered with <see cref="SceneShader"/> as the replacement shader.
-    /// </summary>
+    /// <summary>Replaces the framebuffer contents with the overdraw heat map. Call after the counting render.</summary>
     public void Render()
     {
         Debug.Assert(quadBuffer != null, $"{nameof(Prepare)} must be called before {nameof(Render)}");

--- a/Renderer/Renderer/RenderPass.cs
+++ b/Renderer/Renderer/RenderPass.cs
@@ -50,8 +50,9 @@ namespace ValveResourceFormat.Renderer
         None = 0,
 
         /// <summary>
-        /// Draws in <see cref="RenderPass.Opaque"/>, and with it <see cref="RenderPass.DepthOnly"/>: solid
-        /// geometry is a shadow caster.
+        /// Draws in <see cref="RenderPass.Opaque"/>. Not in <see cref="RenderPass.DepthOnly"/>, so a node
+        /// that draws itself casts no shadow: it has no material to take a depth mode from, and its own
+        /// shaders sample the shadow map that pass renders into.
         /// </summary>
         Opaque = 1 << 0,
 

--- a/Renderer/Renderer/RenderPass.cs
+++ b/Renderer/Renderer/RenderPass.cs
@@ -49,11 +49,7 @@ namespace ValveResourceFormat.Renderer
         /// <summary>Draws in no pass at all.</summary>
         None = 0,
 
-        /// <summary>
-        /// Draws in <see cref="RenderPass.Opaque"/>. Not in <see cref="RenderPass.DepthOnly"/>, so a node
-        /// that draws itself casts no shadow: it has no material to take a depth mode from, and its own
-        /// shaders sample the shadow map that pass renders into.
-        /// </summary>
+        /// <summary>Draws in <see cref="RenderPass.Opaque"/>.</summary>
         Opaque = 1 << 0,
 
         /// <summary>Draws in <see cref="RenderPass.Translucent"/>.</summary>
@@ -66,6 +62,13 @@ namespace ValveResourceFormat.Renderer
 
         /// <summary>Draws in the translucent pass, into the water effects map instead of the scene.</summary>
         WaterEffects = 1 << 3,
+
+        /// <summary>
+        /// Draws in <see cref="RenderPass.DepthOnly"/> too, and so casts a shadow. A node that draws itself
+        /// needs a shader that only lays down depth to set this: its forward shaders sample the very shadow
+        /// map that pass renders into.
+        /// </summary>
+        DepthOnly = 1 << 4,
 
         /// <summary>Draws in the opaque and translucent passes, the default for a node that draws itself.</summary>
         Default = Opaque | Translucent,

--- a/Renderer/Renderer/RenderPass.cs
+++ b/Renderer/Renderer/RenderPass.cs
@@ -63,11 +63,7 @@ namespace ValveResourceFormat.Renderer
         /// <summary>Draws in the translucent pass, into the water effects map instead of the scene.</summary>
         WaterEffects = 1 << 3,
 
-        /// <summary>
-        /// Draws in <see cref="RenderPass.DepthOnly"/> too, and so casts a shadow. A node that draws itself
-        /// needs a shader that only lays down depth to set this: its forward shaders sample the very shadow
-        /// map that pass renders into.
-        /// </summary>
+        /// <summary>Draws in <see cref="RenderPass.DepthOnly"/> too, and so casts a shadow.</summary>
         DepthOnly = 1 << 4,
 
         /// <summary>Draws in the opaque and translucent passes, the default for a node that draws itself.</summary>

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -75,13 +75,7 @@ namespace ValveResourceFormat.Renderer
             /// <summary>Gets or sets an optional shader that overrides per-material shaders for this pass.</summary>
             public Shader? ReplacementShader { get; set; }
 
-            /// <summary>
-            /// Gets or sets the shared depth only shader, set for the passes that only lay down depth. Draws
-            /// in those passes take their material's own depth mode, and this shader when the material's has
-            /// none; what they never take is the material's forward shader. In the shadow passes that would
-            /// sample the very map being rendered into, and in a prepass it would shade everything the pass
-            /// exists to stop shading.
-            /// </summary>
+            /// <summary>Gets or sets the fallback depth only shader, set for the passes that only lay down depth.</summary>
             public Shader? DepthOnlyShader { get; set; }
 
             /// <summary>Gets or sets the fallback counting shader, set for the pass that counts quad overdraw.</summary>
@@ -994,11 +988,7 @@ namespace ValveResourceFormat.Renderer
 
         private Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>> depthOnlyDraws { get; } = CreateDepthOnlyDrawCallCollection();
 
-        /// <summary>
-        /// Alpha tested draws, held out of <see cref="RenderPass.OpaqueAggregate"/> and <see cref="RenderPass.Opaque"/>
-        /// so that they are always prepassed, and always after the geometry that occludes them.
-        /// See <see cref="RenderAlphaTestGeometry"/>.
-        /// </summary>
+        /// <summary>Alpha tested draws, held out of the opaque passes for <see cref="RenderAlphaTestGeometry"/>.</summary>
         private readonly List<MeshBatchRenderer.Request> alphaTestAggregateDraws = [];
 
         /// <inheritdoc cref="alphaTestAggregateDraws"/>
@@ -1070,8 +1060,7 @@ namespace ValveResourceFormat.Renderer
                 isLatePass = true;
             }
 
-            // Alpha tested draws are prepassed on their own, see RenderAlphaTestGeometry. Not the ones that
-            // were rerouted above: those draw after the framebuffer grab, past every depth pass.
+            // Not the ones rerouted above: those draw after the framebuffer grab, past every depth pass
             if (renderPass == RenderPass.Opaque && !isViewmodelLayer && !isLatePass
                 && request.Call.Material is { IsAlphaTest: true, CanDepthPrepass: true })
             {
@@ -1478,10 +1467,7 @@ namespace ValveResourceFormat.Renderer
                 : DepthOnlyBucket.Specialized;
         }
 
-        /// <summary>
-        /// Picks the shader that replaces material shaders for a depth-only bucket, or <see langword="null"/>
-        /// for the bucket that resolves a shader per draw instead. See <see cref="DepthOnlyBucket"/>.
-        /// </summary>
+        /// <summary>Picks the shader for a depth-only bucket, or <see langword="null"/> to resolve one per draw.</summary>
         private static Shader? GetDepthOnlyReplacementShader(DepthOnlyBucket bucket, Shader depthOnlyShader) => bucket switch
         {
             DepthOnlyBucket.AlphaTest => depthOnlyShader.WithCombo(Shader.AlphaTestCombo, 1),
@@ -1714,10 +1700,6 @@ namespace ValveResourceFormat.Renderer
         public static void RenderOpaqueShadows(RenderContext renderContext, Shader depthOnlyShader, Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>> drawCalls)
         {
             renderContext.RenderPass = RenderPass.DepthOnly;
-
-            // The shadow map is the render target here while the forward lighting shaders have it bound as a
-            // texture, so this pass may not run one. Setting this makes every draw that has no replacement
-            // shader resolve a depth mode instead of the material's own shader.
             renderContext.DepthOnlyShader = depthOnlyShader;
 
             PerfStats.Active.SuspendTriangleCounter();
@@ -1738,12 +1720,9 @@ namespace ValveResourceFormat.Renderer
 
         /// <summary>
         /// Renders the opaque pass, optionally with a depth prepass, followed by aggregate indirect draws and static overlay geometry.
-        /// The alpha tested geometry is always prepassed; see <see cref="RenderAlphaTestGeometry"/>.
         /// </summary>
         /// <param name="renderContext">The render context for this pass.</param>
-        /// <param name="depthOnlyShader">Optional depth-only shader. With <see cref="EnableDepthPrepass"/> it prepasses
-        /// the whole opaque layer, and without it only the alpha tested aggregates. Pass <see langword="null"/> for a
-        /// pass that replaces material shaders, which does its own depth priming if it wants one.</param>
+        /// <param name="depthOnlyShader">Optional depth-only shader; <see langword="null"/> for a pass that replaces material shaders.</param>
         public void RenderOpaqueLayer(RenderContext renderContext, Shader? depthOnlyShader = null)
         {
             using var passScope = GraphicsContext.RenderState.Scope();
@@ -1768,12 +1747,6 @@ namespace ValveResourceFormat.Renderer
                 {
                     PerfStats.Active.SuspendTriangleCounter();
 
-                    // The alpha tested draws are not here; they are prepassed on their own further down. What
-                    // is left is opaque, and the bucket the shared shader cannot draw keeps the material's own
-                    // shader rather than a depth mode: the pass that follows tests depth for equality against
-                    // what this one wrote, so the two have to place every fragment identically, and only the
-                    // same program guarantees that. Nothing here samples the target, so a forward pixel
-                    // shader is safe.
                     var passShader = renderContext.ReplacementShader;
 
                     renderContext.RenderPass = RenderPass.DepthOnly;
@@ -1818,15 +1791,7 @@ namespace ValveResourceFormat.Renderer
             }
         }
 
-        /// <summary>
-        /// Prepasses the alpha tested geometry and then draws it. It is prepassed whether or not
-        /// <see cref="EnableDepthPrepass"/> is set, because its pixel shader discards and so cannot early-z
-        /// against itself: without one, every layer of a dense stand of foliage shades.
-        /// <para>
-        /// Both passes run after the opaque geometry rather than before, so the depth it laid down rejects
-        /// most of the prepass as well.
-        /// </para>
-        /// </summary>
+        /// <summary>Prepasses the alpha tested geometry and then draws it, both after the opaque geometry.</summary>
         private void RenderAlphaTestGeometry(RenderContext renderContext, Shader? depthOnlyShader)
         {
             alphaTestAggregateDraws.RemoveAll(MeshBatchRenderer.IsAggregateWithNoVisibleChildren);
@@ -1865,9 +1830,6 @@ namespace ValveResourceFormat.Renderer
 
             using var drawGroup = new GLDebugGroup("Alpha Test Render");
 
-            // The prepass already placed this geometry, and the pass baseline compares strictly closer, which
-            // every one of these fragments would now fail. Testing for equality against what the prepass wrote
-            // instead leaves each surface shaded exactly once, wherever the cutout kept it.
             using var drawState = prepassed
                 ? GraphicsContext.RenderState.Scope(depthWrite: false, depthFunc: RsComparison.Equal)
                 : default;

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -994,7 +994,7 @@ namespace ValveResourceFormat.Renderer
         /// <inheritdoc cref="alphaTestAggregateDraws"/>
         private readonly List<MeshBatchRenderer.Request> alphaTestOpaqueDraws = [];
 
-        private void Add(MeshBatchRenderer.Request request, RenderPass renderPass)
+        private void Add(in MeshBatchRenderer.Request request, RenderPass renderPass)
         {
             Debug.Assert(request.Call is not null);
 

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -1770,7 +1770,7 @@ namespace ValveResourceFormat.Renderer
             }
             else if (DrawMeshletsIndirect)
             {
-                using var meshletGroup = new GLDebugGroup("Meshlet Render");
+                using var aggregateGroup = new GLDebugGroup("Aggregate Render");
 
                 renderContext.RenderPass = RenderPass.OpaqueAggregate;
                 MeshBatchRenderer.Render(renderLists[renderContext.RenderPass], renderContext);

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -75,6 +75,15 @@ namespace ValveResourceFormat.Renderer
             /// <summary>Gets or sets an optional shader that overrides per-material shaders for this pass.</summary>
             public Shader? ReplacementShader { get; set; }
 
+            /// <summary>
+            /// Gets or sets the shared depth only shader, set for the passes that only lay down depth. Draws
+            /// in those passes take their material's own depth mode, and this shader when the material's has
+            /// none; what they never take is the material's forward shader. In the shadow passes that would
+            /// sample the very map being rendered into, and in a prepass it would shade everything the pass
+            /// exists to stop shading.
+            /// </summary>
+            public Shader? DepthOnlyShader { get; set; }
+
             /// <summary>Gets the list of scene-level textures bound to reserved texture slots.</summary>
             public required List<(ReservedTextureSlots Slot, string Name, RenderTexture Texture)> Textures { get; init; }
         }
@@ -982,6 +991,16 @@ namespace ValveResourceFormat.Renderer
 
         private Dictionary<DepthOnlyBucket, List<MeshBatchRenderer.Request>> depthOnlyDraws { get; } = CreateDepthOnlyDrawCallCollection();
 
+        /// <summary>
+        /// Alpha tested draws, held out of <see cref="RenderPass.OpaqueAggregate"/> and <see cref="RenderPass.Opaque"/>
+        /// so that they are always prepassed, and always after the geometry that occludes them.
+        /// See <see cref="RenderAlphaTestGeometry"/>.
+        /// </summary>
+        private readonly List<MeshBatchRenderer.Request> alphaTestAggregateDraws = [];
+
+        /// <inheritdoc cref="alphaTestAggregateDraws"/>
+        private readonly List<MeshBatchRenderer.Request> alphaTestOpaqueDraws = [];
+
         private void Add(MeshBatchRenderer.Request request, RenderPass renderPass)
         {
             Debug.Assert(request.Call is not null);
@@ -1005,6 +1024,13 @@ namespace ValveResourceFormat.Renderer
             {
                 if (request.Node is SceneAggregate { CanDrawIndirect: true })
                 {
+                    // Alpha tested draws are prepassed on their own, see RenderAlphaTestGeometry
+                    if (request.Call.Material is { IsAlphaTest: true, CanDepthPrepass: true })
+                    {
+                        alphaTestAggregateDraws.Add(request);
+                        return;
+                    }
+
                     if (EnableDepthPrepass)
                     {
                         var bucket = GetDepthOnlyBucket(request.Call);
@@ -1041,6 +1067,14 @@ namespace ValveResourceFormat.Renderer
                 isLatePass = true;
             }
 
+            // Alpha tested draws are prepassed on their own, see RenderAlphaTestGeometry. Not the ones that
+            // were rerouted above: those draw after the framebuffer grab, past every depth pass.
+            if (renderPass == RenderPass.Opaque && !isViewmodelLayer && !isLatePass
+                && request.Call.Material is { IsAlphaTest: true, CanDepthPrepass: true })
+            {
+                queueList = alphaTestOpaqueDraws;
+            }
+
             // Only draws that happen after the grab can make use of the resolved copies.
             if (isLatePass)
             {
@@ -1070,6 +1104,8 @@ namespace ValveResourceFormat.Renderer
 
             waterEffectsRenderList.Clear();
             customBufferNodes.Clear();
+            alphaTestAggregateDraws.Clear();
+            alphaTestOpaqueDraws.Clear();
 
             foreach (var bucket in depthOnlyDraws.Values)
             {
@@ -1384,18 +1420,8 @@ namespace ValveResourceFormat.Renderer
                 }
                 else
                 {
-                    // Nodes that draw their own solid geometry cast shadows by drawing into the depth pass
-                    // with their own shaders, which is what this bucket is for.
-                    if ((node.Flags & skipFlags) == 0 && (node.RenderPasses & CustomRenderPasses.Opaque) != 0)
-                    {
-                        AccumulateDepthFit(node);
-
-                        drawBuckets[DepthOnlyBucket.MaterialShader].Add(new MeshBatchRenderer.Request
-                        {
-                            Node = node,
-                        });
-                    }
-
+                    // Nodes that draw themselves have no material to take a depth mode from, and their own
+                    // shaders sample the shadow map this pass renders into, so they cast no shadow.
                     continue;
                 }
 
@@ -1436,16 +1462,19 @@ namespace ValveResourceFormat.Renderer
         // The skinning variant is picked per draw, so the bucket only says which shader draws it
         private static DepthOnlyBucket GetDepthOnlyBucket(DrawCall opaqueCall)
         {
-            return opaqueCall.Material.VertexAnimation ? DepthOnlyBucket.MaterialShader
+            return opaqueCall.Material.VertexAnimation ? DepthOnlyBucket.MaterialDepthMode
                 : opaqueCall.Material.IsAlphaTest ? DepthOnlyBucket.AlphaTest
                 : DepthOnlyBucket.Specialized;
         }
 
-        /// <summary>Picks the shader that replaces material shaders for a depth-only bucket, or <see langword="null"/> for the bucket that keeps the material's own shader.</summary>
+        /// <summary>
+        /// Picks the shader that replaces material shaders for a depth-only bucket, or <see langword="null"/>
+        /// for the bucket that resolves a shader per draw instead. See <see cref="DepthOnlyBucket"/>.
+        /// </summary>
         private static Shader? GetDepthOnlyReplacementShader(DepthOnlyBucket bucket, Shader depthOnlyShader) => bucket switch
         {
-            DepthOnlyBucket.AlphaTest => depthOnlyShader.WithCombo("F_ALPHA_TEST", 1),
-            DepthOnlyBucket.MaterialShader => null,
+            DepthOnlyBucket.AlphaTest => depthOnlyShader.WithCombo(Shader.AlphaTestCombo, 1),
+            DepthOnlyBucket.MaterialDepthMode => null,
             _ => depthOnlyShader,
         };
 
@@ -1675,6 +1704,11 @@ namespace ValveResourceFormat.Renderer
         {
             renderContext.RenderPass = RenderPass.DepthOnly;
 
+            // The shadow map is the render target here while the forward lighting shaders have it bound as a
+            // texture, so this pass may not run one. Setting this makes every draw that has no replacement
+            // shader resolve a depth mode instead of the material's own shader.
+            renderContext.DepthOnlyShader = depthOnlyShader;
+
             PerfStats.Active.SuspendTriangleCounter();
 
             foreach (var (bucket, calls) in drawCalls)
@@ -1693,9 +1727,12 @@ namespace ValveResourceFormat.Renderer
 
         /// <summary>
         /// Renders the opaque pass, optionally with a depth prepass, followed by aggregate indirect draws and static overlay geometry.
+        /// The alpha tested geometry is always prepassed; see <see cref="RenderAlphaTestGeometry"/>.
         /// </summary>
         /// <param name="renderContext">The render context for this pass.</param>
-        /// <param name="depthOnlyShader">Optional depth-only shader; when provided and <see cref="EnableDepthPrepass"/> is set, a depth prepass is performed.</param>
+        /// <param name="depthOnlyShader">Optional depth-only shader. With <see cref="EnableDepthPrepass"/> it prepasses
+        /// the whole opaque layer, and without it only the alpha tested aggregates. Pass <see langword="null"/> for a
+        /// pass that replaces material shaders, which does its own depth priming if it wants one.</param>
         public void RenderOpaqueLayer(RenderContext renderContext, Shader? depthOnlyShader = null)
         {
             using var passScope = GraphicsContext.RenderState.Scope();
@@ -1720,12 +1757,20 @@ namespace ValveResourceFormat.Renderer
                 {
                     PerfStats.Active.SuspendTriangleCounter();
 
+                    // The alpha tested draws are not here; they are prepassed on their own further down. What
+                    // is left is opaque, and the bucket the shared shader cannot draw keeps the material's own
+                    // shader rather than a depth mode: the pass that follows tests depth for equality against
+                    // what this one wrote, so the two have to place every fragment identically, and only the
+                    // same program guarantees that. Nothing here samples the target, so a forward pixel
+                    // shader is safe.
                     renderContext.RenderPass = RenderPass.DepthOnly;
                     foreach (var (bucket, calls) in depthOnlyDraws)
                     {
                         renderContext.ReplacementShader = bucket == DepthOnlyBucket.Specialized ? depthOnlyShader : null;
                         MeshBatchRenderer.Render(calls, renderContext);
                     }
+
+                    renderContext.ReplacementShader = null;
 
                     PerfStats.Active.ResumeTriangleCounter();
                 }
@@ -1737,10 +1782,10 @@ namespace ValveResourceFormat.Renderer
                     MeshBatchRenderer.Render(renderLists[renderContext.RenderPass], renderContext);
                 }
             }
-
-            if (!depthPrepass && DrawMeshletsIndirect)
+            else if (DrawMeshletsIndirect)
             {
-                using var _ = new GLDebugGroup("Meshlet Render");
+                using var meshletGroup = new GLDebugGroup("Meshlet Render");
+
                 renderContext.RenderPass = RenderPass.OpaqueAggregate;
                 MeshBatchRenderer.Render(renderLists[renderContext.RenderPass], renderContext);
             }
@@ -1751,11 +1796,69 @@ namespace ValveResourceFormat.Renderer
                 MeshBatchRenderer.Render(renderLists[renderContext.RenderPass], renderContext);
             }
 
+            RenderAlphaTestGeometry(renderContext, depthOnlyShader);
+
             using (new GLDebugGroup("StaticOverlay Render"))
             {
                 renderContext.RenderPass = RenderPass.StaticOverlay;
                 MeshBatchRenderer.Render(renderLists[renderContext.RenderPass], renderContext);
             }
+        }
+
+        /// <summary>
+        /// Prepasses the alpha tested geometry and then draws it. It is prepassed whether or not
+        /// <see cref="EnableDepthPrepass"/> is set, because its pixel shader discards and so cannot early-z
+        /// against itself: without one, every layer of a dense stand of foliage shades.
+        /// <para>
+        /// Both passes run after the opaque geometry rather than before, so the depth it laid down rejects
+        /// most of the prepass as well.
+        /// </para>
+        /// </summary>
+        private void RenderAlphaTestGeometry(RenderContext renderContext, Shader? depthOnlyShader)
+        {
+            alphaTestAggregateDraws.RemoveAll(MeshBatchRenderer.IsAggregateWithNoVisibleChildren);
+
+            if (alphaTestAggregateDraws.Count == 0 && alphaTestOpaqueDraws.Count == 0)
+            {
+                return;
+            }
+
+            // Both lists are drawn twice, so they are ordered once here instead of per pass.
+            alphaTestAggregateDraws.Sort(MeshBatchRenderer.CompareAlphaTestThenProgram);
+            alphaTestOpaqueDraws.Sort(MeshBatchRenderer.CompareCustomPipeline);
+
+            var prepassed = depthOnlyShader != null;
+
+            if (prepassed)
+            {
+                using var prepassGroup = new GLDebugGroup("Alpha Test Depth Prepass");
+                using var prepassState = GraphicsContext.RenderState.Scope(colorWriteMask: RsColorWriteEnableBits.None);
+
+                PerfStats.Active.SuspendTriangleCounter();
+
+                renderContext.RenderPass = RenderPass.DepthOnly;
+                renderContext.DepthOnlyShader = depthOnlyShader;
+                MeshBatchRenderer.Render(alphaTestAggregateDraws, renderContext);
+                MeshBatchRenderer.Render(alphaTestOpaqueDraws, renderContext);
+                renderContext.DepthOnlyShader = null;
+
+                PerfStats.Active.ResumeTriangleCounter();
+            }
+
+            using var drawGroup = new GLDebugGroup("Alpha Test Render");
+
+            // The prepass already placed this geometry, and the pass baseline compares strictly closer, which
+            // every one of these fragments would now fail. Testing for equality against what the prepass wrote
+            // instead leaves each surface shaded exactly once, wherever the cutout kept it.
+            using var drawState = prepassed
+                ? GraphicsContext.RenderState.Scope(depthWrite: false, depthFunc: RsComparison.Equal)
+                : default;
+
+            renderContext.RenderPass = RenderPass.OpaqueAggregate;
+            MeshBatchRenderer.Render(alphaTestAggregateDraws, renderContext);
+
+            renderContext.RenderPass = RenderPass.Opaque;
+            MeshBatchRenderer.Render(alphaTestOpaqueDraws, renderContext);
         }
 
         /// <summary>Renders all translucent draw calls collected during <see cref="CollectSceneDrawCalls"/>.</summary>

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -1018,7 +1018,7 @@ namespace ValveResourceFormat.Renderer
                 if (request.Node is SceneAggregate { CanDrawIndirect: true })
                 {
                     // Alpha tested draws are prepassed on their own, see RenderAlphaTestGeometry
-                    if (request.Call.Material is { IsAlphaTest: true, CanDepthPrepass: true })
+                    if (request.Call.Material is { IsAlphaTest: true, CanPrimeDepth: true })
                     {
                         alphaTestAggregateDraws.Add(request);
                         return;
@@ -1062,7 +1062,7 @@ namespace ValveResourceFormat.Renderer
 
             // Not the ones rerouted above: those draw after the framebuffer grab, past every depth pass
             if (renderPass == RenderPass.Opaque && !isViewmodelLayer && !isLatePass
-                && request.Call.Material is { IsAlphaTest: true, CanDepthPrepass: true })
+                && request.Call.Material is { IsAlphaTest: true, CanPrimeDepth: true })
             {
                 queueList = alphaTestOpaqueDraws;
             }

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -84,6 +84,9 @@ namespace ValveResourceFormat.Renderer
             /// </summary>
             public Shader? DepthOnlyShader { get; set; }
 
+            /// <summary>Gets or sets the fallback counting shader, set for the pass that counts quad overdraw.</summary>
+            public Shader? OverdrawShader { get; set; }
+
             /// <summary>Gets the list of scene-level textures bound to reserved texture slots.</summary>
             public required List<(ReservedTextureSlots Slot, string Name, RenderTexture Texture)> Textures { get; init; }
         }
@@ -1771,6 +1774,8 @@ namespace ValveResourceFormat.Renderer
                     // what this one wrote, so the two have to place every fragment identically, and only the
                     // same program guarantees that. Nothing here samples the target, so a forward pixel
                     // shader is safe.
+                    var passShader = renderContext.ReplacementShader;
+
                     renderContext.RenderPass = RenderPass.DepthOnly;
                     foreach (var (bucket, calls) in depthOnlyDraws)
                     {
@@ -1778,7 +1783,7 @@ namespace ValveResourceFormat.Renderer
                         MeshBatchRenderer.Render(calls, renderContext);
                     }
 
-                    renderContext.ReplacementShader = null;
+                    renderContext.ReplacementShader = passShader;
 
                     PerfStats.Active.ResumeTriangleCounter();
                 }
@@ -1844,11 +1849,16 @@ namespace ValveResourceFormat.Renderer
 
                 PerfStats.Active.SuspendTriangleCounter();
 
+                var passShader = renderContext.ReplacementShader;
+                renderContext.ReplacementShader = null;
+
                 renderContext.RenderPass = RenderPass.DepthOnly;
                 renderContext.DepthOnlyShader = depthOnlyShader;
                 MeshBatchRenderer.Render(alphaTestAggregateDraws, renderContext);
                 MeshBatchRenderer.Render(alphaTestOpaqueDraws, renderContext);
+
                 renderContext.DepthOnlyShader = null;
+                renderContext.ReplacementShader = passShader;
 
                 PerfStats.Active.ResumeTriangleCounter();
             }

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -1420,8 +1420,16 @@ namespace ValveResourceFormat.Renderer
                 }
                 else
                 {
-                    // Nodes that draw themselves have no material to take a depth mode from, and their own
-                    // shaders sample the shadow map this pass renders into, so they cast no shadow.
+                    if ((node.Flags & skipFlags) == 0 && (node.RenderPasses & CustomRenderPasses.DepthOnly) != 0)
+                    {
+                        AccumulateDepthFit(node);
+
+                        drawBuckets[DepthOnlyBucket.MaterialDepthMode].Add(new MeshBatchRenderer.Request
+                        {
+                            Node = node,
+                        });
+                    }
+
                     continue;
                 }
 

--- a/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
@@ -656,9 +656,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 return;
             }
 
-            // Not RenderPass.DepthOnly: particles have no depth mode to draw a shadow map with, and their
-            // own shaders sample the shadow map that pass renders into.
-            if (context.RenderPass is not (RenderPass.Opaque or RenderPass.Translucent))
+            if (context.RenderPass is not (RenderPass.Opaque or RenderPass.Translucent or RenderPass.DepthOnly))
             {
                 return;
             }

--- a/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
@@ -656,7 +656,9 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 return;
             }
 
-            if (context.RenderPass is not (RenderPass.Opaque or RenderPass.Translucent or RenderPass.DepthOnly))
+            // Not RenderPass.DepthOnly: particles have no depth mode to draw a shadow map with, and their
+            // own shaders sample the shadow map that pass renders into.
+            if (context.RenderPass is not (RenderPass.Opaque or RenderPass.Translucent))
             {
                 return;
             }

--- a/Renderer/Renderer/SceneNodes/SpriteSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/SpriteSceneNode.cs
@@ -62,16 +62,23 @@ namespace ValveResourceFormat.Renderer.SceneNodes
 
             LocalBoundingBox = new AABB(-Vector3.One * spriteSize, Vector3.One * spriteSize);
             Transform = Matrix4x4.CreateTranslation(position.X, position.Y, position.Z);
+
+            RenderPasses |= CustomRenderPasses.DepthOnly;
         }
 
         public override void Render(Scene.RenderContext context)
         {
-            if (context.RenderPass is not RenderPass.Opaque and not RenderPass.Outline)
+            if (context.RenderPass is not RenderPass.Opaque and not RenderPass.Outline and not RenderPass.DepthOnly)
             {
                 return;
             }
 
-            var renderShader = context.ReplacementShader ?? material.Shader;
+            // The sprite's own shader samples the shadow map a depth pass renders into. It needs no depth mode
+            // of its own: the transform uniform set below places the quad the way the shared depth shader does.
+            var renderShader = context.DepthOnlyShader?.WithAlphaTest(material.IsAlphaTest)
+                ?? context.ReplacementShader
+                ?? material.Shader;
+
             renderShader.Use();
 
             VertexArray.Bind(vao, renderShader);
@@ -89,6 +96,8 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 * billboardMatrix
                 * Matrix4x4.CreateTranslation(Transform.Translation);
             renderShader.SetUniform3x4("transform", transform);
+
+            renderShader.SetUniform1("bIsInstancing", 0u);
 
             renderShader.SetBoneAnimationData(false);
             renderShader.SetUniform1("vTint", Color32.FromVector4Clamped(Tint).PackedValue);

--- a/Renderer/Renderer/SceneNodes/SpriteSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/SpriteSceneNode.cs
@@ -73,8 +73,6 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 return;
             }
 
-            // The sprite's own shader samples the shadow map a depth pass renders into. It needs no depth mode
-            // of its own: the transform uniform set below places the quad the way the shared depth shader does.
             var renderShader = context.DepthOnlyShader?.WithAlphaTest(material.IsAlphaTest)
                 ?? context.ReplacementShader
                 ?? material.Shader;

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -4,9 +4,7 @@ using ValveResourceFormat.ThirdParty;
 
 namespace ValveResourceFormat.Renderer.Shaders
 {
-    /// <summary>
-    /// OpenGL shader program with uniform management and material defaults.
-    /// </summary>
+    /// <summary>OpenGL shader program with uniform management and material defaults.</summary>
     public class Shader
     {
         /// <summary>Gets the shader name (typically a Source 2 <c>.vfx</c> shader name).</summary>
@@ -30,11 +28,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         /// <summary>Gets the static combo parameter values used to compile this shader variant.</summary>
         public required IReadOnlyDictionary<string, byte> Parameters { get; init; }
 
-        /// <summary>
-        /// Gets every static combo the shader source declares, with its default value. Unlike
-        /// <see cref="Parameters"/> this covers the combos this variant left at their default, so it answers
-        /// whether a combo exists at all. Shared by every variant compiled from the same source.
-        /// </summary>
+        /// <summary>Gets every static combo the source declares, unlike <see cref="Parameters"/>. Shared by every variant.</summary>
         public required IReadOnlyDictionary<string, byte> Defines { get; init; }
 
         /// <summary>Gets the set of render mode names supported by this shader.</summary>
@@ -51,12 +45,7 @@ namespace ValveResourceFormat.Renderer.Shaders
 
         private GlobalsLayout globalsLayout = GlobalsLayout.Empty;
 
-        /// <summary>
-        /// Gets the packed layout of this shader's loose global uniforms. Derived from the source rather than
-        /// from the linked program, so it is known before the shader links, and is shared by every variant
-        /// compiled from the same source. A <see cref="RenderMaterial"/> only has to refill its constant
-        /// buffer when this changes, which outside of a shader reload it never does.
-        /// </summary>
+        /// <summary>Gets the packed layout of this shader's loose global uniforms, derived from the source and shared by every variant.</summary>
         public GlobalsLayout GlobalsLayout
         {
             get => globalsLayout;
@@ -91,17 +80,10 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
-        /// <summary>
-        /// Gets the set of reserved texture uniform names that this shader samples. Seeded from the parsed source,
-        /// so it is available before the program is linked, and trimmed by <see cref="EnsureLoaded"/> down to the
-        /// ones the linker kept for this variant's combos.
-        /// </summary>
+        /// <summary>Gets the reserved texture uniforms this shader samples, seeded from the source and trimmed by <see cref="EnsureLoaded"/>.</summary>
         public HashSet<string> ReservedTexturesUsed { get; init; } = [];
 
-        /// <summary>
-        /// Gets a value indicating whether the program samples <c>g_tSceneColor</c>. Declaring it is enough until
-        /// the program is linked, after which it means the linker kept it.
-        /// </summary>
+        /// <summary>Gets whether the program samples <c>g_tSceneColor</c>.</summary>
         public bool ReadsSceneColor => ReservedTexturesUsed.Contains("g_tSceneColor");
 
         private readonly Dictionary<string, (ActiveUniformType Type, int Location, bool SrgbRead)> Uniforms = [];
@@ -121,10 +103,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         /// <summary>Gets a value indicating whether material data (textures and params) should be skipped during rendering.</summary>
         public bool IgnoreMaterialData { get; }
 
-        /// <summary>
-        /// Gets whether this variant alpha tests. A material-ignoring replacement shader still reads the
-        /// material's color texture when it does, so that it cuts out the same shape the material would.
-        /// </summary>
+        /// <summary>Gets whether this variant alpha tests, which makes it read the material's color texture.</summary>
         public bool IsAlphaTestVariant => Parameters.GetValueOrDefault(AlphaTestCombo) == 1;
 
         /// <summary>Gets whether the shader source declares <paramref name="combo"/> as a static combo.</summary>
@@ -133,10 +112,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         /// <summary>Gets this shader's depth only mode, or <see langword="null"/> when it has none.</summary>
         public Shader? DepthMode => DeclaresCombo(DepthModeCombo) ? WithCombo(DepthModeCombo, 1) : null;
 
-        /// <summary>
-        /// Gets this shader's alpha test variant when the material alpha tests and this shader has one,
-        /// and this shader otherwise.
-        /// </summary>
+        /// <summary>Gets this shader's alpha test variant when it has one and the material alpha tests, and this shader otherwise.</summary>
         public Shader WithAlphaTest(bool alphaTest)
             => alphaTest && DeclaresCombo(AlphaTestCombo) ? WithCombo(AlphaTestCombo, 1) : this;
 
@@ -155,10 +131,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         private readonly ShaderLoader shaderLoader;
         private Dictionary<(string Combo, byte Value), Shader>? variants;
 
-        /// <summary>
-        /// Gets this shader with one combo set differently. Cached, so a pass can pick a variant per draw
-        /// instead of loading every combination up front. Chain the calls to move on more than one combo.
-        /// </summary>
+        /// <summary>Gets this shader with one combo set differently, cached. Chain the calls to move more than one.</summary>
         public Shader WithCombo(string combo, byte value)
         {
             if (Parameters.GetValueOrDefault(combo) == value)
@@ -266,10 +239,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
-        /// <summary>
-        /// Deletes the program and the buffer holding its default globals. Any stage objects that
-        /// <see cref="EnsureLoaded"/> did not get to clean up are deleted with it.
-        /// </summary>
+        /// <summary>Deletes the program, its default globals buffer, and any stage objects still attached.</summary>
         public void Delete()
         {
             if (Program == 0)
@@ -291,10 +261,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             Default.Delete();
         }
 
-        /// <summary>
-        /// Caches the attribute locations the linked program reads, and verifies each landed where its
-        /// <see cref="VertexSlot"/> puts it. Attributes the linker dropped are not active.
-        /// </summary>
+        /// <summary>Caches the attribute locations the linked program reads, and verifies each landed on its <see cref="VertexSlot"/>.</summary>
         private void StoreRequiredAttributes()
         {
             GL.GetProgram(Program, GetProgramParameterName.ActiveAttributes, out var attributeCount);
@@ -335,11 +302,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
-        /// <summary>
-        /// A shader whose attributes the renderer cannot place is an authoring fault, so development builds
-        /// stop on it. A release build only logs, because a mounted shader must not take the viewer down
-        /// from inside a draw call.
-        /// </summary>
+        /// <summary>Stops on an unplaceable attribute in development builds, and only logs in release.</summary>
         private void ReportBadAttribute(string message)
         {
             Logger.LogError("{Message}", message);
@@ -482,12 +445,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
-        /// <summary>
-        /// Installs this shader program as part of the current rendering state, along with the constant buffer
-        /// holding its own global uniforms. A <see cref="RenderMaterial"/> rendered afterwards replaces that
-        /// buffer with its own; shaders drawn without a material keep it, and <see cref="SetUniform(string, float)"/>
-        /// writes into it.
-        /// </summary>
+        /// <summary>Installs this program and the constant buffer holding its own global uniforms.</summary>
         public void Use()
         {
             EnsureLoaded();
@@ -566,11 +524,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         }
 
 #if DEBUG
-        /// <summary>
-        /// Checks the offsets <see cref="GlobalsLayout"/> computed against the ones the driver laid the
-        /// block out at. They are both std140 so they have to agree, but getting this wrong would corrupt every
-        /// material silently (debug builds only).
-        /// </summary>
+        /// <summary>Checks the offsets <see cref="GlobalsLayout"/> computed against the driver's own std140 layout (debug builds only).</summary>
         private void VerifyGlobalsLayout()
         {
             if (GlobalsLayout.Size == 0)
@@ -729,10 +683,7 @@ namespace ValveResourceFormat.Renderer.Shaders
             }
         }
 
-        /// <summary>
-        /// Gets this shader built for what a mesh supplies. Only a pass that replaces material shaders needs
-        /// it, since a material shader already carries the combo of the mesh it was loaded for.
-        /// </summary>
+        /// <summary>Gets this shader built for what a mesh supplies, for passes that replace material shaders.</summary>
         public Shader WithSkinning(MeshSkinning skinning) => WithCombo("D_SKINNING", (byte)skinning);
 
         /// <summary>Sets the <c>uAnimationData</c> uniform used by skinned mesh shaders.</summary>

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -30,6 +30,13 @@ namespace ValveResourceFormat.Renderer.Shaders
         /// <summary>Gets the static combo parameter values used to compile this shader variant.</summary>
         public required IReadOnlyDictionary<string, byte> Parameters { get; init; }
 
+        /// <summary>
+        /// Gets every static combo the shader source declares, with its default value. Unlike
+        /// <see cref="Parameters"/> this covers the combos this variant left at their default, so it answers
+        /// whether a combo exists at all. Shared by every variant compiled from the same source.
+        /// </summary>
+        public required IReadOnlyDictionary<string, byte> Defines { get; init; }
+
         /// <summary>Gets the set of render mode names supported by this shader.</summary>
         public required HashSet<string> RenderModes { get; init; }
 
@@ -114,8 +121,34 @@ namespace ValveResourceFormat.Renderer.Shaders
         /// <summary>Gets a value indicating whether material data (textures and params) should be skipped during rendering.</summary>
         public bool IgnoreMaterialData { get; }
 
-        /// <summary>Replacement shader that reads the material's color texture.</summary>
-        public bool IsDepthOnlyAlphaTest => Name == "depth_only" && Parameters.GetValueOrDefault("F_ALPHA_TEST") == 1;
+        /// <summary>
+        /// Gets whether this variant alpha tests. A material-ignoring replacement shader still reads the
+        /// material's color texture when it does, so that it cuts out the same shape the material would.
+        /// </summary>
+        public bool IsAlphaTestVariant => Parameters.GetValueOrDefault(AlphaTestCombo) == 1;
+
+        /// <summary>Gets whether the shader source declares <paramref name="combo"/> as a static combo.</summary>
+        public bool DeclaresCombo(string combo) => Defines.ContainsKey(combo);
+
+        /// <summary>
+        /// Gets this shader's depth only mode, or <see langword="null"/> when it has none. Valve declares the
+        /// mode on the vfx as <c>Depth(S_MODE_DEPTH)</c>; the combo drops the forward pixel shader, leaving a
+        /// program that cannot sample the shadow map a depth pass renders into.
+        /// </summary>
+        public Shader? DepthMode => DeclaresCombo(DepthModeCombo) ? WithCombo(DepthModeCombo, 1) : null;
+
+        /// <summary>
+        /// Gets this shader's alpha test variant when the material alpha tests and this shader has one,
+        /// and this shader otherwise.
+        /// </summary>
+        public Shader WithAlphaTest(bool alphaTest)
+            => alphaTest && DeclaresCombo(AlphaTestCombo) ? WithCombo(AlphaTestCombo, 1) : this;
+
+        /// <summary>The static combo that selects a material shader's depth only mode.</summary>
+        public const string DepthModeCombo = "S_MODE_DEPTH";
+
+        /// <summary>The static combo that turns on alpha testing.</summary>
+        public const string AlphaTestCombo = "F_ALPHA_TEST";
 
         private readonly ShaderLoader shaderLoader;
         private Dictionary<(string Combo, byte Value), Shader>? variants;
@@ -148,7 +181,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         }
 
         /// <summary>Sets a uniform on this shader and on every variant taken from it, which are separate
-        /// programs and so hold their own copy.</summary>
+        /// programs and so hold their own copy. Variants can be taken of variants, so the walk recurses.</summary>
         public void SetUniform1AllVariants(string name, uint value)
         {
             SetUniform1(name, value);
@@ -160,7 +193,7 @@ namespace ValveResourceFormat.Renderer.Shaders
 
             foreach (var variant in variants.Values)
             {
-                variant.SetUniform1(name, value);
+                variant.SetUniform1AllVariants(name, value);
             }
         }
 

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -130,11 +130,7 @@ namespace ValveResourceFormat.Renderer.Shaders
         /// <summary>Gets whether the shader source declares <paramref name="combo"/> as a static combo.</summary>
         public bool DeclaresCombo(string combo) => Defines.ContainsKey(combo);
 
-        /// <summary>
-        /// Gets this shader's depth only mode, or <see langword="null"/> when it has none. Valve declares the
-        /// mode on the vfx as <c>Depth(S_MODE_DEPTH)</c>; the combo drops the forward pixel shader, leaving a
-        /// program that cannot sample the shadow map a depth pass renders into.
-        /// </summary>
+        /// <summary>Gets this shader's depth only mode, or <see langword="null"/> when it has none.</summary>
         public Shader? DepthMode => DeclaresCombo(DepthModeCombo) ? WithCombo(DepthModeCombo, 1) : null;
 
         /// <summary>

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -144,8 +144,14 @@ namespace ValveResourceFormat.Renderer.Shaders
         public Shader WithAlphaTest(bool alphaTest)
             => alphaTest && DeclaresCombo(AlphaTestCombo) ? WithCombo(AlphaTestCombo, 1) : this;
 
+        /// <summary>Gets this shader's quad overdraw counting mode, or <see langword="null"/> when it has none.</summary>
+        public Shader? OverdrawMode => DeclaresCombo(OverdrawModeCombo) ? WithCombo(OverdrawModeCombo, 1) : null;
+
         /// <summary>The static combo that selects a material shader's depth only mode.</summary>
         public const string DepthModeCombo = "S_MODE_DEPTH";
+
+        /// <summary>The static combo that selects the quad overdraw counting mode.</summary>
+        public const string OverdrawModeCombo = "S_MODE_OVERDRAW";
 
         /// <summary>The static combo that turns on alpha testing.</summary>
         public const string AlphaTestCombo = "F_ALPHA_TEST";

--- a/Renderer/Renderer/Shaders/ShaderLoader.cs
+++ b/Renderer/Renderer/Shaders/ShaderLoader.cs
@@ -285,6 +285,7 @@ namespace ValveResourceFormat.Renderer.Shaders
 #endif
 
                     Parameters = arguments,
+                    Defines = parsedData.Defines,
                     GlobalsLayout = parsedData.GlobalsLayout,
                     Program = shaderProgram,
                     ShaderObjects = shaderObjects,

--- a/Renderer/Renderer/World/WorldLoader.cs
+++ b/Renderer/Renderer/World/WorldLoader.cs
@@ -47,7 +47,7 @@ namespace ValveResourceFormat.Renderer.World
         public WorldNode? MainWorldNode { get; private set; }
 
         /// <summary>Layer names that should be visible by default, populated during loading.</summary>
-        public HashSet<string> DefaultEnabledLayers { get; } = ["No layer", "Entities", "Particles"];
+        public HashSet<string> DefaultEnabledLayers { get; } = ["No layer", "Entities", EditorEntityNode.LayerName, "Particles"];
 
         /// <summary>Names of info_camera_link entities found in the world.</summary>
         public List<string> CameraNames { get; } = [];

--- a/Renderer/Shaders/common/quad_overdraw.slang
+++ b/Renderer/Shaders/common/quad_overdraw.slang
@@ -23,4 +23,56 @@ int QuadOverdrawCountIndex(ivec2 quad)
     return QuadOverdrawLockIndex(quad) + 1;
 }
 
+void CountQuadOverdraw()
+{
+    const uint QUAD_UNLOCKED = 0u;
+
+    ivec2 quad = ivec2(gl_FragCoord.xy * 0.5);
+    int lockIndex = QuadOverdrawLockIndex(quad);
+
+    // Zero means unlocked (so the buffer clears to all zeroes), quads are claimed with the primitive id offset by one.
+    uint claimValue = uint(gl_PrimitiveID) + 1u;
+
+    // A primitive that touches a 2x2 quad shades it once per covered pixel, but must count only once.
+
+    // The quad lock serves as a scoreboard: each fragment tries to claim the quad with its primitive id, and only a claim
+    // that observed the quad unlocked counts.
+
+    // Fragments that see their primitive id lost the race to a sibling fragment and bail.
+
+    // Fragments that see a different primitive spin while that primitive releases the
+    // lock, bounded to keep the loop finite under heavy load.
+    uint lockValue = 0u;
+    bool done = false;
+    int claimed = 0;
+
+    for (int i = 0; i < 16; i++)
+    {
+        if (!done)
+        {
+            lockValue = atomicCompSwap(g_quadOverdraw[lockIndex], QUAD_UNLOCKED, claimValue);
+        }
+
+        if (lockValue == QUAD_UNLOCKED)
+        {
+            // First pass claims the quad, the iteration after releases it.
+            claimed++;
+
+            if (claimed == 2)
+            {
+                lockValue = atomicExchange(g_quadOverdraw[lockIndex], QUAD_UNLOCKED);
+            }
+
+            done = true;
+        }
+
+        done = done || lockValue == claimValue;
+    }
+
+    if (claimed != 0)
+    {
+        atomicAdd(g_quadOverdraw[lockIndex + 1], 1u);
+    }
+}
+
 #endif

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -240,7 +240,7 @@ vec3 calculateWorldNormal(vec3 normalMap, vec3 normal, vec3 tangent, vec3 bitang
 
     float AlphaTestAntiAliasing(float flOpacity, vec2 UVs)
     {
-        const bool isMsaa = true;
+        bool isMsaa = gl_NumSamples > 1;
 
         const float epsilon = 1 / 255.0;
         float flTestValue = isMsaa

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -51,11 +51,8 @@
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 // MODES
-// Valve declares this one on the vfx as Depth(S_MODE_DEPTH): the shader's depth only mode. It keeps the
-// vertex shader, and with it skinning, morphs, animated texture coordinates and foliage animation, but
-// cuts the pixel shader down to the alpha test. The depth passes draw with it because a forward pixel
-// shader would sample the very shadow map it is drawing into.
 #define S_MODE_DEPTH 0
+#define S_MODE_OVERDRAW 0
 // BLENDING
 #define F_FULLBRIGHT 0 // global_lit_simple
 #define F_LIT 0 // csgo_static_overlay, vr_static_overlay
@@ -106,8 +103,12 @@ centroid in vec4 vVertexColorOut;
     in float vCurvatureOut;
 #endif
 
-#if (S_MODE_DEPTH == 0)
+#if (S_MODE_DEPTH == 0) && (S_MODE_OVERDRAW == 0)
     out vec4 outputColor;
+#endif
+
+#if (S_MODE_OVERDRAW == 1)
+    #include "common/quad_overdraw.slang"
 #endif
 
 uniform sampler2D g_tBlueNoise; // reserved
@@ -312,27 +313,26 @@ uniform sampler2D g_tTintMask;
 #include "common/texturing.slang"
 #include "common/fog.slang"
 
-#if (S_MODE_DEPTH == 1)
+#if (S_MODE_DEPTH == 1) || (S_MODE_OVERDRAW == 1)
 
-    #if (alphatest)
-        // Alpha to coverage masks depth writes as well as color, and reads the alpha written here. Running
-        // the same test the forward pass runs therefore lays depth down on exactly the samples that pass
-        // will shade, edge included. A shadow map has neither a color attachment nor multisampling, so
-        // there the write is dropped and the test falls back to a hard cutout at the reference.
+    #if (alphatest) || (S_MODE_OVERDRAW == 1)
         out vec4 outputColor;
-    #else
-        // Nothing discards, so the depth test can run ahead of this (empty) shader
+    #endif
+
+    #if (S_MODE_OVERDRAW == 1) || !(alphatest)
         layout (early_fragment_tests) in;
     #endif
 
-    // Depth only mode. Deliberately stops short of including lighting.slang: leaving the shadow map
-    // samplers out of the program is what makes it impossible to sample a shadow map while rendering
-    // into it. The texture coordinates are the vertex shader's, so animated and scrolling UVs cut out
-    // the same shape here as they do in the forward pass.
     void main()
     {
         #if (alphatest)
             outputColor = vec4(0.0, 0.0, 0.0, AlphaTestAntiAliasing(texture(g_tColor, vTexCoordOut).a, vTexCoordOut));
+        #elif (S_MODE_OVERDRAW == 1)
+            outputColor = vec4(0.0, 0.0, 0.0, 1.0);
+        #endif
+
+        #if (S_MODE_OVERDRAW == 1)
+            CountQuadOverdraw();
         #endif
     }
 

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -50,6 +50,12 @@
 #endif
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
+// MODES
+// Valve declares this one on the vfx as Depth(S_MODE_DEPTH): the shader's depth only mode. It keeps the
+// vertex shader, and with it skinning, morphs, animated texture coordinates and foliage animation, but
+// cuts the pixel shader down to the alpha test. The depth passes draw with it because a forward pixel
+// shader would sample the very shadow map it is drawing into.
+#define S_MODE_DEPTH 0
 // BLENDING
 #define F_FULLBRIGHT 0 // global_lit_simple
 #define F_LIT 0 // csgo_static_overlay, vr_static_overlay
@@ -100,7 +106,9 @@ centroid in vec4 vVertexColorOut;
     in float vCurvatureOut;
 #endif
 
-out vec4 outputColor;
+#if (S_MODE_DEPTH == 0)
+    out vec4 outputColor;
+#endif
 
 uniform sampler2D g_tBlueNoise; // reserved
 uniform sampler2D g_tColor; // SrgbRead(true) Sampler(UserConfig)
@@ -303,6 +311,32 @@ uniform sampler2D g_tTintMask;
 #include "common/fullbright.slang"
 #include "common/texturing.slang"
 #include "common/fog.slang"
+
+#if (S_MODE_DEPTH == 1)
+
+    #if (alphatest)
+        // Alpha to coverage masks depth writes as well as color, and reads the alpha written here. Running
+        // the same test the forward pass runs therefore lays depth down on exactly the samples that pass
+        // will shade, edge included. A shadow map has neither a color attachment nor multisampling, so
+        // there the write is dropped and the test falls back to a hard cutout at the reference.
+        out vec4 outputColor;
+    #else
+        // Nothing discards, so the depth test can run ahead of this (empty) shader
+        layout (early_fragment_tests) in;
+    #endif
+
+    // Depth only mode. Deliberately stops short of including lighting.slang: leaving the shadow map
+    // samplers out of the program is what makes it impossible to sample a shadow map while rendering
+    // into it. The texture coordinates are the vertex shader's, so animated and scrolling UVs cut out
+    // the same shape here as they do in the forward pass.
+    void main()
+    {
+        #if (alphatest)
+            outputColor = vec4(0.0, 0.0, 0.0, AlphaTestAntiAliasing(texture(g_tColor, vTexCoordOut).a, vTexCoordOut));
+        #endif
+    }
+
+#else
 
 // Must be last
 #include "common/lighting.slang"
@@ -782,3 +816,5 @@ void main()
     }
 #endif
 }
+
+#endif

--- a/Renderer/Shaders/depth_only.frag.slang
+++ b/Renderer/Shaders/depth_only.frag.slang
@@ -8,6 +8,7 @@
 
 #if (F_ALPHA_TEST == 1)
     layout (location = 0) in vec2 texCoord;
+    layout (location = 0) out vec4 outputColor;
     uniform sampler2D g_tColor;
     uniform float g_flAlphaTestReference = 0.5;
 #endif
@@ -18,5 +19,7 @@ void main()
         float opacity = texture(g_tColor, texCoord).a;
         if (opacity - 0.001 < g_flAlphaTestReference)
             discard;
+
+        outputColor = vec4(0.0, 0.0, 0.0, 1.0);
     #endif
 }

--- a/Renderer/Shaders/particle_cable.frag.slang
+++ b/Renderer/Shaders/particle_cable.frag.slang
@@ -9,6 +9,8 @@
 
 // cables.vfx
 
+#define S_MODE_DEPTH 0
+
 uniform sampler2D g_tColor; // SrgbRead(true)
 
 uniform float g_flRoughness = 1.0;
@@ -19,6 +21,16 @@ in vec3 vFragPosition;
 in vec3 vNormalOut;
 in vec2 vTexCoordOut;
 in vec4 vColorOut;
+
+#if (S_MODE_DEPTH == 1)
+
+layout (early_fragment_tests) in;
+
+void main(void)
+{
+}
+
+#else
 
 out vec4 outputColor;
 
@@ -64,3 +76,5 @@ void main(void)
         //
     }
 }
+
+#endif

--- a/Renderer/Shaders/quad_overdraw.frag.slang
+++ b/Renderer/Shaders/quad_overdraw.frag.slang
@@ -1,11 +1,19 @@
 #version 460
 
 #define renderMode_QuadOverdraw 0
+#define F_ALPHA_TEST 0 // set per draw from the material, see MeshBatchRenderer
 
 #include "common/quad_overdraw.slang"
 
-// Count with the depth test the scene actually rendered with, and without the UAV writes disabling early z.
-layout(early_fragment_tests) in;
+#if (F_ALPHA_TEST == 0)
+    // Count with the depth test the scene actually rendered with, and without the UAV writes disabling early z.
+    // Alpha tested draws cannot have it: an early depth write would record the fragments they discard.
+    layout(early_fragment_tests) in;
+#else
+    layout (location = 0) in vec2 texCoord;
+    uniform sampler2D g_tColor;
+    uniform float g_flAlphaTestReference = 0.5;
+#endif
 
 layout(location = 0) out vec4 outputColor;
 
@@ -17,6 +25,13 @@ const uint QUAD_UNLOCKED = 0u;
 
 void main()
 {
+    // Before anything is counted, so cut out geometry costs what it really costs.
+    #if (F_ALPHA_TEST == 1)
+        float opacity = texture(g_tColor, texCoord).a;
+        if (opacity - 0.001 < g_flAlphaTestReference)
+            discard;
+    #endif
+
     outputColor = vec4(0.0, 0.0, 0.0, 1.0);
 
     if (!bCountQuads)

--- a/Renderer/Shaders/quad_overdraw.frag.slang
+++ b/Renderer/Shaders/quad_overdraw.frag.slang
@@ -5,11 +5,9 @@
 
 #include "common/quad_overdraw.slang"
 
-#if (F_ALPHA_TEST == 0)
-    // Count with the depth test the scene actually rendered with, and without the UAV writes disabling early z.
-    // Alpha tested draws cannot have it: an early depth write would record the fragments they discard.
-    layout(early_fragment_tests) in;
-#else
+layout(early_fragment_tests) in;
+
+#if (F_ALPHA_TEST == 1)
     layout (location = 0) in vec2 texCoord;
     uniform sampler2D g_tColor;
     uniform float g_flAlphaTestReference = 0.5;
@@ -17,72 +15,15 @@
 
 layout(location = 0) out vec4 outputColor;
 
-// False during the depth prime pass, which fills the depth buffer so that the
-// counting pass only shades (and counts) the surfaces that end up visible.
-uniform bool bCountQuads = true;
-
-const uint QUAD_UNLOCKED = 0u;
-
 void main()
 {
-    // Before anything is counted, so cut out geometry costs what it really costs.
+    outputColor = vec4(0.0, 0.0, 0.0, 1.0);
+
     #if (F_ALPHA_TEST == 1)
         float opacity = texture(g_tColor, texCoord).a;
         if (opacity - 0.001 < g_flAlphaTestReference)
             discard;
     #endif
 
-    outputColor = vec4(0.0, 0.0, 0.0, 1.0);
-
-    if (!bCountQuads)
-    {
-        return;
-    }
-
-    ivec2 quad = ivec2(gl_FragCoord.xy * 0.5);
-    int lockIndex = QuadOverdrawLockIndex(quad);
-
-    // Zero means unlocked (so the buffer clears to all zeroes), quads are claimed with the primitive id offset by one.
-    uint claimValue = uint(gl_PrimitiveID) + 1u;
-
-    // A primitive that touches a 2x2 quad shades it once per covered pixel, but must count only once.
-
-    // The quad lock serves as a scoreboard: each fragment tries to claim the quad with its primitive id, and only a claim
-    // that observed the quad unlocked counts.
-
-    // Fragments that see their primitive id lost the race to a sibling fragment and bail.
-
-    // Fragments that see a different primitive spin while that primitive releases the
-    // lock, bounded to keep the loop finite under heavy load.
-    uint lockValue = 0u;
-    bool done = false;
-    int claimed = 0;
-
-    for (int i = 0; i < 16; i++)
-    {
-        if (!done)
-        {
-            lockValue = atomicCompSwap(g_quadOverdraw[lockIndex], QUAD_UNLOCKED, claimValue);
-        }
-
-        if (lockValue == QUAD_UNLOCKED)
-        {
-            // First pass claims the quad, the iteration after releases it.
-            claimed++;
-
-            if (claimed == 2)
-            {
-                lockValue = atomicExchange(g_quadOverdraw[lockIndex], QUAD_UNLOCKED);
-            }
-
-            done = true;
-        }
-
-        done = done || lockValue == claimValue;
-    }
-
-    if (claimed != 0)
-    {
-        atomicAdd(g_quadOverdraw[lockIndex + 1], 1u);
-    }
+    CountQuadOverdraw();
 }

--- a/Renderer/Shaders/quad_overdraw.vert.slang
+++ b/Renderer/Shaders/quad_overdraw.vert.slang
@@ -1,12 +1,22 @@
 #version 460
 
+#define F_ALPHA_TEST 0 // set per draw from the material, see MeshBatchRenderer
+
 #include "common/instancing.slang"
 #include "common/animation.slang"
 
 in vec3 vPOSITION;
+#if (F_ALPHA_TEST == 1)
+    in vec2 vTEXCOORD;
+    layout (location = 0) out vec2 texCoord;
+#endif
 
 #include "common/ViewConstants.slang"
 
 void main(void) {
+#if (F_ALPHA_TEST == 1)
+    texCoord = vTEXCOORD;
+#endif
+
     gl_Position = g_matWorldToProjection * vec4(vec4(vPOSITION, 1.0) * CalculateSkinTransform(), 1.0);
 }


### PR DESCRIPTION
Fixes alpha test overdraw by first priming depth with simple shader. Then runs forward lighting shader with Equal check. No discard, so it benefits from early-Z.

<img width=70% alt="fps number" src="https://github.com/user-attachments/assets/f8916c2d-6046-4f69-b5b2-570525f319ce" />

Makes all geometry draw shadows with proper specialized shader. Vertex animated geo now will animate in shadows as well.

Makes all geometry calculate overdraw (QuadOverdraw debug mode) with proper specialized shader for better counting.

<img width=70% alt="quad overdraw" src="https://github.com/user-attachments/assets/1d39a1f9-713e-4417-9791-6f7eb0dde573" />

Previously the above view was all pink/white.
