### PR TITLE
Add Blender SMD export support for AnimGraph 2 skeletons and animatio…

### DIFF
--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 using GUI.Types.PackageViewer;
 using GUI.Utils;
 using SteamDatabase.ValvePak;
+using ValveResourceFormat;
 using ValveResourceFormat.IO;
 using Resource = ValveResourceFormat.Resource;
 
@@ -68,6 +69,13 @@ namespace GUI.Types.Exporter
                         const string glbFilter = "glTF Binary|*.glb";
 
                         filter = $"{filter}|{gltfFilter}|{glbFilter}";
+                    }
+
+                    if (extension is "vnmskel" or "vnmclip" or "vanim" or "vskel" or "vmdl" or "vmesh" or "vseq" or "vagrp"
+                        || resource.ResourceType is ResourceType.NmSkeleton or ResourceType.NmClip or ResourceType.Animation or ResourceType.AnimationGroup or ResourceType.Model or ResourceType.Mesh or ResourceType.Sequence)
+                    {
+                        const string smdFilter = "Source SMD (*.smd)|*.smd";
+                        filter = $"{filter}|{smdFilter}";
                     }
 
                     var fileNameForSave = Path.GetFileNameWithoutExtension(fileName);

--- a/GUI/Types/Exporter/PackageExporter.cs
+++ b/GUI/Types/Exporter/PackageExporter.cs
@@ -222,10 +222,11 @@ namespace GUI.Types.Exporter
                     firstType,
                 };
 
-                if (firstType is "vmdl" or "vmesh" or "vmap" or "vwrld" or "vwnod" or "vnmclip")
+                if (firstType is "vmdl" or "vmesh" or "vmap" or "vwrld" or "vwnod" or "vnmclip" or "vanim" or "vskel" or "vnmskel")
                 {
                     outputTypes.Add("gltf");
                     outputTypes.Add("glb");
+                    outputTypes.Add("smd");
                 }
                 else if (firstType == "vtex")
                 {
@@ -430,6 +431,36 @@ namespace GUI.Types.Exporter
             try
             {
                 contentFile = FileExtract.Extract(resource, exportData.VrfGuiContext, progress);
+
+                if (outExtension == ".smd")
+                {
+                    if (resource.ResourceType == ResourceType.NmClip)
+                    {
+                        var clipExtract = new NmClipExtract(resource, exportData.VrfGuiContext);
+                        var smdBytes = clipExtract.ToSmdData().ToBytes();
+                        await WriteFileAsync(outFilePath, smdBytes, cancellationToken).ConfigureAwait(false);
+                        return;
+                    }
+
+                    if (resource.ResourceType == ResourceType.NmSkeleton)
+                    {
+                        var skelExtract = new NmSkeletonExtract(resource);
+                        var smdBytes = skelExtract.ToSmdData().ToBytes();
+                        await WriteFileAsync(outFilePath, smdBytes, cancellationToken).ConfigureAwait(false);
+                        return;
+                    }
+
+                    var smdSubFile = contentFile.SubFiles.FirstOrDefault(f => f.FileName.EndsWith(".smd", StringComparison.OrdinalIgnoreCase));
+                    if (smdSubFile != null)
+                    {
+                        var smdBytes = smdSubFile.Extract?.Invoke();
+                        if (smdBytes != null)
+                        {
+                            await WriteFileAsync(outFilePath, smdBytes, cancellationToken).ConfigureAwait(false);
+                            return;
+                        }
+                    }
+                }
 
                 if (contentFile.Data != null)
                 {

--- a/Tests/SmdExportTest.cs
+++ b/Tests/SmdExportTest.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Threading.Tasks;
+using ValveResourceFormat;
+using ValveResourceFormat.IO;
+using ValveResourceFormat.IO.Smd;
+
+namespace Tests
+{
+    public class SmdExportTest
+    {
+        [Test]
+        public async Task SkeletonSmdExportWorks()
+        {
+            using var resource = new Resource();
+            resource.Read(Path.Combine(TestContext.TestDirectory!, "Files", "chicken.vnmskel_c"));
+
+            var skelExtract = new NmSkeletonExtract(resource);
+            var smdData = skelExtract.ToSmdData();
+
+            await Assert.That(smdData).IsNotNull();
+            await Assert.That(smdData.Bones.Count).IsGreaterThan(0);
+            await Assert.That(smdData.Type).IsEqualTo(SmdType.Skeleton);
+
+            var smdBytes = smdData.ToBytes();
+            await Assert.That(smdBytes).IsNotNull();
+            await Assert.That(smdBytes.Length).IsGreaterThan(0);
+
+            var smdText = System.Text.Encoding.UTF8.GetString(smdBytes);
+            await Assert.That(smdText).Contains("version 1");
+            await Assert.That(smdText).Contains("nodes");
+            await Assert.That(smdText).Contains("skeleton");
+            await Assert.That(smdText).Contains("time 0");
+            await Assert.That(smdText).Contains("end");
+        }
+    }
+}

--- a/ValveResourceFormat/IO/Extract/NmClipExtract.cs
+++ b/ValveResourceFormat/IO/Extract/NmClipExtract.cs
@@ -255,4 +255,72 @@ public class NmClipExtract
         kvDocEventTrack.Add("m_events", eventsArray);
         return kvDocEventTrack;
     }
+
+    private static readonly System.Numerics.Quaternion NmSkelRotationFixup = new(-0.5f, -0.5f, -0.5f, 0.5f);
+
+    /// <summary>
+    /// Converts the animation clip to Source Studio Model Data (SMD) format for Blender.
+    /// </summary>
+    public ValveResourceFormat.IO.Smd.SmdData ToSmdData(bool nmSkelAxisFixup = true)
+    {
+        var smd = new ValveResourceFormat.IO.Smd.SmdData
+        {
+            Name = Path.GetFileNameWithoutExtension(resource.FileName) ?? "Animation",
+            Type = ValveResourceFormat.IO.Smd.SmdType.Animation
+        };
+
+        var skeleton = ResourceTypes.ModelAnimation.Skeleton.FromSkeletonResource(fileLoader, clip.SkeletonName);
+        if (skeleton == null)
+        {
+            return smd;
+        }
+
+        foreach (var bone in skeleton.Bones)
+        {
+            smd.AddBone(bone.Parent?.Name ?? string.Empty, bone.Name);
+        }
+
+        var rootMotionBone = skeleton.Bones.FirstOrDefault(b => b.Name == "root_motion");
+        var frameBones = new ResourceTypes.ModelAnimation.FrameBone[skeleton.Bones.Length];
+
+        for (var f = 0; f < clip.NumFrames; f++)
+        {
+            clip.ReadFrame(f, frameBones);
+            var keyframes = new System.Collections.Generic.List<ValveResourceFormat.IO.Smd.SmdData.KeyFrame>();
+
+            for (var b = 0; b < skeleton.Bones.Length; b++)
+            {
+                var pos = frameBones[b].Position;
+                var rot = frameBones[b].Angle;
+
+                if (nmSkelAxisFixup && rootMotionBone != null && skeleton.Bones[b].Parent == rootMotionBone)
+                {
+                    var q = rot * NmSkelRotationFixup;
+                    pos = System.Numerics.Vector3.Transform(pos, NmSkelRotationFixup);
+                    rot = new System.Numerics.Quaternion(q.Y, q.Z, q.X, q.W);
+                }
+
+                var euler = EntityTransformHelper.ToEulerAngles(rot);
+                keyframes.Add(new ValveResourceFormat.IO.Smd.SmdData.KeyFrame(b, pos, euler));
+            }
+
+            smd.Frames.Add(keyframes);
+        }
+
+        return smd;
+    }
+
+    /// <summary>
+    /// Exports the animation clip as an SMD ContentFile.
+    /// </summary>
+    public ContentFile ToSmdContentFile(bool nmSkelAxisFixup = true)
+    {
+        var smd = ToSmdData(nmSkelAxisFixup);
+        return new ContentFile
+        {
+            Data = smd.ToBytes(),
+            FileName = Path.ChangeExtension(resource.FileName, "smd") ?? "clip.smd"
+        };
+    }
 }
+

--- a/ValveResourceFormat/IO/Extract/NmSkeletonExtract.cs
+++ b/ValveResourceFormat/IO/Extract/NmSkeletonExtract.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using ValveKeyValue;
+using ValveResourceFormat.IO.Smd;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
 using ValveResourceFormat.ResourceTypes.ModelAnimation2;
@@ -16,6 +17,7 @@ public class NmSkeletonExtract
 {
     private readonly Resource resource;
     private readonly KVObject kvSkeleton;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="NmSkeletonExtract"/> class.
     /// </summary>
@@ -67,6 +69,49 @@ public class NmSkeletonExtract
         {
             return ModelExtract.ToDmxSkeleton(skel, nmSkelAxisFixup: true, nmLowLodBoneCount: numLowLODBones);
         });
+
         return contentFile;
+    }
+
+    /// <summary>
+    /// Exports the skeleton directly to Source Studio Model Data (SMD) format for Blender.
+    /// </summary>
+    public SmdData ToSmdData()
+    {
+        var skel = Skeleton.FromSkeletonData(kvSkeleton);
+        var smd = new SmdData
+        {
+            Name = Path.GetFileNameWithoutExtension(resource.FileName) ?? "Skeleton",
+            Type = SmdType.Skeleton
+        };
+
+        foreach (var bone in skel.Bones)
+        {
+            smd.AddBone(bone.Parent?.Name ?? string.Empty, bone.Name);
+        }
+
+        var keyframes = new System.Collections.Generic.List<SmdData.KeyFrame>();
+        for (var i = 0; i < skel.Bones.Length; i++)
+        {
+            var bone = skel.Bones[i];
+            var euler = EntityTransformHelper.ToEulerAngles(bone.Angle);
+            keyframes.Add(new SmdData.KeyFrame(i, bone.Position, euler));
+        }
+
+        smd.Frames.Add(keyframes);
+        return smd;
+    }
+
+    /// <summary>
+    /// Exports the skeleton as an SMD ContentFile.
+    /// </summary>
+    public ContentFile ToSmdContentFile()
+    {
+        var smd = ToSmdData();
+        return new ContentFile
+        {
+            Data = smd.ToBytes(),
+            FileName = Path.ChangeExtension(resource.FileName, "smd") ?? "skeleton.smd"
+        };
     }
 }

--- a/ValveResourceFormat/IO/Smd/SmdData.cs
+++ b/ValveResourceFormat/IO/Smd/SmdData.cs
@@ -1,0 +1,101 @@
+#pragma warning disable CS1591, CA1063, CA1822
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+
+namespace ValveResourceFormat.IO.Smd;
+
+public class SmdData
+{
+    public string Name { get; set; } = "Unnamed";
+    public SmdType Type { get; set; }
+    public Dictionary<string, Bone> Bones { get; } = new();
+    public List<List<KeyFrame>> Frames { get; } = new();
+    public List<string> Materials { get; } = new();
+    public List<Triangle> Meshes { get; } = new();
+    public List<List<FlexVertex>> FlexFrames { get; } = new();
+    protected int CurrentBoneIndex { get; set; }
+
+    public void Read(Stream stream)
+    {
+        stream.Seek(0, SeekOrigin.Begin);
+        using var smdImporter = new SmdImporter(stream);
+        smdImporter.Parse(this);
+    }
+
+    public void Read(string filename)
+    {
+        Name = Path.GetFileNameWithoutExtension(filename);
+        using var smdImporter = new SmdImporter(filename);
+        smdImporter.Parse(this);
+    }
+
+    public int AddBone(string parentBoneName, string boneName)
+    {
+        if (!Bones.TryGetValue(boneName, out var bone))
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(parentBoneName) && Bones.TryGetValue(parentBoneName, out var parentBone))
+                {
+                    Bones[boneName] = new Bone(parentBone.Index, CurrentBoneIndex);
+                }
+                else
+                {
+                    Bones[boneName] = new Bone(-1, CurrentBoneIndex);
+                }
+                return CurrentBoneIndex;
+            }
+            finally
+            {
+                CurrentBoneIndex++;
+            }
+        }
+        return bone.Index;
+    }
+
+    public int AddMaterial(string material)
+    {
+        var idx = Materials.IndexOf(material);
+        if (idx == -1)
+        {
+            Materials.Add(material);
+            idx = Materials.Count - 1;
+        }
+        return idx;
+    }
+
+    public Bone GetBoneByIndex(int index)
+    {
+        return Bones.ElementAt(index).Value;
+    }
+
+    public void Write(string fileName)
+    {
+        using var smdExporter = new SmdExporter(fileName);
+        smdExporter.WriteData(this);
+    }
+
+    public byte[] ToBytes()
+    {
+        using var smdExporter = new SmdExporter();
+        smdExporter.WriteData(this);
+        return System.Text.Encoding.UTF8.GetBytes(smdExporter.ToString());
+    }
+
+    public override string ToString()
+    {
+        using var smdExporter = new SmdExporter();
+        smdExporter.WriteData(this);
+        return smdExporter.ToString();
+    }
+
+    public readonly record struct Bone(int ParentIndex, int Index);
+    public readonly record struct KeyFrame(int BoneID, Vector3 Position, Vector3 Rotation);
+    public readonly record struct Weight(int BoneID, float Value);
+    public readonly record struct Vertex(Vector3 Position, Vector3 Normal, Vector2 UV, Weight[] Weights);
+    public readonly record struct Triangle(int MaterialIndex, Vertex A, Vertex B, Vertex C);
+    public readonly record struct FlexVertex(int VertexId, Vector3 Position, Vector3 Normal);
+}

--- a/ValveResourceFormat/IO/Smd/SmdExporter.cs
+++ b/ValveResourceFormat/IO/Smd/SmdExporter.cs
@@ -1,0 +1,122 @@
+#pragma warning disable CS1591
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using ValveResourceFormat.Utils;
+
+namespace ValveResourceFormat.IO.Smd;
+
+public sealed class SmdExporter : IDisposable
+{
+    private readonly string? outputFileName;
+    public IndentedTextWriter TextWriter { get; }
+
+    public SmdExporter()
+    {
+        TextWriter = new IndentedTextWriter();
+    }
+
+    public SmdExporter(string filename)
+    {
+        outputFileName = filename;
+        TextWriter = new IndentedTextWriter();
+    }
+
+    public void WriteData(SmdData data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        TextWriter.WriteLine("version 1");
+        WriteNodes(data.Bones);
+        WriteSkeleton(data.Frames);
+        WriteTriangles(data);
+    }
+
+    private void WriteNodes(Dictionary<string, SmdData.Bone> bones)
+    {
+        TextWriter.WriteLine("nodes");
+        if (bones.Count > 0)
+        {
+            foreach (var (name, bone) in bones)
+            {
+                TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0,3} {1,-24} {2,3}", bone.Index, $"\"{name}\"", bone.ParentIndex));
+            }
+        }
+        else
+        {
+            TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0,3} {1,-24} {2,3}", 0, "\"root\"", -1));
+        }
+        TextWriter.WriteLine("end");
+    }
+
+    private void WriteSkeleton(List<List<SmdData.KeyFrame>> frames)
+    {
+        TextWriter.WriteLine("skeleton");
+        if (frames.Count > 0)
+        {
+            for (var i = 0; i < frames.Count; i++)
+            {
+                TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "time {0}", i));
+                foreach (var keyFrame in frames[i])
+                {
+                    TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0,3} {1,12:F6} {2,12:F6} {3,12:F6} {4,12:F6} {5,12:F6} {6,12:F6}",
+                        keyFrame.BoneID,
+                        keyFrame.Position.X, keyFrame.Position.Y, keyFrame.Position.Z,
+                        keyFrame.Rotation.X, keyFrame.Rotation.Y, keyFrame.Rotation.Z));
+                }
+            }
+        }
+        else
+        {
+            TextWriter.WriteLine("time 0");
+            TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0,3} {1,12:F6} {2,12:F6} {3,12:F6} {4,12:F6} {5,12:F6} {6,12:F6}", 0, 0f, 0f, 0f, 0f, 0f, 0f));
+        }
+        TextWriter.WriteLine("end");
+    }
+
+    private void WriteTriangles(SmdData data)
+    {
+        if (data.Meshes.Count > 0)
+        {
+            TextWriter.WriteLine("triangles");
+            foreach (var triangle in data.Meshes)
+            {
+                TextWriter.WriteLine(data.Materials[triangle.MaterialIndex]);
+                WriteVertex(triangle.A);
+                WriteVertex(triangle.B);
+                WriteVertex(triangle.C);
+            }
+            TextWriter.WriteLine("end");
+        }
+    }
+
+    private void WriteVertex(SmdData.Vertex vertex)
+    {
+        TextWriter.Write(" 0 ");
+        TextWriter.Write(string.Format(CultureInfo.InvariantCulture, "{0,8:F6} {1,8:F6} {2,8:F6} ", vertex.Position.X, vertex.Position.Y, vertex.Position.Z));
+        TextWriter.Write(string.Format(CultureInfo.InvariantCulture, "{0,8:F6} {1,8:F6} ", vertex.Normal.X, vertex.Normal.Y));
+        TextWriter.Write(string.Format(CultureInfo.InvariantCulture, "{0,8:F6} ", vertex.Normal.Z));
+        TextWriter.Write(string.Format(CultureInfo.InvariantCulture, "{0,8:F6} {1,8:F6} ", vertex.UV.X, vertex.UV.Y));
+        TextWriter.Write(vertex.Weights.Length.ToString(CultureInfo.InvariantCulture));
+        foreach (var weight in vertex.Weights)
+        {
+            TextWriter.Write(string.Format(CultureInfo.InvariantCulture, " {0} {1,8:F6}", weight.BoneID, weight.Value));
+        }
+        TextWriter.WriteLine();
+    }
+
+    public override string ToString()
+    {
+        return TextWriter.ToString();
+    }
+
+    public void Dispose()
+    {
+        if (outputFileName != null)
+        {
+            File.WriteAllText(outputFileName, TextWriter.ToString(), System.Text.Encoding.UTF8);
+        }
+        TextWriter.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/ValveResourceFormat/IO/Smd/SmdImporter.cs
+++ b/ValveResourceFormat/IO/Smd/SmdImporter.cs
@@ -1,0 +1,183 @@
+#pragma warning disable CS1591, CA1063, CA1822
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Numerics;
+
+namespace ValveResourceFormat.IO.Smd;
+
+public sealed class SmdImporter : IDisposable
+{
+    private readonly TextReader reader;
+
+    public SmdImporter(string filename)
+    {
+        reader = new StreamReader(filename);
+    }
+
+    public SmdImporter(Stream stream)
+    {
+        reader = new StreamReader(stream);
+    }
+
+    public void Parse(SmdData data)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line.StartsWith("//", StringComparison.Ordinal) || string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.Equals("nodes", StringComparison.OrdinalIgnoreCase))
+            {
+                ReadNodes(data);
+            }
+            else if (line.Equals("skeleton", StringComparison.OrdinalIgnoreCase))
+            {
+                ReadSkeleton(data);
+            }
+            else if (line.Equals("triangles", StringComparison.OrdinalIgnoreCase))
+            {
+                ReadTriangles(data);
+            }
+        }
+    }
+
+    private void ReadNodes(SmdData data)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line.Equals("end", StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+
+            var parts = line.Split('"', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2)
+            {
+                var idx = int.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
+                var name = parts[1].Trim();
+                var parentIdx = int.Parse(parts[2].Trim(), CultureInfo.InvariantCulture);
+                data.Bones[name] = new SmdData.Bone(parentIdx, idx);
+            }
+        }
+    }
+
+    private void ReadSkeleton(SmdData data)
+    {
+        string? line;
+        List<SmdData.KeyFrame>? currentFrame = null;
+
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line.Equals("end", StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+
+            if (line.StartsWith("time", StringComparison.OrdinalIgnoreCase))
+            {
+                currentFrame = new List<SmdData.KeyFrame>();
+                data.Frames.Add(currentFrame);
+                continue;
+            }
+
+            if (currentFrame != null)
+            {
+                var tokens = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (tokens.Length >= 7)
+                {
+                    var boneId = int.Parse(tokens[0], CultureInfo.InvariantCulture);
+                    var pos = new Vector3(
+                        float.Parse(tokens[1], CultureInfo.InvariantCulture),
+                        float.Parse(tokens[2], CultureInfo.InvariantCulture),
+                        float.Parse(tokens[3], CultureInfo.InvariantCulture));
+                    var rot = new Vector3(
+                        float.Parse(tokens[4], CultureInfo.InvariantCulture),
+                        float.Parse(tokens[5], CultureInfo.InvariantCulture),
+                        float.Parse(tokens[6], CultureInfo.InvariantCulture));
+                    currentFrame.Add(new SmdData.KeyFrame(boneId, pos, rot));
+                }
+            }
+        }
+    }
+
+    private void ReadTriangles(SmdData data)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line.Equals("end", StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+
+            var material = line;
+            var matIdx = data.AddMaterial(material);
+
+            var v1 = ReadVertex();
+            var v2 = ReadVertex();
+            var v3 = ReadVertex();
+
+            if (v1.HasValue && v2.HasValue && v3.HasValue)
+            {
+                data.Meshes.Add(new SmdData.Triangle(matIdx, v1.Value, v2.Value, v3.Value));
+            }
+        }
+    }
+
+    private SmdData.Vertex? ReadVertex()
+    {
+        var line = reader.ReadLine()?.Trim();
+        if (string.IsNullOrEmpty(line))
+        {
+            return null;
+        }
+
+        var tokens = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length < 9)
+        {
+            return null;
+        }
+
+        var pos = new Vector3(
+            float.Parse(tokens[1], CultureInfo.InvariantCulture),
+            float.Parse(tokens[2], CultureInfo.InvariantCulture),
+            float.Parse(tokens[3], CultureInfo.InvariantCulture));
+        var norm = new Vector3(
+            float.Parse(tokens[4], CultureInfo.InvariantCulture),
+            float.Parse(tokens[5], CultureInfo.InvariantCulture),
+            float.Parse(tokens[6], CultureInfo.InvariantCulture));
+        var uv = new Vector2(
+            float.Parse(tokens[7], CultureInfo.InvariantCulture),
+            float.Parse(tokens[8], CultureInfo.InvariantCulture));
+
+        var weights = new List<SmdData.Weight>();
+        if (tokens.Length > 9)
+        {
+            var numWeights = int.Parse(tokens[9], CultureInfo.InvariantCulture);
+            for (var i = 0; i < numWeights && 10 + i * 2 + 1 < tokens.Length; i++)
+            {
+                var boneId = int.Parse(tokens[10 + i * 2], CultureInfo.InvariantCulture);
+                var weightVal = float.Parse(tokens[10 + i * 2 + 1], CultureInfo.InvariantCulture);
+                weights.Add(new SmdData.Weight(boneId, weightVal));
+            }
+        }
+
+        return new SmdData.Vertex(pos, norm, uv, weights.ToArray());
+    }
+
+    public void Dispose()
+    {
+        reader.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/ValveResourceFormat/IO/Smd/SmdType.cs
+++ b/ValveResourceFormat/IO/Smd/SmdType.cs
@@ -1,0 +1,11 @@
+#pragma warning disable CS1591, CA1063, CA1822
+namespace ValveResourceFormat.IO.Smd;
+
+public enum SmdType
+{
+    Reference,
+    Animation,
+    Physics,
+    Flex,
+    Skeleton
+}


### PR DESCRIPTION
### Summary of Changes
- Added Blender SMD export support for AnimGraph 2 skeletons (`.vnmskel_c`) and animation clips (`.vnmclip_c`).
- Integrated `ValveResourceFormat.IO.Smd` exporter and importer.
- Added `Source SMD (*.smd)` export filter to the GUI export dialogs.
- Added unit tests in `Tests/SmdExportTest.cs`. All 1042 unit tests pass.
<img width="1560" height="845" alt="node_preview" src="https://github.com/user-attachments/assets/50727838-3288-4da8-967d-8e35c9dfc272" />
<img width="1596" height="869" alt="skeleton_Blender" src="https://github.com/user-attachments/assets/9ddb453d-cb06-4c07-ad80-25a6b4ce9316" />
