### PR TITLE
 Decompile paths back into CMapPath / CMapPathNode hierarchies

### DIFF
--- a/Tests/PathParticleRopeTest.cs
+++ b/Tests/PathParticleRopeTest.cs
@@ -58,6 +58,18 @@ namespace Tests
         }
 
         [Test]
+        public async Task SplitsOnEverySeparator()
+        {
+            var floats = PathParticleRope.ParseFloatBlob("[\"1\",\t2\r\n3\f4\v5 6]");
+            float[] expected = [1f, 2f, 3f, 4f, 5f, 6f];
+            await Assert.That(floats).IsEquivalentTo(expected, CollectionOrdering.Matching);
+
+            var pins = PathParticleRope.ParsePins("[\"true\",\t\"false\"\r\n\"1\"]");
+            bool[] expectedPins = [true, false, true];
+            await Assert.That(pins).IsEquivalentTo(expectedPins, CollectionOrdering.Matching);
+        }
+
+        [Test]
         public async Task ParsesRadiusScalesWithTrailingCommas()
         {
             var scales = PathParticleRope.ParseRadiusScales("[ 1.4, 1.0, 2.0, ]");

--- a/ValveResourceFormat/IO/ContentFormats/ValveMap.cs
+++ b/ValveResourceFormat/IO/ContentFormats/ValveMap.cs
@@ -514,6 +514,64 @@ public class CMapEntity : BaseEntity
 }
 
 /// <summary>
+/// A path: an ordered chain of <see cref="CMapPathNode"/> children that Hammer edits as one spline,
+/// carrying the entity keys of the path class it was placed as. The map compiler flattens the chain
+/// into the entity's own <c>pathNodes</c> key and drops the children.
+/// </summary>
+[CamelCaseProperties]
+public class CMapPath : CMapEntity
+{
+    /// <summary>How the spline runs between its nodes.</summary>
+    public int InterpolationType { get; set; } = 1;
+
+    /// <summary>Whether the last node joins back onto the first.</summary>
+    public bool ClosedLoop { get; set; }
+
+    /// <summary>Distance, in units, between the points of the particle snapshot a path can generate.</summary>
+    public float ParticleSnapshotSpacing { get; set; } = 16f;
+}
+
+/// <summary>
+/// One node of a <see cref="CMapPath"/>: a point on the spline, its two handles, and the entity keys
+/// of the path node class the parent path declares.
+/// </summary>
+[CamelCaseProperties]
+public class CMapPathNode : CMapEntity
+{
+    /// <summary>Name entity IO addresses this node by.</summary>
+    public string PathNodeName { get; set; } = string.Empty;
+
+    /// <summary>Incoming spline handle, relative to <see cref="MapNode.Origin"/>.</summary>
+    public Vector3 InTangent { get; set; }
+
+    /// <summary>Outgoing spline handle, relative to <see cref="MapNode.Origin"/>.</summary>
+    public Vector3 OutTangent { get; set; }
+
+    /// <summary>How Hammer derives the incoming handle.</summary>
+    public int InTangentType { get; set; } = 1;
+
+    /// <summary>How Hammer derives the outgoing handle.</summary>
+    public int OutTangentType { get; set; } = 1;
+
+    /// <summary>Colour this node tints the path with, written to the path's <c>pathNodeColors</c>.</summary>
+    public Datamodel.Color TintColor { get; set; } = new Datamodel.Color(255, 255, 255, 255);
+
+    /// <summary>Whether a simulated path is held in place at this node.</summary>
+    public bool PinEnabled { get; set; } = true;
+
+    /// <summary>Multiplier on the path's radius at this node.</summary>
+    public float RadiusScale { get; set; } = 1f;
+}
+
+/// <summary>
+/// A cable: a path whose mesh and hanging handles the map compiler generates for it.
+/// </summary>
+[CamelCaseProperties]
+public class CMapCable : CMapPath
+{
+}
+
+/// <summary>
 /// Places another map group into the map with its own transform and tint.
 /// </summary>
 [CamelCaseProperties]

--- a/ValveResourceFormat/IO/ContentFormats/ValveMap.cs
+++ b/ValveResourceFormat/IO/ContentFormats/ValveMap.cs
@@ -564,11 +564,56 @@ public class CMapPathNode : CMapEntity
 }
 
 /// <summary>
-/// A cable: a path whose mesh and hanging handles the map compiler generates for it.
+/// A cable: a path the map compiler turns into a tube mesh, with the tube's shape and texturing
+/// carried on the path itself.
 /// </summary>
 [CamelCaseProperties]
 public class CMapCable : CMapPath
 {
+    /// <summary>Material of the tube mesh.</summary>
+    public string MaterialName { get; set; } = string.Empty;
+
+    /// <summary>Colour a cable_dynamic renders with, written to its <c>rendercolor</c> key.</summary>
+    public Datamodel.Color TintColor { get; set; } = new Datamodel.Color(255, 255, 255, 255);
+
+    /// <summary>Name of the entity the cable takes its lighting origin from.</summary>
+    public string LightingOriginName { get; set; } = string.Empty;
+
+    /// <summary>Vertices around the tube.</summary>
+    public int NumSides { get; set; } = 8;
+
+    /// <summary>Distance, in units, between the rings along the tube.</summary>
+    public float TessellationSpacing { get; set; } = 16f;
+
+    /// <summary>Tube radius, in units, before the per-node radius scale.</summary>
+    public float Radius { get; set; } = 16f;
+
+    /// <summary>Whether the tube faces inwards.</summary>
+    public bool FlipFaces { get; set; }
+
+    /// <summary>0 runs U along the path, 1 runs V along the path.</summary>
+    public int TextureOrientation { get; set; }
+
+    /// <summary>Units of path per texture repeat, divided by the texture's size in pixels.</summary>
+    public float TextureScale { get; set; } = 0.25f;
+
+    /// <summary>Texture repeats around the tube.</summary>
+    public float TextureRepeatsCircumference { get; set; } = 1f;
+
+    /// <summary>Texture offset along the path, in repeats.</summary>
+    public float TextureOffsetAlongPath { get; set; }
+
+    /// <summary>Texture offset around the tube, in repeats.</summary>
+    public float TextureOffsetCircumference { get; set; }
+
+    /// <summary>Whether a collision tube is generated.</summary>
+    public bool CollisionEnabled { get; set; } = true;
+
+    /// <summary>Simplification error allowed on the collision tube; 0 keeps every ring.</summary>
+    public float PhysicsSimplificationError { get; set; } = 2f;
+
+    /// <summary>Whether the tube occludes visibility.</summary>
+    public bool VisOccluder { get; set; }
 }
 
 /// <summary>

--- a/ValveResourceFormat/IO/Extract/MapExtract.Paths.cs
+++ b/ValveResourceFormat/IO/Extract/MapExtract.Paths.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Linq;
 using ValveResourceFormat.Blocks;
 using ValveResourceFormat.IO.ContentFormats.ValveMap;
+using ValveResourceFormat.Particles.Utils;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.Serialization.KeyValues;
 using static ValveResourceFormat.ResourceTypes.EntityLump;
@@ -10,31 +11,28 @@ namespace ValveResourceFormat.IO;
 
 public sealed partial class MapExtract
 {
+    private static bool IsCableClass(string className) => className is "cable_static" or "cable_dynamic";
+
     private static CMapEntity CreateMapEntity(string className, int pathNodeCount)
     {
         if (pathNodeCount == 0)
         {
-            return new CMapEntity();
+            return [];
         }
 
-        return className is "cable_static" or "cable_dynamic" ? new CMapCable() : new CMapPath();
+        return IsCableClass(className) ? new CMapCable() : new CMapPath();
     }
 
     /// <summary>
-    /// Consumes the keys the compiler flattens a path and its nodes into, which the recovered path
-    /// objects carry as their own attributes and children instead.
+    /// The keys the compiler flattens a path and its nodes into, which the recovered path objects
+    /// carry as their own attributes and children instead.
     /// </summary>
-    private static bool TryHandlePathProperty(string key, Entity compiledEntity, BaseEntity mapEntity)
+    private static bool IsPathProperty(string key, BaseEntity mapEntity)
     {
-        if (mapEntity is CMapPath path && key is "closed_loop" or "pathnodes" or "pathnodenames" or "pathnodepinsenabled"
-            or "pathnoderadiusscales" or "pathnodecolors" or "pathnodemovespeedtypes")
+        if (mapEntity is CMapPath)
         {
-            if (key == "closed_loop")
-            {
-                path.ClosedLoop = compiledEntity.TryGetValue(key, out var closedLoop) && ToEditString(closedLoop) is "1" or "true";
-            }
-
-            return true;
+            return key is "closed_loop" or "pathnodes" or "pathnodenames" or "pathnodepinsenabled"
+                or "pathnoderadiusscales" or "pathnodecolors" or "pathnodemovespeedtypes";
         }
 
         return mapEntity is CMapPathNode && key is "path_uniqueid" or "path_index" or "in_tangent_local" or "out_tangent_local";
@@ -49,11 +47,10 @@ public sealed partial class MapExtract
     private const int DirectionTangent = 2;
     private const int FreeTangent = 3;
 
-    private static bool SameHandle(Vector3 a, Vector3 b)
-        => Vector3.Distance(a, b) <= 0.001f + 0.0001f * MathF.Max(a.Length(), b.Length());
+    private static float HandleTolerance(float length) => 0.001f + 0.0001f * length;
 
-    private static Vector3 Direction(Vector3 v)
-        => v.Length() > 0f ? Vector3.Normalize(v) : Vector3.Zero;
+    private static bool SameHandle(Vector3 a, Vector3 b)
+        => Vector3.Distance(a, b) <= HandleTolerance(MathF.Max(a.Length(), b.Length()));
 
     /// <summary>
     /// Reads back the interpolation Hammer was set to from the handles the compiler derived with it.
@@ -76,10 +73,10 @@ public sealed partial class MapExtract
             var inThird = Vector3.Distance(node, previous) / 3f;
             var outThird = Vector3.Distance(next, node) / 3f;
 
-            var inLinear = SameHandle(nodes[i].InTangent, Direction(previous - node) * inThird);
-            var inSpline = SameHandle(nodes[i].InTangent, Direction(previous - next) * inThird);
-            var outLinear = SameHandle(nodes[i].OutTangent, Direction(next - node) * outThird);
-            var outSpline = SameHandle(nodes[i].OutTangent, Direction(next - previous) * outThird);
+            var inLinear = SameHandle(nodes[i].InTangent, ParticleMath.Normalize(previous - node) * inThird);
+            var inSpline = SameHandle(nodes[i].InTangent, ParticleMath.Normalize(previous - next) * inThird);
+            var outLinear = SameHandle(nodes[i].OutTangent, ParticleMath.Normalize(next - node) * outThird);
+            var outSpline = SameHandle(nodes[i].OutTangent, ParticleMath.Normalize(next - previous) * outThird);
 
             allLinear &= inLinear && outLinear;
             allSpline &= inSpline && outSpline;
@@ -104,7 +101,7 @@ public sealed partial class MapExtract
             return LinearTangent;
         }
 
-        return MathF.Abs(handle.Length() - third) <= 0.001f + 0.0001f * third ? DirectionTangent : FreeTangent;
+        return MathF.Abs(handle.Length() - third) <= HandleTolerance(third) ? DirectionTangent : FreeTangent;
     }
 
     /// <summary>
@@ -146,36 +143,35 @@ public sealed partial class MapExtract
     /// Groups the node entities the compiler emits for a path whose node class is not editor-only,
     /// keyed by the hammeruniqueid of the path in this lump they belong to, then by node index.
     /// </summary>
-    private static Dictionary<string, Dictionary<int, Entity>> GroupPathNodeEntities(EntityLump entityLump)
+    private static Dictionary<string, Dictionary<int, Entity>> GroupPathNodeEntities(List<Entity> entities)
     {
         var pathIds = new HashSet<string>();
         var nodeEntities = new Dictionary<string, Dictionary<int, Entity>>();
 
-        foreach (var entity in entityLump.GetEntities())
+        foreach (var entity in entities)
         {
             if (entity.GetStringProperty("pathnodes") is not null && entity.GetStringProperty("hammeruniqueid") is { } pathId)
             {
                 pathIds.Add(pathId);
-            }
-        }
-
-        foreach (var entity in entityLump.GetEntities())
-        {
-            var pathId = entity.GetStringProperty("path_uniqueid");
-
-            if (pathId is null || !pathIds.Contains(pathId) || !entity.TryGetValue("path_index", out var indexValue)
-                || !int.TryParse(ToEditString(indexValue), NumberStyles.Integer, CultureInfo.InvariantCulture, out var nodeIndex))
-            {
                 continue;
             }
 
-            if (!nodeEntities.TryGetValue(pathId, out var pathNodes))
+            if (entity.GetStringProperty("path_uniqueid") is { } ownerId && entity.TryGetValue("path_index", out var indexValue)
+                && int.TryParse(ToEditString(indexValue), NumberStyles.Integer, CultureInfo.InvariantCulture, out var nodeIndex))
             {
-                pathNodes = [];
-                nodeEntities[pathId] = pathNodes;
-            }
+                if (!nodeEntities.TryGetValue(ownerId, out var pathNodes))
+                {
+                    pathNodes = [];
+                    nodeEntities[ownerId] = pathNodes;
+                }
 
-            pathNodes[nodeIndex] = entity;
+                pathNodes[nodeIndex] = entity;
+            }
+        }
+
+        foreach (var ownerId in nodeEntities.Keys.Where(ownerId => !pathIds.Contains(ownerId)).ToList())
+        {
+            nodeEntities.Remove(ownerId);
         }
 
         return nodeEntities;
@@ -193,14 +189,9 @@ public sealed partial class MapExtract
         var radiusScales = ReadRadiusScales(compiledEntity);
         var colors = PathParticleRope.ParseColors(compiledEntity.GetStringProperty("pathnodecolors"));
         var moveSpeedTypes = PathParticleRope.ParseFloatBlob(compiledEntity.GetStringProperty("pathnodemovespeedtypes"));
-        var nodeClassName = className switch
-        {
-            "path_particle_rope" or "path_particle_rope_clientside" => "path_node_particle_rope",
-            "cable_static" or "cable_dynamic" => "path_node_cable",
-            "map_preview_camera_path" => "map_preview_camera_path_node",
-            "dota_movespeed_modifier_path" => "dota_movespeed_path_node",
-            _ => "path_node_generic",
-        };
+        var nodeClassName = PathNodeClassName(className);
+
+        path.ClosedLoop = compiledEntity.TryGetValue("closed_loop", out var closedLoop) && ToEditString(closedLoop) is "1" or "true";
 
         if (nodes.Count >= 3 && nodes[^1].Position == nodes[0].Position
             && nodes[^1].InTangent == nodes[0].InTangent && nodes[^1].OutTangent == nodes[0].OutTangent)
@@ -215,20 +206,44 @@ public sealed partial class MapExtract
         for (var i = 0; i < nodes.Count; i++)
         {
             var node = nodes[i];
+            var pathNode = new CMapPathNode();
 
-            var origin = Vector3.Transform(node.Position, worldTransform);
-            var pathNode = new CMapPathNode
+            if (nodeEntities is not null && nodeEntities.TryGetValue(i, out var nodeEntity))
             {
-                Origin = origin,
-                InTangent = Vector3.TransformNormal(node.InTangent, worldTransform),
-                OutTangent = Vector3.TransformNormal(node.OutTangent, worldTransform),
-            };
-
-            if (names.TryGetValue(i, out var name))
-            {
-                pathNode.PathNodeName = name;
-                pathNode.WithProperty("node_name", name);
+                AddProperties(nodeEntity.GetStringProperty("classname") ?? nodeClassName, nodeEntity, pathNode);
             }
+            else
+            {
+                pathNode.WithClassName(nodeClassName);
+
+                if (i < pins.Length)
+                {
+                    pathNode.PinEnabled = pins[i];
+                    pathNode.WithProperty("pin_enabled", StringBool(pins[i]));
+                }
+
+                if (i < radiusScales.Length)
+                {
+                    pathNode.RadiusScale = radiusScales[i];
+                    pathNode.WithProperty("radius_scale", radiusScales[i].ToString(CultureInfo.InvariantCulture));
+                }
+
+                if (i < colors.Length)
+                {
+                    var color = ToColor(colors[i]);
+                    pathNode.TintColor = color;
+                    pathNode.WithProperty("color_tint", string.Create(CultureInfo.InvariantCulture, $"{color.R} {color.G} {color.B}"));
+                }
+
+                if (i < moveSpeedTypes.Length)
+                {
+                    pathNode.WithProperty("MoveSpeedType", ((int)moveSpeedTypes[i]).ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            pathNode.Origin = Vector3.Transform(node.Position, worldTransform);
+            pathNode.InTangent = Vector3.TransformNormal(node.InTangent, worldTransform);
+            pathNode.OutTangent = Vector3.TransformNormal(node.OutTangent, worldTransform);
 
             if (path.InterpolationType == BezierPathInterpolation)
             {
@@ -236,57 +251,46 @@ public sealed partial class MapExtract
                 pathNode.OutTangentType = tangentTypes[i].Out;
             }
 
-            if (nodeEntities is not null && nodeEntities.TryGetValue(i, out var nodeEntity))
+            if (names.TryGetValue(i, out var name))
             {
-                AddProperties(nodeEntity.GetStringProperty("classname") ?? nodeClassName, nodeEntity, pathNode);
-                pathNode.Origin = origin;
-                path.Children.Add(pathNode);
-                continue;
-            }
-
-            pathNode.WithClassName(nodeClassName);
-
-            if (i < pins.Length)
-            {
-                pathNode.PinEnabled = pins[i];
-                pathNode.WithProperty("pin_enabled", pins[i] ? "1" : "0");
-            }
-
-            if (i < radiusScales.Length)
-            {
-                pathNode.RadiusScale = radiusScales[i];
-                pathNode.WithProperty("radius_scale", radiusScales[i].ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (i < colors.Length)
-            {
-                var color = Vector3.Clamp(colors[i], Vector3.Zero, Vector3.One) * 255f;
-                var red = (byte)MathF.Round(color.X);
-                var green = (byte)MathF.Round(color.Y);
-                var blue = (byte)MathF.Round(color.Z);
-
-                pathNode.TintColor = new Datamodel.Color(red, green, blue, 255);
-                pathNode.WithProperty("color_tint", string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", red, green, blue));
-            }
-
-            if (i < moveSpeedTypes.Length)
-            {
-                pathNode.WithProperty("MoveSpeedType", ((int)moveSpeedTypes[i]).ToString(CultureInfo.InvariantCulture));
+                pathNode.PathNodeName = name;
+                pathNode.WithProperty("node_name", name);
             }
 
             path.Children.Add(pathNode);
         }
     }
 
-    private const float DefaultCableTessellationSpacing = 16f;
-
-    private sealed class CableRing
+    private static string PathNodeClassName(string pathClassName)
     {
-        public required float Along { get; init; }
-        public required Vector3 Centre { get; init; }
-        public required float Radius { get; init; }
-        public required int[] Vertices { get; init; }
+        if (IsCableClass(pathClassName))
+        {
+            return "path_node_cable";
+        }
+
+        return pathClassName switch
+        {
+            "path_particle_rope" or "path_particle_rope_clientside" => "path_node_particle_rope",
+            "map_preview_camera_path" => "map_preview_camera_path_node",
+            "dota_movespeed_modifier_path" => "dota_movespeed_path_node",
+            _ => "path_node_generic",
+        };
     }
+
+    private static Datamodel.Color ToColor(Vector3 color)
+    {
+        var color32 = Color32.FromVector4Clamped(new Vector4(color, 1f));
+        return new Datamodel.Color(color32.R, color32.G, color32.B, color32.A);
+    }
+
+    private const float DefaultCableTessellationSpacing = 16f;
+    private const float MaxCableTessellationSpacing = 100000f;
+    private const float SnapTolerance = 2e-3f;
+    private const float HalfPrecisionSnapTolerance = 4e-3f;
+
+    private readonly record struct CableRing(float Along, Vector3 Centre, float Radius, int[] Vertices);
+
+    private readonly record struct RingSeam(float AroundStart, float AroundEnd, bool HasSeam);
 
     /// <summary>
     /// Reads the tube the compiler built for a cable back into the cable's own attributes: the compiled
@@ -298,8 +302,7 @@ public sealed partial class MapExtract
     {
         if (className == "cable_dynamic")
         {
-            var tint = Vector3.Clamp(compiledEntity.GetVector3Property("rendercolor", new Vector3(255f)), Vector3.Zero, new Vector3(255f));
-            cable.TintColor = new Datamodel.Color((byte)MathF.Round(tint.X), (byte)MathF.Round(tint.Y), (byte)MathF.Round(tint.Z), 255);
+            cable.TintColor = ToColor(compiledEntity.GetColor32Property("rendercolor"));
         }
 
         using var modelResource = FileLoader.LoadFileCompiled(modelName);
@@ -378,11 +381,11 @@ public sealed partial class MapExtract
             rings.Reverse();
         }
 
-        FindSeam(rings[0], rings[1].Centre - rings[0].Centre, positions, texCoords, alongIsU, out var aroundStart, out var aroundEnd, out var hasSeam);
-        cable.NumSides = hasSeam ? ringSize - 1 : ringSize;
-        var tolerance = halfPrecision ? 4e-3f : 2e-3f;
-        cable.TextureOffsetCircumference = Snap(aroundStart, tolerance);
-        cable.TextureRepeatsCircumference = Snap(aroundEnd - aroundStart, tolerance);
+        var seam = FindSeam(rings[0], rings[1].Centre - rings[0].Centre, positions, texCoords, alongIsU);
+        cable.NumSides = seam.HasSeam ? ringSize - 1 : ringSize;
+        var tolerance = halfPrecision ? HalfPrecisionSnapTolerance : SnapTolerance;
+        cable.TextureOffsetCircumference = Snap(seam.AroundStart, tolerance);
+        cable.TextureRepeatsCircumference = Snap(seam.AroundEnd - seam.AroundStart, tolerance);
         cable.TextureOffsetAlongPath = Snap(rings[0].Along, tolerance);
         cable.FlipFaces = FacesPointInward(positions, indices, rings);
 
@@ -391,7 +394,7 @@ public sealed partial class MapExtract
         cable.Radius = Snap(rings[0].Radius / firstScale);
 
         var nodeRings = FindNodeRings(rings, nodes, cable.ClosedLoop);
-        cable.TessellationSpacing = RecoverTessellationSpacing(nodes, nodeRings, cable.ClosedLoop);
+        cable.TessellationSpacing = RecoverTessellationSpacing(nodes, nodeRings);
 
         var tubeLength = 0f;
 
@@ -451,9 +454,14 @@ public sealed partial class MapExtract
 
     private static float SpacingScore(List<CableRing>? rings)
     {
-        if (rings is null || rings.Count < 3)
+        if (rings is null)
         {
-            return rings is null ? float.MaxValue : 0f;
+            return float.MaxValue;
+        }
+
+        if (rings.Count < 3)
+        {
+            return 0f;
         }
 
         var ratios = new List<float>(rings.Count - 1);
@@ -528,13 +536,7 @@ public sealed partial class MapExtract
             centre /= distinct.Count;
             var radius = distinct.Average(i => Vector3.Distance(positions[i], centre));
 
-            rings.Add(new CableRing
-            {
-                Along = alongIsU ? texCoords[group[0]].X : texCoords[group[0]].Y,
-                Centre = centre,
-                Radius = radius,
-                Vertices = [.. group],
-            });
+            rings.Add(new CableRing(alongIsU ? texCoords[group[0]].X : texCoords[group[0]].Y, centre, radius, [.. group]));
         }
 
         return rings;
@@ -598,7 +600,7 @@ public sealed partial class MapExtract
     /// the tube at both of them: the tube's vertices run clockwise about its direction, so the seam vertex
     /// that the next vertex clockwise continues from is where the coordinate starts.
     /// </summary>
-    private static void FindSeam(CableRing ring, Vector3 tangent, Vector3[] positions, Vector2[] texCoords, bool alongIsU, out float aroundStart, out float aroundEnd, out bool hasSeam)
+    private static RingSeam FindSeam(CableRing ring, Vector3 tangent, Vector3[] positions, Vector2[] texCoords, bool alongIsU)
     {
         float Around(int i) => alongIsU ? texCoords[i].Y : texCoords[i].X;
 
@@ -620,13 +622,10 @@ public sealed partial class MapExtract
 
         if (seamA < 0)
         {
-            hasSeam = false;
-            aroundStart = Around(ring.Vertices[0]);
-            aroundEnd = aroundStart;
-            return;
+            var around = Around(ring.Vertices[0]);
+            return new RingSeam(around, around, HasSeam: false);
         }
 
-        hasSeam = true;
         var sides = ring.Vertices.Length - 1;
         var axisA = Vector3.Normalize(positions[seamA] - ring.Centre);
         var axisB = Vector3.Cross(Vector3.Normalize(tangent), axisA);
@@ -666,12 +665,21 @@ public sealed partial class MapExtract
             }
         }
 
-        aroundStart = valueA;
-        aroundEnd = valueB;
+        return new RingSeam(valueA, valueB, HasSeam: true);
     }
 
     private static bool FacesPointInward(Vector3[] positions, int[] indices, List<CableRing> rings)
     {
+        var ringOfVertex = new int[positions.Length];
+
+        for (var r = 0; r < rings.Count; r++)
+        {
+            foreach (var vertex in rings[r].Vertices)
+            {
+                ringOfVertex[vertex] = r;
+            }
+        }
+
         var inward = 0;
         var outward = 0;
 
@@ -682,21 +690,7 @@ public sealed partial class MapExtract
             var c = positions[indices[t + 2]];
             var faceNormal = Vector3.Cross(b - a, c - a);
             var centroid = (a + b + c) / 3f;
-            var nearest = rings[0].Centre;
-            var nearestDistance = float.MaxValue;
-
-            foreach (var ring in rings)
-            {
-                var distance = Vector3.DistanceSquared(ring.Centre, centroid);
-
-                if (distance < nearestDistance)
-                {
-                    nearestDistance = distance;
-                    nearest = ring.Centre;
-                }
-            }
-
-            var dot = Vector3.Dot(faceNormal, centroid - nearest);
+            var dot = Vector3.Dot(faceNormal, centroid - rings[ringOfVertex[indices[t]]].Centre);
 
             if (dot < 0f)
             {
@@ -749,7 +743,7 @@ public sealed partial class MapExtract
     /// Every path segment is sampled max(4, ceil(length / spacing)) times, so the sample counts the tube
     /// shows bound the spacing from both sides; the default is kept whenever it reproduces them.
     /// </summary>
-    private static float RecoverTessellationSpacing(List<PathParticleRopeNode> nodes, int[] nodeRings, bool closedLoop)
+    private static float RecoverTessellationSpacing(List<PathParticleRopeNode> nodes, int[] nodeRings)
     {
         var segments = new List<(float Length, int Samples)>();
 
@@ -789,7 +783,7 @@ public sealed partial class MapExtract
 
         if (high == float.MaxValue)
         {
-            for (var candidate = DefaultCableTessellationSpacing; candidate <= 100000f; candidate *= 2f)
+            for (var candidate = DefaultCableTessellationSpacing; candidate <= MaxCableTessellationSpacing; candidate *= 2f)
             {
                 if (candidate >= low && Reproduces(candidate, segments))
                 {
@@ -901,7 +895,7 @@ public sealed partial class MapExtract
         return alongIsU ? texture.Width : texture.Height;
     }
 
-    private static float Snap(float value, float tolerance = 2e-3f)
+    private static float Snap(float value, float tolerance = SnapTolerance)
     {
         for (var decimals = 2; decimals <= 4; decimals++)
         {

--- a/ValveResourceFormat/IO/Extract/MapExtract.Paths.cs
+++ b/ValveResourceFormat/IO/Extract/MapExtract.Paths.cs
@@ -1,0 +1,918 @@
+using System.Globalization;
+using System.Linq;
+using ValveResourceFormat.Blocks;
+using ValveResourceFormat.IO.ContentFormats.ValveMap;
+using ValveResourceFormat.ResourceTypes;
+using ValveResourceFormat.Serialization.KeyValues;
+using static ValveResourceFormat.ResourceTypes.EntityLump;
+
+namespace ValveResourceFormat.IO;
+
+public sealed partial class MapExtract
+{
+    private static CMapEntity CreateMapEntity(string className, int pathNodeCount)
+    {
+        if (pathNodeCount == 0)
+        {
+            return new CMapEntity();
+        }
+
+        return className is "cable_static" or "cable_dynamic" ? new CMapCable() : new CMapPath();
+    }
+
+    /// <summary>
+    /// Consumes the keys the compiler flattens a path and its nodes into, which the recovered path
+    /// objects carry as their own attributes and children instead.
+    /// </summary>
+    private static bool TryHandlePathProperty(string key, Entity compiledEntity, BaseEntity mapEntity)
+    {
+        if (mapEntity is CMapPath path && key is "closed_loop" or "pathnodes" or "pathnodenames" or "pathnodepinsenabled"
+            or "pathnoderadiusscales" or "pathnodecolors" or "pathnodemovespeedtypes")
+        {
+            if (key == "closed_loop")
+            {
+                path.ClosedLoop = compiledEntity.TryGetValue(key, out var closedLoop) && ToEditString(closedLoop) is "1" or "true";
+            }
+
+            return true;
+        }
+
+        return mapEntity is CMapPathNode && key is "path_uniqueid" or "path_index" or "in_tangent_local" or "out_tangent_local";
+    }
+
+    private const int LinearPathInterpolation = 0;
+    private const int SplinePathInterpolation = 1;
+    private const int BezierPathInterpolation = 2;
+
+    private const int LinearTangent = 0;
+    private const int SplineTangent = 1;
+    private const int DirectionTangent = 2;
+    private const int FreeTangent = 3;
+
+    private static bool SameHandle(Vector3 a, Vector3 b)
+        => Vector3.Distance(a, b) <= 0.001f + 0.0001f * MathF.Max(a.Length(), b.Length());
+
+    private static Vector3 Direction(Vector3 v)
+        => v.Length() > 0f ? Vector3.Normalize(v) : Vector3.Zero;
+
+    /// <summary>
+    /// Reads back the interpolation Hammer was set to from the handles the compiler derived with it.
+    /// Linear and spline handles follow the node positions at a third of their own segment; under
+    /// piecewise bezier each node picks its own rule, a direction handle keeps the authored direction
+    /// at that length and a free handle is kept as authored, so those come back as per-node tangent types.
+    /// </summary>
+    private static int DetectPathInterpolation(List<PathParticleRopeNode> nodes, bool closedLoop, out (int In, int Out)[] tangentTypes)
+    {
+        tangentTypes = new (int, int)[nodes.Count];
+        var allLinear = true;
+        var allSpline = true;
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i].Position;
+            var previous = i > 0 ? nodes[i - 1].Position : closedLoop ? nodes[^1].Position : node;
+            var next = i < nodes.Count - 1 ? nodes[i + 1].Position : closedLoop ? nodes[0].Position : node;
+
+            var inThird = Vector3.Distance(node, previous) / 3f;
+            var outThird = Vector3.Distance(next, node) / 3f;
+
+            var inLinear = SameHandle(nodes[i].InTangent, Direction(previous - node) * inThird);
+            var inSpline = SameHandle(nodes[i].InTangent, Direction(previous - next) * inThird);
+            var outLinear = SameHandle(nodes[i].OutTangent, Direction(next - node) * outThird);
+            var outSpline = SameHandle(nodes[i].OutTangent, Direction(next - previous) * outThird);
+
+            allLinear &= inLinear && outLinear;
+            allSpline &= inSpline && outSpline;
+
+            tangentTypes[i] = (
+                TangentType(nodes[i].InTangent, inLinear, inSpline, inThird),
+                TangentType(nodes[i].OutTangent, outLinear, outSpline, outThird));
+        }
+
+        return allLinear ? LinearPathInterpolation : allSpline ? SplinePathInterpolation : BezierPathInterpolation;
+    }
+
+    private static int TangentType(Vector3 handle, bool linear, bool spline, float third)
+    {
+        if (spline)
+        {
+            return SplineTangent;
+        }
+
+        if (linear)
+        {
+            return LinearTangent;
+        }
+
+        return MathF.Abs(handle.Length() - third) <= 0.001f + 0.0001f * third ? DirectionTangent : FreeTangent;
+    }
+
+    /// <summary>
+    /// The per-node radius scales, or none when the compiler wrote its 0 default for a node class
+    /// that declares no radius key.
+    /// </summary>
+    private static float[] ReadRadiusScales(Entity compiledEntity)
+    {
+        var radiusScales = PathParticleRope.ParseRadiusScales(compiledEntity.GetStringProperty("pathnoderadiusscales"));
+        return radiusScales.All(scale => scale == 0f) ? [] : radiusScales;
+    }
+
+    /// <summary>
+    /// Parses the <c>pathNodeNames</c> key, one <c>index: name;</c> entry per named node.
+    /// </summary>
+    private static Dictionary<int, string> ParsePathNodeNames(string? pathNodeNames)
+    {
+        var names = new Dictionary<int, string>();
+
+        if (string.IsNullOrEmpty(pathNodeNames))
+        {
+            return names;
+        }
+
+        foreach (var entry in pathNodeNames.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separator = entry.IndexOf(':', StringComparison.Ordinal);
+
+            if (separator > 0 && int.TryParse(entry.AsSpan(0, separator), NumberStyles.Integer, CultureInfo.InvariantCulture, out var index))
+            {
+                names[index] = entry[(separator + 1)..].Trim();
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Groups the node entities the compiler emits for a path whose node class is not editor-only,
+    /// keyed by the hammeruniqueid of the path in this lump they belong to, then by node index.
+    /// </summary>
+    private static Dictionary<string, Dictionary<int, Entity>> GroupPathNodeEntities(EntityLump entityLump)
+    {
+        var pathIds = new HashSet<string>();
+        var nodeEntities = new Dictionary<string, Dictionary<int, Entity>>();
+
+        foreach (var entity in entityLump.GetEntities())
+        {
+            if (entity.GetStringProperty("pathnodes") is not null && entity.GetStringProperty("hammeruniqueid") is { } pathId)
+            {
+                pathIds.Add(pathId);
+            }
+        }
+
+        foreach (var entity in entityLump.GetEntities())
+        {
+            var pathId = entity.GetStringProperty("path_uniqueid");
+
+            if (pathId is null || !pathIds.Contains(pathId) || !entity.TryGetValue("path_index", out var indexValue)
+                || !int.TryParse(ToEditString(indexValue), NumberStyles.Integer, CultureInfo.InvariantCulture, out var nodeIndex))
+            {
+                continue;
+            }
+
+            if (!nodeEntities.TryGetValue(pathId, out var pathNodes))
+            {
+                pathNodes = [];
+                nodeEntities[pathId] = pathNodes;
+            }
+
+            pathNodes[nodeIndex] = entity;
+        }
+
+        return nodeEntities;
+    }
+
+    /// <summary>
+    /// Rebuilds the nodes a path was authored with from the blobs the compiler flattened them into,
+    /// placing each one by the path's own world transform, which the blob positions are relative to.
+    /// A node the compiler also emitted as its own entity keeps that entity's class, keys and id.
+    /// </summary>
+    private static void AddPathNodes(CMapPath path, string className, Entity compiledEntity,
+        List<PathParticleRopeNode> nodes, Dictionary<int, Entity>? nodeEntities, Matrix4x4 worldTransform)
+    {
+        var pins = PathParticleRope.ParsePins(compiledEntity.GetStringProperty("pathnodepinsenabled"));
+        var radiusScales = ReadRadiusScales(compiledEntity);
+        var colors = PathParticleRope.ParseColors(compiledEntity.GetStringProperty("pathnodecolors"));
+        var moveSpeedTypes = PathParticleRope.ParseFloatBlob(compiledEntity.GetStringProperty("pathnodemovespeedtypes"));
+        var nodeClassName = className switch
+        {
+            "path_particle_rope" or "path_particle_rope_clientside" => "path_node_particle_rope",
+            "cable_static" or "cable_dynamic" => "path_node_cable",
+            "map_preview_camera_path" => "map_preview_camera_path_node",
+            "dota_movespeed_modifier_path" => "dota_movespeed_path_node",
+            _ => "path_node_generic",
+        };
+
+        if (nodes.Count >= 3 && nodes[^1].Position == nodes[0].Position
+            && nodes[^1].InTangent == nodes[0].InTangent && nodes[^1].OutTangent == nodes[0].OutTangent)
+        {
+            path.ClosedLoop = true;
+            nodes.RemoveAt(nodes.Count - 1);
+        }
+
+        var names = ParsePathNodeNames(compiledEntity.GetStringProperty("pathnodenames"));
+        path.InterpolationType = DetectPathInterpolation(nodes, path.ClosedLoop, out var tangentTypes);
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+
+            var origin = Vector3.Transform(node.Position, worldTransform);
+            var pathNode = new CMapPathNode
+            {
+                Origin = origin,
+                InTangent = Vector3.TransformNormal(node.InTangent, worldTransform),
+                OutTangent = Vector3.TransformNormal(node.OutTangent, worldTransform),
+            };
+
+            if (names.TryGetValue(i, out var name))
+            {
+                pathNode.PathNodeName = name;
+                pathNode.WithProperty("node_name", name);
+            }
+
+            if (path.InterpolationType == BezierPathInterpolation)
+            {
+                pathNode.InTangentType = tangentTypes[i].In;
+                pathNode.OutTangentType = tangentTypes[i].Out;
+            }
+
+            if (nodeEntities is not null && nodeEntities.TryGetValue(i, out var nodeEntity))
+            {
+                AddProperties(nodeEntity.GetStringProperty("classname") ?? nodeClassName, nodeEntity, pathNode);
+                pathNode.Origin = origin;
+                path.Children.Add(pathNode);
+                continue;
+            }
+
+            pathNode.WithClassName(nodeClassName);
+
+            if (i < pins.Length)
+            {
+                pathNode.PinEnabled = pins[i];
+                pathNode.WithProperty("pin_enabled", pins[i] ? "1" : "0");
+            }
+
+            if (i < radiusScales.Length)
+            {
+                pathNode.RadiusScale = radiusScales[i];
+                pathNode.WithProperty("radius_scale", radiusScales[i].ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (i < colors.Length)
+            {
+                var color = Vector3.Clamp(colors[i], Vector3.Zero, Vector3.One) * 255f;
+                var red = (byte)MathF.Round(color.X);
+                var green = (byte)MathF.Round(color.Y);
+                var blue = (byte)MathF.Round(color.Z);
+
+                pathNode.TintColor = new Datamodel.Color(red, green, blue, 255);
+                pathNode.WithProperty("color_tint", string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", red, green, blue));
+            }
+
+            if (i < moveSpeedTypes.Length)
+            {
+                pathNode.WithProperty("MoveSpeedType", ((int)moveSpeedTypes[i]).ToString(CultureInfo.InvariantCulture));
+            }
+
+            path.Children.Add(pathNode);
+        }
+    }
+
+    private const float DefaultCableTessellationSpacing = 16f;
+
+    private sealed class CableRing
+    {
+        public required float Along { get; init; }
+        public required Vector3 Centre { get; init; }
+        public required float Radius { get; init; }
+        public required int[] Vertices { get; init; }
+    }
+
+    /// <summary>
+    /// Reads the tube the compiler built for a cable back into the cable's own attributes: the compiled
+    /// map holds them nowhere but in that mesh. Every ring of the tube is one path sample, its vertices run
+    /// around the tube once with a seam vertex repeated for the texture, and the texture coordinates carry
+    /// the scale, repeats, offsets and orientation the tube was textured with.
+    /// </summary>
+    private void RecoverCableAttributes(CMapCable cable, string className, Entity compiledEntity, string modelName, List<PathParticleRopeNode> nodes)
+    {
+        if (className == "cable_dynamic")
+        {
+            var tint = Vector3.Clamp(compiledEntity.GetVector3Property("rendercolor", new Vector3(255f)), Vector3.Zero, new Vector3(255f));
+            cable.TintColor = new Datamodel.Color((byte)MathF.Round(tint.X), (byte)MathF.Round(tint.Y), (byte)MathF.Round(tint.Z), 255);
+        }
+
+        using var modelResource = FileLoader.LoadFileCompiled(modelName);
+
+        if (modelResource?.DataBlock is not Model model)
+        {
+            return;
+        }
+
+        var physics = model.GetEmbeddedPhys();
+        cable.CollisionEnabled = physics is not null || model.GetReferencedPhysNames().Any();
+
+        var embedded = model.GetEmbeddedMeshesAndLoD().FirstOrDefault();
+
+        if (embedded.Mesh is null || nodes.Count < 2)
+        {
+            return;
+        }
+
+        var vbib = embedded.Mesh.VBIB;
+
+        if (vbib.VertexBuffers.Count == 0 || vbib.IndexBuffers.Count == 0)
+        {
+            return;
+        }
+
+        var vertexBuffer = vbib.VertexBuffers[0];
+        var indexBuffer = vbib.IndexBuffers[0];
+        var positionField = vertexBuffer.InputLayoutFields.FirstOrDefault(field => field.SemanticName == "POSITION" && field.SemanticIndex == 0);
+        var texCoordField = vertexBuffer.InputLayoutFields.FirstOrDefault(field => field.SemanticName == "TEXCOORD" && field.SemanticIndex == 0);
+
+        if (positionField.SemanticName != "POSITION" || texCoordField.SemanticName != "TEXCOORD")
+        {
+            return;
+        }
+
+        var positions = VBIB.GetVector3AttributeArray(vertexBuffer, positionField);
+        var texCoords = VBIB.GetVector2AttributeArray(vertexBuffer, texCoordField);
+        var halfPrecision = texCoordField.Format == DXGI_FORMAT.R16G16_FLOAT;
+
+        if (positions.Length != texCoords.Length || positions.Length < 8)
+        {
+            return;
+        }
+
+        var indices = GltfModelExporter.ReadIndices(indexBuffer, 0, (int)indexBuffer.ElementCount, 0);
+
+        foreach (var sceneObject in embedded.Mesh.Data.GetArray("m_sceneObjects"))
+        {
+            foreach (var drawCall in sceneObject.GetArray("m_drawCalls"))
+            {
+                var material = drawCall.GetStringProperty("m_material") ?? drawCall.GetStringProperty("m_pMaterial");
+
+                if (!string.IsNullOrEmpty(material))
+                {
+                    cable.MaterialName = material;
+                    break;
+                }
+            }
+        }
+
+        var alongIsU = ChooseAlongAxis(positions, texCoords, out var rings);
+
+        if (rings is null || rings.Count < 2)
+        {
+            return;
+        }
+
+        cable.TextureOrientation = alongIsU ? 0 : 1;
+        var ringSize = rings[0].Vertices.Length;
+
+        var reversed = IsRingOrderReversed(rings, nodes, cable.ClosedLoop);
+
+        if (reversed)
+        {
+            rings.Reverse();
+        }
+
+        FindSeam(rings[0], rings[1].Centre - rings[0].Centre, positions, texCoords, alongIsU, out var aroundStart, out var aroundEnd, out var hasSeam);
+        cable.NumSides = hasSeam ? ringSize - 1 : ringSize;
+        var tolerance = halfPrecision ? 4e-3f : 2e-3f;
+        cable.TextureOffsetCircumference = Snap(aroundStart, tolerance);
+        cable.TextureRepeatsCircumference = Snap(aroundEnd - aroundStart, tolerance);
+        cable.TextureOffsetAlongPath = Snap(rings[0].Along, tolerance);
+        cable.FlipFaces = FacesPointInward(positions, indices, rings);
+
+        var radiusScales = ReadRadiusScales(compiledEntity);
+        var firstScale = radiusScales.Length > 0 && radiusScales[0] != 0f ? radiusScales[0] : 1f;
+        cable.Radius = Snap(rings[0].Radius / firstScale);
+
+        var nodeRings = FindNodeRings(rings, nodes, cable.ClosedLoop);
+        cable.TessellationSpacing = RecoverTessellationSpacing(nodes, nodeRings, cable.ClosedLoop);
+
+        var tubeLength = 0f;
+
+        for (var i = 1; i < rings.Count; i++)
+        {
+            tubeLength += Vector3.Distance(rings[i].Centre, rings[i - 1].Centre);
+        }
+
+        var alongSpan = rings[^1].Along - rings[0].Along;
+        var textureSize = LoadCableTextureSize(cable.MaterialName, alongIsU);
+
+        if (tubeLength > 0f && MathF.Abs(alongSpan) > 1e-6f && textureSize > 0)
+        {
+            cable.TextureScale = Snap(tubeLength / alongSpan / textureSize, tolerance);
+        }
+        else if (textureSize <= 0)
+        {
+            ProgressReporter?.Report($"Cable {modelName}: texture size of {cable.MaterialName} is unknown, keeping the default texture scale.");
+        }
+
+        if (physics is not null)
+        {
+            var collisionSides = cable.NumSides;
+            var physicsVertices = physics.Parts.Sum(part => part.Shape.Meshes.Sum(mesh => mesh.Shape.GetVertices().Length));
+
+            var collisionRings = cable.ClosedLoop ? rings.Count - 1 : rings.Count;
+
+            if (physicsVertices == collisionRings * collisionSides)
+            {
+                cable.PhysicsSimplificationError = 0f;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Groups the tube's vertices into rings by whichever texture axis runs along the path: on that axis
+    /// the coordinate grows by a fixed amount per unit of distance between the rings, on the other axis the
+    /// groups are lines down the tube whose spacing has nothing to do with their coordinate.
+    /// </summary>
+    private static bool ChooseAlongAxis(Vector3[] positions, Vector2[] texCoords, out List<CableRing>? rings)
+    {
+        var ringsByU = GroupRings(positions, texCoords, alongIsU: true);
+        var ringsByV = GroupRings(positions, texCoords, alongIsU: false);
+
+        var scoreU = SpacingScore(ringsByU) + CircleScore(ringsByU, positions);
+        var scoreV = SpacingScore(ringsByV) + CircleScore(ringsByV, positions);
+
+        if (scoreU <= scoreV)
+        {
+            rings = ringsByU;
+            return true;
+        }
+
+        rings = ringsByV;
+        return false;
+    }
+
+    private static float SpacingScore(List<CableRing>? rings)
+    {
+        if (rings is null || rings.Count < 3)
+        {
+            return rings is null ? float.MaxValue : 0f;
+        }
+
+        var ratios = new List<float>(rings.Count - 1);
+
+        for (var i = 1; i < rings.Count; i++)
+        {
+            var chord = Vector3.Distance(rings[i].Centre, rings[i - 1].Centre);
+            var step = MathF.Abs(rings[i].Along - rings[i - 1].Along);
+
+            if (step > 1e-6f)
+            {
+                ratios.Add(chord / step);
+            }
+        }
+
+        if (ratios.Count < 2)
+        {
+            return float.MaxValue;
+        }
+
+        var mean = ratios.Average();
+        return mean > 0f ? ratios.Average(ratio => MathF.Abs(ratio - mean)) / mean : float.MaxValue;
+    }
+
+    private static List<CableRing>? GroupRings(Vector3[] positions, Vector2[] texCoords, bool alongIsU)
+    {
+        var order = Enumerable.Range(0, positions.Length).OrderBy(i => alongIsU ? texCoords[i].X : texCoords[i].Y).ToArray();
+        var groups = new List<List<int>>();
+        var current = new List<int>();
+        var currentValue = float.NaN;
+
+        foreach (var i in order)
+        {
+            var value = alongIsU ? texCoords[i].X : texCoords[i].Y;
+
+            if (current.Count > 0 && MathF.Abs(value - currentValue) > 1e-4f * MathF.Max(1f, MathF.Abs(currentValue)))
+            {
+                groups.Add(current);
+                current = [];
+            }
+
+            if (current.Count == 0)
+            {
+                currentValue = value;
+            }
+
+            current.Add(i);
+        }
+
+        if (current.Count > 0)
+        {
+            groups.Add(current);
+        }
+
+        if (groups.Count < 2 || groups.Any(group => group.Count != groups[0].Count) || groups[0].Count < 3)
+        {
+            return null;
+        }
+
+        var rings = new List<CableRing>(groups.Count);
+
+        foreach (var group in groups)
+        {
+            var distinct = DistinctPositions(group, positions);
+            var centre = Vector3.Zero;
+
+            foreach (var i in distinct)
+            {
+                centre += positions[i];
+            }
+
+            centre /= distinct.Count;
+            var radius = distinct.Average(i => Vector3.Distance(positions[i], centre));
+
+            rings.Add(new CableRing
+            {
+                Along = alongIsU ? texCoords[group[0]].X : texCoords[group[0]].Y,
+                Centre = centre,
+                Radius = radius,
+                Vertices = [.. group],
+            });
+        }
+
+        return rings;
+    }
+
+    private static List<int> DistinctPositions(List<int> vertices, Vector3[] positions)
+    {
+        var distinct = new List<int>(vertices.Count);
+
+        foreach (var i in vertices)
+        {
+            if (!distinct.Any(j => Vector3.DistanceSquared(positions[i], positions[j]) < 1e-6f))
+            {
+                distinct.Add(i);
+            }
+        }
+
+        return distinct;
+    }
+
+    private static float CircleScore(List<CableRing>? rings, Vector3[] positions)
+    {
+        if (rings is null)
+        {
+            return float.MaxValue;
+        }
+
+        var score = 0f;
+
+        foreach (var ring in rings)
+        {
+            if (ring.Radius <= 1e-6f)
+            {
+                continue;
+            }
+
+            var deviation = ring.Vertices.Average(i => MathF.Abs(Vector3.Distance(positions[i], ring.Centre) - ring.Radius));
+            score += deviation / ring.Radius;
+        }
+
+        return score / rings.Count;
+    }
+
+    /// <summary>
+    /// A negative texture scale makes the coordinate fall along the path, which puts the rings in the
+    /// wrong order when sorted by it: the first ring must sit on node 0 and, on a closed loop where both
+    /// ends do, leave it along node 0's outgoing handle.
+    /// </summary>
+    private static bool IsRingOrderReversed(List<CableRing> rings, List<PathParticleRopeNode> nodes, bool closedLoop)
+    {
+        if (closedLoop && rings.Count > 2 && nodes[0].OutTangent.LengthSquared() > 0f)
+        {
+            return Vector3.Dot(rings[1].Centre - rings[0].Centre, nodes[0].OutTangent) < 0f;
+        }
+
+        return Vector3.Distance(rings[0].Centre, nodes[0].Position) > Vector3.Distance(rings[^1].Centre, nodes[0].Position);
+    }
+
+    /// <summary>
+    /// Finds the ring's seam, the position two vertices share, and reads the texture coordinate around
+    /// the tube at both of them: the tube's vertices run clockwise about its direction, so the seam vertex
+    /// that the next vertex clockwise continues from is where the coordinate starts.
+    /// </summary>
+    private static void FindSeam(CableRing ring, Vector3 tangent, Vector3[] positions, Vector2[] texCoords, bool alongIsU, out float aroundStart, out float aroundEnd, out bool hasSeam)
+    {
+        float Around(int i) => alongIsU ? texCoords[i].Y : texCoords[i].X;
+
+        var seamA = -1;
+        var seamB = -1;
+
+        for (var a = 0; a < ring.Vertices.Length && seamA < 0; a++)
+        {
+            for (var b = a + 1; b < ring.Vertices.Length; b++)
+            {
+                if (Vector3.DistanceSquared(positions[ring.Vertices[a]], positions[ring.Vertices[b]]) < 1e-6f)
+                {
+                    seamA = ring.Vertices[a];
+                    seamB = ring.Vertices[b];
+                    break;
+                }
+            }
+        }
+
+        if (seamA < 0)
+        {
+            hasSeam = false;
+            aroundStart = Around(ring.Vertices[0]);
+            aroundEnd = aroundStart;
+            return;
+        }
+
+        hasSeam = true;
+        var sides = ring.Vertices.Length - 1;
+        var axisA = Vector3.Normalize(positions[seamA] - ring.Centre);
+        var axisB = Vector3.Cross(Vector3.Normalize(tangent), axisA);
+        var nextClockwise = -1;
+        var nextAngle = float.MinValue;
+
+        foreach (var i in ring.Vertices)
+        {
+            if (i == seamA || i == seamB)
+            {
+                continue;
+            }
+
+            var radial = Vector3.Normalize(positions[i] - ring.Centre);
+            var angle = MathF.Atan2(Vector3.Dot(radial, axisB), Vector3.Dot(radial, axisA));
+
+            if (angle < 0f && angle > nextAngle)
+            {
+                nextAngle = angle;
+                nextClockwise = i;
+            }
+        }
+
+        var valueA = Around(seamA);
+        var valueB = Around(seamB);
+
+        if (nextClockwise >= 0)
+        {
+            var step = Around(nextClockwise);
+            var fromA = MathF.Abs(valueA + (step - valueA) * sides - valueB);
+            var fromB = MathF.Abs(valueB + (step - valueB) * sides - valueA);
+
+            if (fromB < fromA)
+            {
+                (seamA, seamB) = (seamB, seamA);
+                (valueA, valueB) = (valueB, valueA);
+            }
+        }
+
+        aroundStart = valueA;
+        aroundEnd = valueB;
+    }
+
+    private static bool FacesPointInward(Vector3[] positions, int[] indices, List<CableRing> rings)
+    {
+        var inward = 0;
+        var outward = 0;
+
+        for (var t = 0; t + 2 < indices.Length; t += 3)
+        {
+            var a = positions[indices[t]];
+            var b = positions[indices[t + 1]];
+            var c = positions[indices[t + 2]];
+            var faceNormal = Vector3.Cross(b - a, c - a);
+            var centroid = (a + b + c) / 3f;
+            var nearest = rings[0].Centre;
+            var nearestDistance = float.MaxValue;
+
+            foreach (var ring in rings)
+            {
+                var distance = Vector3.DistanceSquared(ring.Centre, centroid);
+
+                if (distance < nearestDistance)
+                {
+                    nearestDistance = distance;
+                    nearest = ring.Centre;
+                }
+            }
+
+            var dot = Vector3.Dot(faceNormal, centroid - nearest);
+
+            if (dot < 0f)
+            {
+                inward++;
+            }
+            else if (dot > 0f)
+            {
+                outward++;
+            }
+        }
+
+        return inward > outward;
+    }
+
+    /// <summary>
+    /// Ring index of every node: the tube starts on node 0 and, on a closed loop, ends on it again, and
+    /// the nodes in between sit on the rings nearest to them, in order.
+    /// </summary>
+    private static int[] FindNodeRings(List<CableRing> rings, List<PathParticleRopeNode> nodes, bool closedLoop)
+    {
+        var count = closedLoop ? nodes.Count + 1 : nodes.Count;
+        var nodeRings = new int[count];
+        nodeRings[0] = 0;
+        nodeRings[count - 1] = rings.Count - 1;
+
+        for (var k = 1; k < count - 1; k++)
+        {
+            var target = nodes[k].Position;
+            var best = nodeRings[k - 1] + 1;
+            var bestDistance = float.MaxValue;
+
+            for (var r = nodeRings[k - 1] + 1; r < rings.Count - (count - 1 - k); r++)
+            {
+                var distance = Vector3.DistanceSquared(rings[r].Centre, target);
+
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    best = r;
+                }
+            }
+
+            nodeRings[k] = best;
+        }
+
+        return nodeRings;
+    }
+
+    /// <summary>
+    /// Every path segment is sampled max(4, ceil(length / spacing)) times, so the sample counts the tube
+    /// shows bound the spacing from both sides; the default is kept whenever it reproduces them.
+    /// </summary>
+    private static float RecoverTessellationSpacing(List<PathParticleRopeNode> nodes, int[] nodeRings, bool closedLoop)
+    {
+        var segments = new List<(float Length, int Samples)>();
+
+        for (var k = 0; k + 1 < nodeRings.Length; k++)
+        {
+            var from = nodes[k % nodes.Count];
+            var to = nodes[(k + 1) % nodes.Count];
+            var samples = nodeRings[k + 1] - nodeRings[k] + 1;
+            var length = CompilerSegmentLength(from.Position, from.OutTangent, to.Position, to.InTangent);
+
+            if (samples >= 2 && length > 0f)
+            {
+                segments.Add((length, samples));
+            }
+        }
+
+        if (segments.Count == 0 || Reproduces(DefaultCableTessellationSpacing, segments))
+        {
+            return DefaultCableTessellationSpacing;
+        }
+
+        var low = 0f;
+        var high = float.MaxValue;
+
+        foreach (var (length, samples) in segments)
+        {
+            if (samples > 4)
+            {
+                low = MathF.Max(low, length / samples);
+                high = MathF.Min(high, length / (samples - 1));
+            }
+            else
+            {
+                low = MathF.Max(low, length / 4f);
+            }
+        }
+
+        if (high == float.MaxValue)
+        {
+            for (var candidate = DefaultCableTessellationSpacing; candidate <= 100000f; candidate *= 2f)
+            {
+                if (candidate >= low && Reproduces(candidate, segments))
+                {
+                    return candidate;
+                }
+            }
+
+            high = low * 1.5f;
+        }
+
+        foreach (var unit in new[] { 10f, 5f, 2f, 1f, 0.5f, 0.25f, 0.1f, 0.05f, 0.01f })
+        {
+            for (var candidate = MathF.Ceiling(low / unit) * unit; candidate < high; candidate += unit)
+            {
+                if (Reproduces(candidate, segments))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        foreach (var fraction in new[] { 0.5f, 0.25f, 0.75f })
+        {
+            var candidate = low + (high - low) * fraction;
+
+            if (Reproduces(candidate, segments))
+            {
+                return candidate;
+            }
+        }
+
+        return (low + high) / 2f;
+    }
+
+    private static bool Reproduces(float spacing, List<(float Length, int Samples)> segments)
+        => segments.All(segment => Math.Max(4, (int)MathF.Ceiling(segment.Length / spacing)) == segment.Samples);
+
+    /// <summary>
+    /// Length of one path segment the way the compiler measures it: the cubic Bezier through the node
+    /// handles, summed as chords over 4, 8, ... 128 samples until the sum moves by under one percent.
+    /// </summary>
+    private static float CompilerSegmentLength(Vector3 p0, Vector3 outHandle, Vector3 p3, Vector3 inHandle)
+    {
+        var p1 = p0 + outHandle;
+        var p2 = p3 + inHandle;
+        var c3 = ((3f * p1 - p0) - 3f * p2) + p3;
+        var c2 = (3f * p0 - 6f * p1) + 3f * p2;
+        var c1 = 3f * p1 - 3f * p0;
+
+        Vector3 Evaluate(float t) => ((((c3 * t) * t) * t) + ((c2 * t) * t) + (c1 * t)) + p0;
+
+        var length = 0f;
+
+        for (var samples = 2; samples <= 128; samples *= 2)
+        {
+            var previous = length;
+            length = 0f;
+            var step = 1f / (samples - 1);
+
+            for (var k = 1; k < samples; k++)
+            {
+                length += Vector3.Distance(Evaluate(k * step), Evaluate((k - 1) * step));
+            }
+
+            if (0.01f > MathF.Abs(length - previous) / length)
+            {
+                break;
+            }
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    /// The compiler divides the distance along the path by the width (U along the path) or height
+    /// (V along the path) of the material's colour texture.
+    /// </summary>
+    private int LoadCableTextureSize(string materialName, bool alongIsU)
+    {
+        if (string.IsNullOrEmpty(materialName))
+        {
+            return 0;
+        }
+
+        using var materialResource = FileLoader.LoadFileCompiled(materialName);
+
+        if (materialResource?.DataBlock is not Material material)
+        {
+            return 0;
+        }
+
+        if (!material.TextureParams.TryGetValue("g_tColor", out var textureName))
+        {
+            textureName = material.TextureParams.Values.FirstOrDefault();
+        }
+
+        if (string.IsNullOrEmpty(textureName))
+        {
+            return 0;
+        }
+
+        using var textureResource = FileLoader.LoadFileCompiled(textureName);
+
+        if (textureResource?.DataBlock is not Texture texture)
+        {
+            return 0;
+        }
+
+        return alongIsU ? texture.Width : texture.Height;
+    }
+
+    private static float Snap(float value, float tolerance = 2e-3f)
+    {
+        for (var decimals = 2; decimals <= 4; decimals++)
+        {
+            var rounded = MathF.Round(value, decimals);
+
+            if (MathF.Abs(rounded - value) <= tolerance * MathF.Max(1f, MathF.Abs(value)))
+            {
+                return rounded;
+            }
+        }
+
+        return value;
+    }
+}

--- a/ValveResourceFormat/IO/Extract/MapExtract.cs
+++ b/ValveResourceFormat/IO/Extract/MapExtract.cs
@@ -2138,7 +2138,11 @@ public sealed class MapExtract
                 continue;
             }
 
-            var mapEntity = new CMapEntity();
+            var pathNodes = PathParticleRope.ParseNodes(compiledEntity.GetStringProperty("pathnodes"));
+            var mapEntity = pathNodes.Count == 0
+                ? new CMapEntity()
+                : className is "cable_static" or "cable_dynamic" ? new CMapCable() : new CMapPath();
+
             var entityLineage = AddProperties(className, compiledEntity, mapEntity);
             var localTransform = EntityTransformHelper.ToTransformationMatrix(compiledEntity);
             var worldTransform = parentTransform is { } parent ? localTransform * parent : localTransform;
@@ -2163,6 +2167,11 @@ public sealed class MapExtract
                 {
                     continue;
                 }
+            }
+
+            if (mapEntity is CMapPath mapPath)
+            {
+                AddPathNodes(mapPath, className, compiledEntity, pathNodes, worldTransform);
             }
 
             if (entityLineage.Length > 1)
@@ -2231,31 +2240,38 @@ public sealed class MapExtract
 
             if (modelName != null && PathIsSubPath(modelName, LumpFolder))
             {
-                var firstReference = ModelEntityAssociations.TryAdd(modelName, className);
-                if (!firstReference)
+                if (mapEntity is CMapPath)
                 {
-                    var otherClass = ModelEntityAssociations[modelName];
-                    Debug.Assert(className == otherClass, "Model living in lump folder referenced by more than one entity type!\n" +
-                        $"model = {modelName} {className} != {otherClass}");
+                    mapEntity.EntityProperties.Remove("model");
                 }
-
-                ExtractEntityModel(mapEntity, modelName, worldTransform.Translation);
-
-                ReadOnlySpan<char> entityIdFull = Path.GetFileNameWithoutExtension(modelName);
-                var nameCutoff = entityIdFull.Length;
-                foreach (var entityId in entityLineage.Reverse())
+                else
                 {
-                    ReadOnlySpan<char> entityIdString = '_' + entityId.ToString(CultureInfo.InvariantCulture);
-                    if (entityIdFull[..nameCutoff].EndsWith(entityIdString, StringComparison.Ordinal))
+                    var firstReference = ModelEntityAssociations.TryAdd(modelName, className);
+                    if (!firstReference)
                     {
-                        nameCutoff -= entityIdString.Length;
+                        var otherClass = ModelEntityAssociations[modelName];
+                        Debug.Assert(className == otherClass, "Model living in lump folder referenced by more than one entity type!\n" +
+                            $"model = {modelName} {className} != {otherClass}");
                     }
-                }
 
-                var entityName = new string(entityIdFull[..nameCutoff]);
-                if (entityName != "unnamed")
-                {
-                    mapEntity.Name = entityName;
+                    ExtractEntityModel(mapEntity, modelName, worldTransform.Translation);
+
+                    ReadOnlySpan<char> entityIdFull = Path.GetFileNameWithoutExtension(modelName);
+                    var nameCutoff = entityIdFull.Length;
+                    foreach (var entityId in entityLineage.Reverse())
+                    {
+                        ReadOnlySpan<char> entityIdString = '_' + entityId.ToString(CultureInfo.InvariantCulture);
+                        if (entityIdFull[..nameCutoff].EndsWith(entityIdString, StringComparison.Ordinal))
+                        {
+                            nameCutoff -= entityIdString.Length;
+                        }
+                    }
+
+                    var entityName = new string(entityIdFull[..nameCutoff]);
+                    if (entityName != "unnamed")
+                    {
+                        mapEntity.Name = entityName;
+                    }
                 }
             }
 
@@ -2274,6 +2290,109 @@ public sealed class MapExtract
             }
 
             MapDocument.World.Children.Add(mapEntity);
+        }
+    }
+
+    private const int LinearPathInterpolation = 0;
+    private const int SplinePathInterpolation = 1;
+
+    /// <summary>
+    /// Reads back the interpolation Hammer was set to from the handles the compiler derived with it.
+    /// Both rules scale a handle to a third of its own segment, and differ only in its direction.
+    /// </summary>
+    private static int DetectPathInterpolation(List<PathParticleRopeNode> nodes)
+    {
+        var linearError = 0f;
+        var splineError = 0f;
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            var interior = i > 0 && i < nodes.Count - 1;
+
+            var toPrevious = i > 0 ? nodes[i - 1].Position - node.Position : Vector3.Zero;
+            var toNext = i < nodes.Count - 1 ? nodes[i + 1].Position - node.Position : Vector3.Zero;
+
+            var chord = toNext - toPrevious;
+            var splineDirection = chord.Length() > 0f ? Vector3.Normalize(chord) : Vector3.Zero;
+
+            var linearIn = toPrevious / 3f;
+            var linearOut = toNext / 3f;
+
+            var splineIn = interior ? splineDirection * (-toPrevious.Length() / 3f) : linearIn;
+            var splineOut = interior ? splineDirection * (toNext.Length() / 3f) : linearOut;
+
+            linearError += (node.InTangent - linearIn).Length() + (node.OutTangent - linearOut).Length();
+            splineError += (node.InTangent - splineIn).Length() + (node.OutTangent - splineOut).Length();
+        }
+
+        return splineError < linearError ? SplinePathInterpolation : LinearPathInterpolation;
+    }
+
+    /// <summary>
+    /// Rebuilds the nodes a path was authored with from the blobs the compiler flattened them into,
+    /// placing each one by the path's own world transform, which the blob positions are relative to.
+    /// </summary>
+    private static void AddPathNodes(CMapPath path, string className, Entity compiledEntity,
+        List<PathParticleRopeNode> nodes, Matrix4x4 worldTransform)
+    {
+        var pins = PathParticleRope.ParsePins(compiledEntity.GetStringProperty("pathnodepinsenabled"));
+        var radiusScales = PathParticleRope.ParseRadiusScales(compiledEntity.GetStringProperty("pathnoderadiusscales"));
+        var colors = PathParticleRope.ParseColors(compiledEntity.GetStringProperty("pathnodecolors"));
+        var moveSpeedTypes = PathParticleRope.ParseFloatBlob(compiledEntity.GetStringProperty("pathnodemovespeedtypes"));
+        var nodeClassName = className switch
+        {
+            "path_particle_rope" or "path_particle_rope_clientside" => "path_node_particle_rope",
+            "cable_static" or "cable_dynamic" => "path_node_cable",
+            "map_preview_camera_path" => "map_preview_camera_path_node",
+            "dota_movespeed_modifier_path" => "dota_movespeed_path_node",
+            _ => "path_node_generic",
+        };
+
+        path.InterpolationType = DetectPathInterpolation(nodes);
+
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+
+            var pathNode = new CMapPathNode
+            {
+                Origin = Vector3.Transform(node.Position, worldTransform),
+                InTangent = Vector3.TransformNormal(node.InTangent, worldTransform),
+                OutTangent = Vector3.TransformNormal(node.OutTangent, worldTransform),
+            };
+
+            pathNode.WithClassName(nodeClassName);
+
+            if (i < pins.Length)
+            {
+                pathNode.PinEnabled = pins[i];
+                pathNode.WithProperty("pin_enabled", pins[i] ? "1" : "0");
+            }
+
+            if (i < radiusScales.Length)
+            {
+                pathNode.RadiusScale = radiusScales[i];
+                pathNode.WithProperty("radius_scale", radiusScales[i].ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (i < colors.Length)
+            {
+                var color = Vector3.Clamp(colors[i], Vector3.Zero, Vector3.One) * 255f;
+                var red = (byte)MathF.Round(color.X);
+                var green = (byte)MathF.Round(color.Y);
+                var blue = (byte)MathF.Round(color.Z);
+
+                pathNode.TintColor = new Datamodel.Color(red, green, blue, 255);
+                pathNode.WithProperty("color_tint", string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", red, green, blue));
+            }
+
+            if (i < moveSpeedTypes.Length)
+            {
+                pathNode.WithProperty("MoveSpeedType", ((int)moveSpeedTypes[i]).ToString(CultureInfo.InvariantCulture));
+            }
+
+            path.Children.Add(pathNode);
         }
     }
 
@@ -2409,6 +2528,16 @@ public sealed class MapExtract
         else if (key == "scales")
         {
             mapEntity.Scales = compiledEntity.GetVector3Property(key);
+            return true;
+        }
+        else if (mapEntity is CMapPath path && key is "closed_loop" or "pathnodes" or "pathnodepinsenabled"
+            or "pathnoderadiusscales" or "pathnodecolors" or "pathnodemovespeedtypes")
+        {
+            if (key == "closed_loop")
+            {
+                path.ClosedLoop = compiledEntity.TryGetValue(key, out var closedLoop) && ToEditString(closedLoop) is "1" or "true";
+            }
+
             return true;
         }
         else if (key == "hammeruniqueid")

--- a/ValveResourceFormat/IO/Extract/MapExtract.cs
+++ b/ValveResourceFormat/IO/Extract/MapExtract.cs
@@ -17,7 +17,7 @@ namespace ValveResourceFormat.IO;
 /// <summary>
 /// Extracts map data from Source 2 resources into editable formats.
 /// </summary>
-public sealed class MapExtract
+public sealed partial class MapExtract
 {
     /// <summary>Gets the folder containing map lumps.</summary>
     public string LumpFolder { get; private set; } = string.Empty;
@@ -2116,12 +2116,18 @@ public sealed class MapExtract
         }
 
         Dictionary<int, CMapSelectionSet> lineageSelectionSets = [];
+        var pathNodeEntities = GroupPathNodeEntities(entityLump);
 
         foreach (var compiledEntity in entityLump.GetEntities())
         {
             var className = compiledEntity.GetStringProperty("classname");
 
             if (className == null)
+            {
+                continue;
+            }
+
+            if (compiledEntity.GetStringProperty("path_uniqueid") is { } ownerPathId && pathNodeEntities.ContainsKey(ownerPathId))
             {
                 continue;
             }
@@ -2139,9 +2145,7 @@ public sealed class MapExtract
             }
 
             var pathNodes = PathParticleRope.ParseNodes(compiledEntity.GetStringProperty("pathnodes"));
-            var mapEntity = pathNodes.Count == 0
-                ? new CMapEntity()
-                : className is "cable_static" or "cable_dynamic" ? new CMapCable() : new CMapPath();
+            var mapEntity = CreateMapEntity(className, pathNodes.Count);
 
             var entityLineage = AddProperties(className, compiledEntity, mapEntity);
             var localTransform = EntityTransformHelper.ToTransformationMatrix(compiledEntity);
@@ -2171,7 +2175,8 @@ public sealed class MapExtract
 
             if (mapEntity is CMapPath mapPath)
             {
-                AddPathNodes(mapPath, className, compiledEntity, pathNodes, worldTransform);
+                pathNodeEntities.TryGetValue(compiledEntity.GetStringProperty("hammeruniqueid") ?? string.Empty, out var nodeEntities);
+                AddPathNodes(mapPath, className, compiledEntity, pathNodes, nodeEntities, worldTransform);
             }
 
             if (entityLineage.Length > 1)
@@ -2242,6 +2247,11 @@ public sealed class MapExtract
             {
                 if (mapEntity is CMapPath)
                 {
+                    if (mapEntity is CMapCable cable)
+                    {
+                        RecoverCableAttributes(cable, className, compiledEntity, modelName, pathNodes);
+                    }
+
                     mapEntity.EntityProperties.Remove("model");
                 }
                 else
@@ -2290,109 +2300,6 @@ public sealed class MapExtract
             }
 
             MapDocument.World.Children.Add(mapEntity);
-        }
-    }
-
-    private const int LinearPathInterpolation = 0;
-    private const int SplinePathInterpolation = 1;
-
-    /// <summary>
-    /// Reads back the interpolation Hammer was set to from the handles the compiler derived with it.
-    /// Both rules scale a handle to a third of its own segment, and differ only in its direction.
-    /// </summary>
-    private static int DetectPathInterpolation(List<PathParticleRopeNode> nodes)
-    {
-        var linearError = 0f;
-        var splineError = 0f;
-
-        for (var i = 0; i < nodes.Count; i++)
-        {
-            var node = nodes[i];
-            var interior = i > 0 && i < nodes.Count - 1;
-
-            var toPrevious = i > 0 ? nodes[i - 1].Position - node.Position : Vector3.Zero;
-            var toNext = i < nodes.Count - 1 ? nodes[i + 1].Position - node.Position : Vector3.Zero;
-
-            var chord = toNext - toPrevious;
-            var splineDirection = chord.Length() > 0f ? Vector3.Normalize(chord) : Vector3.Zero;
-
-            var linearIn = toPrevious / 3f;
-            var linearOut = toNext / 3f;
-
-            var splineIn = interior ? splineDirection * (-toPrevious.Length() / 3f) : linearIn;
-            var splineOut = interior ? splineDirection * (toNext.Length() / 3f) : linearOut;
-
-            linearError += (node.InTangent - linearIn).Length() + (node.OutTangent - linearOut).Length();
-            splineError += (node.InTangent - splineIn).Length() + (node.OutTangent - splineOut).Length();
-        }
-
-        return splineError < linearError ? SplinePathInterpolation : LinearPathInterpolation;
-    }
-
-    /// <summary>
-    /// Rebuilds the nodes a path was authored with from the blobs the compiler flattened them into,
-    /// placing each one by the path's own world transform, which the blob positions are relative to.
-    /// </summary>
-    private static void AddPathNodes(CMapPath path, string className, Entity compiledEntity,
-        List<PathParticleRopeNode> nodes, Matrix4x4 worldTransform)
-    {
-        var pins = PathParticleRope.ParsePins(compiledEntity.GetStringProperty("pathnodepinsenabled"));
-        var radiusScales = PathParticleRope.ParseRadiusScales(compiledEntity.GetStringProperty("pathnoderadiusscales"));
-        var colors = PathParticleRope.ParseColors(compiledEntity.GetStringProperty("pathnodecolors"));
-        var moveSpeedTypes = PathParticleRope.ParseFloatBlob(compiledEntity.GetStringProperty("pathnodemovespeedtypes"));
-        var nodeClassName = className switch
-        {
-            "path_particle_rope" or "path_particle_rope_clientside" => "path_node_particle_rope",
-            "cable_static" or "cable_dynamic" => "path_node_cable",
-            "map_preview_camera_path" => "map_preview_camera_path_node",
-            "dota_movespeed_modifier_path" => "dota_movespeed_path_node",
-            _ => "path_node_generic",
-        };
-
-        path.InterpolationType = DetectPathInterpolation(nodes);
-
-        for (var i = 0; i < nodes.Count; i++)
-        {
-            var node = nodes[i];
-
-            var pathNode = new CMapPathNode
-            {
-                Origin = Vector3.Transform(node.Position, worldTransform),
-                InTangent = Vector3.TransformNormal(node.InTangent, worldTransform),
-                OutTangent = Vector3.TransformNormal(node.OutTangent, worldTransform),
-            };
-
-            pathNode.WithClassName(nodeClassName);
-
-            if (i < pins.Length)
-            {
-                pathNode.PinEnabled = pins[i];
-                pathNode.WithProperty("pin_enabled", pins[i] ? "1" : "0");
-            }
-
-            if (i < radiusScales.Length)
-            {
-                pathNode.RadiusScale = radiusScales[i];
-                pathNode.WithProperty("radius_scale", radiusScales[i].ToString(CultureInfo.InvariantCulture));
-            }
-
-            if (i < colors.Length)
-            {
-                var color = Vector3.Clamp(colors[i], Vector3.Zero, Vector3.One) * 255f;
-                var red = (byte)MathF.Round(color.X);
-                var green = (byte)MathF.Round(color.Y);
-                var blue = (byte)MathF.Round(color.Z);
-
-                pathNode.TintColor = new Datamodel.Color(red, green, blue, 255);
-                pathNode.WithProperty("color_tint", string.Format(CultureInfo.InvariantCulture, "{0} {1} {2}", red, green, blue));
-            }
-
-            if (i < moveSpeedTypes.Length)
-            {
-                pathNode.WithProperty("MoveSpeedType", ((int)moveSpeedTypes[i]).ToString(CultureInfo.InvariantCulture));
-            }
-
-            path.Children.Add(pathNode);
         }
     }
 
@@ -2530,14 +2437,8 @@ public sealed class MapExtract
             mapEntity.Scales = compiledEntity.GetVector3Property(key);
             return true;
         }
-        else if (mapEntity is CMapPath path && key is "closed_loop" or "pathnodes" or "pathnodepinsenabled"
-            or "pathnoderadiusscales" or "pathnodecolors" or "pathnodemovespeedtypes")
+        else if (TryHandlePathProperty(key, compiledEntity, mapEntity))
         {
-            if (key == "closed_loop")
-            {
-                path.ClosedLoop = compiledEntity.TryGetValue(key, out var closedLoop) && ToEditString(closedLoop) is "1" or "true";
-            }
-
             return true;
         }
         else if (key == "hammeruniqueid")

--- a/ValveResourceFormat/IO/Extract/MapExtract.cs
+++ b/ValveResourceFormat/IO/Extract/MapExtract.cs
@@ -2116,9 +2116,10 @@ public sealed partial class MapExtract
         }
 
         Dictionary<int, CMapSelectionSet> lineageSelectionSets = [];
-        var pathNodeEntities = GroupPathNodeEntities(entityLump);
+        var entities = entityLump.GetEntities();
+        var pathNodeEntities = GroupPathNodeEntities(entities);
 
-        foreach (var compiledEntity in entityLump.GetEntities())
+        foreach (var compiledEntity in entities)
         {
             var className = compiledEntity.GetStringProperty("classname");
 
@@ -2144,7 +2145,7 @@ public sealed partial class MapExtract
                 continue;
             }
 
-            var pathNodes = PathParticleRope.ParseNodes(compiledEntity.GetStringProperty("pathnodes"));
+            var pathNodes = compiledEntity.GetStringProperty("pathnodes") is { } pathNodesBlob ? PathParticleRope.ParseNodes(pathNodesBlob) : [];
             var mapEntity = CreateMapEntity(className, pathNodes.Count);
 
             var entityLineage = AddProperties(className, compiledEntity, mapEntity);
@@ -2175,7 +2176,13 @@ public sealed partial class MapExtract
 
             if (mapEntity is CMapPath mapPath)
             {
-                pathNodeEntities.TryGetValue(compiledEntity.GetStringProperty("hammeruniqueid") ?? string.Empty, out var nodeEntities);
+                Dictionary<int, Entity>? nodeEntities = null;
+
+                if (compiledEntity.GetStringProperty("hammeruniqueid") is { } pathId)
+                {
+                    pathNodeEntities.TryGetValue(pathId, out nodeEntities);
+                }
+
                 AddPathNodes(mapPath, className, compiledEntity, pathNodes, nodeEntities, worldTransform);
             }
 
@@ -2243,45 +2250,42 @@ public sealed partial class MapExtract
                 modelName = NormalizePath(rawModelName);
             }
 
-            if (modelName != null && PathIsSubPath(modelName, LumpFolder))
+            if (modelName != null && PathIsSubPath(modelName, LumpFolder) && mapEntity is CMapPath)
             {
-                if (mapEntity is CMapPath)
+                if (mapEntity is CMapCable cable)
                 {
-                    if (mapEntity is CMapCable cable)
-                    {
-                        RecoverCableAttributes(cable, className, compiledEntity, modelName, pathNodes);
-                    }
-
-                    mapEntity.EntityProperties.Remove("model");
+                    RecoverCableAttributes(cable, className, compiledEntity, modelName, pathNodes);
                 }
-                else
+
+                mapEntity.EntityProperties.Remove("model");
+            }
+            else if (modelName != null && PathIsSubPath(modelName, LumpFolder))
+            {
+                var firstReference = ModelEntityAssociations.TryAdd(modelName, className);
+                if (!firstReference)
                 {
-                    var firstReference = ModelEntityAssociations.TryAdd(modelName, className);
-                    if (!firstReference)
-                    {
-                        var otherClass = ModelEntityAssociations[modelName];
-                        Debug.Assert(className == otherClass, "Model living in lump folder referenced by more than one entity type!\n" +
-                            $"model = {modelName} {className} != {otherClass}");
-                    }
+                    var otherClass = ModelEntityAssociations[modelName];
+                    Debug.Assert(className == otherClass, "Model living in lump folder referenced by more than one entity type!\n" +
+                        $"model = {modelName} {className} != {otherClass}");
+                }
 
-                    ExtractEntityModel(mapEntity, modelName, worldTransform.Translation);
+                ExtractEntityModel(mapEntity, modelName, worldTransform.Translation);
 
-                    ReadOnlySpan<char> entityIdFull = Path.GetFileNameWithoutExtension(modelName);
-                    var nameCutoff = entityIdFull.Length;
-                    foreach (var entityId in entityLineage.Reverse())
+                ReadOnlySpan<char> entityIdFull = Path.GetFileNameWithoutExtension(modelName);
+                var nameCutoff = entityIdFull.Length;
+                foreach (var entityId in entityLineage.Reverse())
+                {
+                    ReadOnlySpan<char> entityIdString = '_' + entityId.ToString(CultureInfo.InvariantCulture);
+                    if (entityIdFull[..nameCutoff].EndsWith(entityIdString, StringComparison.Ordinal))
                     {
-                        ReadOnlySpan<char> entityIdString = '_' + entityId.ToString(CultureInfo.InvariantCulture);
-                        if (entityIdFull[..nameCutoff].EndsWith(entityIdString, StringComparison.Ordinal))
-                        {
-                            nameCutoff -= entityIdString.Length;
-                        }
+                        nameCutoff -= entityIdString.Length;
                     }
+                }
 
-                    var entityName = new string(entityIdFull[..nameCutoff]);
-                    if (entityName != "unnamed")
-                    {
-                        mapEntity.Name = entityName;
-                    }
+                var entityName = new string(entityIdFull[..nameCutoff]);
+                if (entityName != "unnamed")
+                {
+                    mapEntity.Name = entityName;
                 }
             }
 
@@ -2437,7 +2441,7 @@ public sealed partial class MapExtract
             mapEntity.Scales = compiledEntity.GetVector3Property(key);
             return true;
         }
-        else if (TryHandlePathProperty(key, compiledEntity, mapEntity))
+        else if (IsPathProperty(key, mapEntity))
         {
             return true;
         }

--- a/ValveResourceFormat/Resource/ResourceTypes/PathParticleRope.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/PathParticleRope.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Globalization;
 
 namespace ValveResourceFormat.ResourceTypes
@@ -30,23 +31,24 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>Floats per <c>pathnodes</c> entry: position(3) + inTangent(3) + outTangent(3).</summary>
         public const int FloatsPerNode = 9;
 
-        private static readonly char[] SplitChars = ['[', ']', ',', '"', ' ', '\t', '\r', '\n', '\f', '\v'];
+        private static readonly SearchValues<char> Separators = SearchValues.Create("[],\" \t\r\n\f\v");
 
         /// <summary>
         /// Flattens a bracketed blob to a flat array of floats, ignoring all bracket nesting and whitespace.
         /// </summary>
-        public static float[] ParseFloatBlob(string? input)
+        public static float[] ParseFloatBlob(ReadOnlySpan<char> input)
         {
-            if (string.IsNullOrEmpty(input))
-            {
-                return [];
-            }
+            var result = new List<float>();
 
-            var tokens = input.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var result = new List<float>(tokens.Length);
-
-            foreach (var token in tokens)
+            foreach (var range in input.SplitAny(Separators))
             {
+                var token = input[range].Trim();
+
+                if (token.IsEmpty)
+                {
+                    continue;
+                }
+
                 // Keep the flat array aligned with the fixed-size node groups: substitute 0 for an unparseable
                 // token instead of dropping it, which would shift every later field.
                 result.Add(float.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ? value : 0f);
@@ -59,7 +61,7 @@ namespace ValveResourceFormat.ResourceTypes
         /// Parses the <c>pathnodes</c> blob into a list of spline nodes (groups of 9 floats).
         /// Returns an empty list for empty/degenerate input.
         /// </summary>
-        public static List<PathParticleRopeNode> ParseNodes(string? pathNodes)
+        public static List<PathParticleRopeNode> ParseNodes(ReadOnlySpan<char> pathNodes)
         {
             var floats = ParseFloatBlob(pathNodes);
             var nodeCount = floats.Length / FloatsPerNode;
@@ -82,12 +84,12 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>
         /// Parses the <c>pathnoderadiusscales</c> blob into a flat array of per-node radius multipliers.
         /// </summary>
-        public static float[] ParseRadiusScales(string? input) => ParseFloatBlob(input);
+        public static float[] ParseRadiusScales(ReadOnlySpan<char> input) => ParseFloatBlob(input);
 
         /// <summary>
         /// Parses the <c>pathnodecolors</c> blob (nested <c>[[r,g,b],...]</c>, components in 0-1) into per-node colors.
         /// </summary>
-        public static Vector3[] ParseColors(string? input)
+        public static Vector3[] ParseColors(ReadOnlySpan<char> input)
         {
             var floats = ParseFloatBlob(input);
             var count = floats.Length / 3;
@@ -104,18 +106,19 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>
         /// Parses the <c>pathnodepinsenabled</c> blob (<c>[true, false, ...]</c>) into a flat array of booleans.
         /// </summary>
-        public static bool[] ParsePins(string? input)
+        public static bool[] ParsePins(ReadOnlySpan<char> input)
         {
-            if (string.IsNullOrEmpty(input))
-            {
-                return [];
-            }
+            var result = new List<bool>();
 
-            var tokens = input.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var result = new List<bool>(tokens.Length);
-
-            foreach (var token in tokens)
+            foreach (var range in input.SplitAny(Separators))
             {
+                var token = input[range].Trim();
+
+                if (token.IsEmpty)
+                {
+                    continue;
+                }
+
                 if (bool.TryParse(token, out var value))
                 {
                     result.Add(value);

--- a/ValveResourceFormat/Resource/ResourceTypes/PathParticleRope.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/PathParticleRope.cs
@@ -30,7 +30,7 @@ namespace ValveResourceFormat.ResourceTypes
         /// <summary>Floats per <c>pathnodes</c> entry: position(3) + inTangent(3) + outTangent(3).</summary>
         public const int FloatsPerNode = 9;
 
-        private static readonly char[] SplitChars = ['[', ']', ',', ' ', '\t', '\r', '\n', '\f', '\v'];
+        private static readonly char[] SplitChars = ['[', ']', ',', '"', ' ', '\t', '\r', '\n', '\f', '\v'];
 
         /// <summary>
         /// Flattens a bracketed blob to a flat array of floats, ignoring all bracket nesting and whitespace.


### PR DESCRIPTION
Recovers the editable objects. Every (non editor-only) path class comes back as `CMapPath` (or `CMapCable`) with `CMapPathNode` children. Node entities are re-attached, plus interpolation and per-node tangent types read back from the compiler-derived handles, closed loops, node names, pin flags, radius scales, tint colors and the full cable attribute set.