### PR TITLE
Ignore lower map mesh LoDs in glTF export

### DIFF
--- a/Renderer/Renderer/SceneAggregate.cs
+++ b/Renderer/Renderer/SceneAggregate.cs
@@ -258,7 +258,7 @@ namespace ValveResourceFormat.Renderer
                 return true;
             }
 
-            return (fragment.LodGroupMask & (1u << activeLodLevels[fragment.LodSetupIndex])) != 0;
+            return ModelLodInfo.IsInLevel(fragment.LodGroupMask, activeLodLevels[fragment.LodSetupIndex]);
         }
 
         /// <summary>Appends a meshlet covering an entire draw call.</summary>

--- a/ValveResourceFormat/IO/Gltf/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/Gltf/GltfModelExporter.Mesh.cs
@@ -532,12 +532,15 @@ public partial class GltfModelExporter
             drawCalls.AddRange(objectDrawCalls);
         }
 
-        var combinedLodMask = 0u;
+        // LoD levels are indexed within each m_lodSetups entry, so the highest detail tier is the
+        // lowest level present per setup, not across the whole aggregate.
+        var combinedLodMaskPerSetup = new Dictionary<int, uint>();
         foreach (var fragmentData in aggregateMeshes)
         {
-            combinedLodMask |= fragmentData.GetUInt32Property("m_nLODGroupMask");
+            var setupIndex = fragmentData.GetInt32Property("m_nLODSetupIndex", -1);
+            combinedLodMaskPerSetup.TryGetValue(setupIndex, out var combinedLodMask);
+            combinedLodMaskPerSetup[setupIndex] = combinedLodMask | fragmentData.GetUInt32Property("m_nLODGroupMask");
         }
-        var lowestLodBit = combinedLodMask == 0 ? 0u : 1u << ResourceTypes.ModelLodInfo.LowestSetLevel(combinedLodMask);
 
         var id = 0;
 
@@ -563,6 +566,8 @@ public partial class GltfModelExporter
             }
 
             var lodGroupMask = fragmentData.GetUInt32Property("m_nLODGroupMask");
+            var setupIndex = fragmentData.GetInt32Property("m_nLODSetupIndex", -1);
+            var lowestLodBit = ResourceTypes.ModelLodInfo.LowestSetLevelMask(combinedLodMaskPerSetup[setupIndex]);
             var isHighestDetailMesh = lodGroupMask == 0 || (lodGroupMask & lowestLodBit) != 0;
             if (!isHighestDetailMesh)
             {

--- a/ValveResourceFormat/IO/Gltf/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/Gltf/GltfModelExporter.Mesh.cs
@@ -567,9 +567,7 @@ public partial class GltfModelExporter
 
             var lodGroupMask = fragmentData.GetUInt32Property("m_nLODGroupMask");
             var setupIndex = fragmentData.GetInt32Property("m_nLODSetupIndex", -1);
-            var lowestLodBit = ResourceTypes.ModelLodInfo.LowestSetLevelMask(combinedLodMaskPerSetup[setupIndex]);
-            var isHighestDetailMesh = lodGroupMask == 0 || (lodGroupMask & lowestLodBit) != 0;
-            if (!isHighestDetailMesh)
+            if (!ResourceTypes.ModelLodInfo.IsInLowestSetLevel(lodGroupMask, combinedLodMaskPerSetup[setupIndex]))
             {
                 continue;
             }

--- a/ValveResourceFormat/IO/Gltf/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/Gltf/GltfModelExporter.Mesh.cs
@@ -532,6 +532,13 @@ public partial class GltfModelExporter
             drawCalls.AddRange(objectDrawCalls);
         }
 
+        var combinedLodMask = 0u;
+        foreach (var fragmentData in aggregateMeshes)
+        {
+            combinedLodMask |= fragmentData.GetUInt32Property("m_nLODGroupMask");
+        }
+        var lowestLodBit = combinedLodMask == 0 ? 0u : 1u << ResourceTypes.ModelLodInfo.LowestSetLevel(combinedLodMask);
+
         var id = 0;
 
         foreach (var fragmentData in aggregateMeshes)
@@ -553,6 +560,13 @@ public partial class GltfModelExporter
                     ProgressReporter?.Report($"Skipping mesh: {meshName} because it has a scale of zero.");
                     continue;
                 }
+            }
+
+            var lodGroupMask = fragmentData.GetUInt32Property("m_nLODGroupMask");
+            var isHighestDetailMesh = lodGroupMask == 0 || (lodGroupMask & lowestLodBit) != 0;
+            if (!isHighestDetailMesh)
+            {
+                continue;
             }
 
             var tintColor = Vector4.One;

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelLodInfo.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelLodInfo.cs
@@ -144,5 +144,9 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>Returns the index of the lowest set bit in <paramref name="combinedMask"/>, or 0 if none.</summary>
         public static int LowestSetLevel(long combinedMask)
             => combinedMask == 0 ? 0 : BitOperations.TrailingZeroCount((ulong)combinedMask);
+
+        /// <summary>Returns a mask with only the lowest set level bit of <paramref name="combinedMask"/>, or 0 if none.</summary>
+        public static uint LowestSetLevelMask(uint combinedMask)
+            => combinedMask == 0 ? 0u : 1u << LowestSetLevel(combinedMask);
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelLodInfo.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelLodInfo.cs
@@ -47,7 +47,7 @@ namespace ValveResourceFormat.ResourceTypes
         /// empty LOD0) is a real LOD.
         /// </summary>
         public bool HasDistinctLevels => Enumerable.Range(1, Math.Max(LevelCount - 1, 0))
-            .Any(level => meshLodMasks.Any(mask => (mask & 1L) != ((mask >> level) & 1L)));
+            .Any(level => meshLodMasks.Any(mask => IsInLevel(mask, 0) != IsInLevel(mask, level)));
 
         /// <summary>
         /// Initializes LOD info from a model's mesh LOD masks (<c>m_refLODGroupMasks</c>) and switch
@@ -88,7 +88,7 @@ namespace ValveResourceFormat.ResourceTypes
         /// <paramref name="level"/>. Meshes without a mask entry are treated as always present.
         /// </summary>
         public bool IsMeshInLevel(int meshIndex, int level)
-            => meshIndex >= meshLodMasks.Length || (meshLodMasks[meshIndex] & 1L << level) != 0;
+            => meshIndex >= meshLodMasks.Length || IsInLevel(meshLodMasks[meshIndex], level);
 
         /// <summary>
         /// Determines whether the mesh at <paramref name="meshIndex"/> shows up in every populated LOD
@@ -145,8 +145,15 @@ namespace ValveResourceFormat.ResourceTypes
         public static int LowestSetLevel(long combinedMask)
             => combinedMask == 0 ? 0 : BitOperations.TrailingZeroCount((ulong)combinedMask);
 
-        /// <summary>Returns a mask with only the lowest set level bit of <paramref name="combinedMask"/>, or 0 if none.</summary>
-        public static uint LowestSetLevelMask(uint combinedMask)
-            => combinedMask == 0 ? 0u : 1u << LowestSetLevel(combinedMask);
+        /// <summary>Determines whether <paramref name="lodGroupMask"/> contains LOD level <paramref name="level"/>.</summary>
+        public static bool IsInLevel(long lodGroupMask, int level)
+            => (lodGroupMask & 1L << level) != 0;
+
+        /// <summary>
+        /// Determines whether <paramref name="lodGroupMask"/> includes the lowest set level of
+        /// <paramref name="combinedMask"/>. A mask of 0 is not LoD-managed and is always present.
+        /// </summary>
+        public static bool IsInLowestSetLevel(uint lodGroupMask, uint combinedMask)
+            => lodGroupMask == 0 || IsInLevel(lodGroupMask, LowestSetLevel(combinedMask));
     }
 }


### PR DESCRIPTION
## Description

Map aggregates tag each fragment with an LoD tier mask, the exporter wrote out every tier, so a map export contains overlapping duplicate copies of the same geometry

The renderer picks tiers dynamically from the world node LoD setups at camera distance. An export has no camera, so the filter keeps the highest detail tier present per aggregate

The filter runs after the fragment transform is consumed, so the remaining transforms keep their positional order — the same ordering the fragment transform fix needed

## Reproduction
Before: de_train 6274 fragment meshes
After: de_train 6187

Before: de_nuke 8239
After: de_nuke 8191

de_dust2 stays at 3472, its aggregates are single tier

Every retained mesh exists before and after with identical transforms and primitive counts, the dropped set is a strict subset

<img width="2226" height="906" alt="gltf_lod_bug" src="https://github.com/user-attachments/assets/88b899d5-8d59-4531-8828-7031cece5923" />

